### PR TITLE
Fix empty string validation errors for nested model fields

### DIFF
--- a/materialize/src/main.rs
+++ b/materialize/src/main.rs
@@ -579,15 +579,20 @@ fn enrich_file(mut file: Document, lookups: &LookupTables) -> Document {
                         let mut bio_copy = biosample.clone();
                         bio_copy.remove("_id");
 
-                        // Lookup anatomy for biosample
-                        if let Some(anatomy_id) = biosample.get_str("anatomy").ok() {
+                        // Lookup anatomy for biosample (replace raw ID string with document)
+                        let anatomy_id = biosample.get_str("anatomy").unwrap_or_default().to_string();
+                        if !anatomy_id.is_empty() {
                             if let Some(anatomy) =
-                                lookups.anatomies.get(&(submission.clone(), anatomy_id.to_string()))
+                                lookups.anatomies.get(&(submission.clone(), anatomy_id))
                             {
                                 let mut anatomy_copy = anatomy.clone();
                                 anatomy_copy.remove("_id");
                                 bio_copy.insert("anatomy", anatomy_copy);
+                            } else {
+                                bio_copy.remove("anatomy");
                             }
+                        } else {
+                            bio_copy.remove("anatomy");
                         }
 
                         // Lookup subjects for this biosample
@@ -906,6 +911,309 @@ fn create_indexes(coll: &Collection<Document>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a LookupTables with all empty maps.
+    fn empty_lookups() -> LookupTables {
+        LookupTables {
+            dccs: HashMap::new(),
+            file_formats: HashMap::new(),
+            data_types: HashMap::new(),
+            assay_types: HashMap::new(),
+            anatomies: HashMap::new(),
+            ncbi_taxonomies: HashMap::new(),
+            projects: HashMap::new(),
+            collections: HashMap::new(),
+            biosamples: HashMap::new(),
+            subjects: HashMap::new(),
+            file_in_collection: HashMap::new(),
+            biosample_in_collection: HashMap::new(),
+            biosample_from_subject: HashMap::new(),
+            subject_race: HashMap::new(),
+            subject_role_taxonomy: HashMap::new(),
+            collection_by_persistent_id: HashMap::new(),
+            collection_anatomy: HashMap::new(),
+            subject_in_collection: HashMap::new(),
+        }
+    }
+
+    /// Build the minimal file, collection, biosample, and junction table
+    /// entries needed to exercise the biosample anatomy lookup path in
+    /// enrich_file.
+    fn lookups_with_biosample(
+        biosample_doc: Document,
+        anatomies: LookupMap,
+    ) -> (Document, LookupTables) {
+        let submission = "4dn".to_string();
+        let file_ns = "4dn".to_string();
+        let file_id = "file-001".to_string();
+        let coll_ns = "4dn".to_string();
+        let coll_id = "coll-001".to_string();
+        let bio_ns = biosample_doc.get_str("id_namespace").unwrap_or("4dn").to_string();
+        let bio_id = biosample_doc.get_str("local_id").unwrap_or("bio-001").to_string();
+
+        let file = doc! {
+            "submission": &submission,
+            "id_namespace": &file_ns,
+            "local_id": &file_id,
+            "filename": "test.fastq",
+        };
+
+        let mut lookups = empty_lookups();
+        lookups.dccs.insert(
+            submission.clone(),
+            doc! { "id": "cfde_registry_dcc:4dn", "dcc_name": "4DN" },
+        );
+        lookups.collections.insert(
+            (coll_ns.clone(), coll_id.clone()),
+            doc! { "id_namespace": &coll_ns, "local_id": &coll_id, "name": "Test Collection" },
+        );
+        lookups.file_in_collection.insert(
+            (file_ns.clone(), file_id.clone()),
+            vec![doc! {
+                "collection_id_namespace": &coll_ns,
+                "collection_local_id": &coll_id,
+            }],
+        );
+        lookups.biosamples.insert(
+            (bio_ns.clone(), bio_id.clone()),
+            biosample_doc,
+        );
+        lookups.biosample_in_collection.insert(
+            (coll_ns, coll_id),
+            vec![doc! {
+                "biosample_id_namespace": &bio_ns,
+                "biosample_local_id": &bio_id,
+            }],
+        );
+        lookups.anatomies = anatomies;
+
+        (file, lookups)
+    }
+
+    /// Extract the first biosample from the enriched file's first collection.
+    fn first_biosample(result: &Document) -> &Document {
+        result
+            .get_array("collections").unwrap()
+            .first().unwrap()
+            .as_document().unwrap()
+            .get_array("biosamples").unwrap()
+            .first().unwrap()
+            .as_document().unwrap()
+    }
+
+    mod enrich_file_tests {
+        use super::*;
+
+        #[test]
+        /// Test biosample anatomy removal when the raw anatomy field is empty.
+        ///
+        /// Given:
+        ///     A biosample with anatomy set to an empty string.
+        /// When:
+        ///     enrich_file processes the file.
+        /// Then:
+        ///     It should remove the anatomy field from the biosample.
+        fn test_enrich_file_with_empty_biosample_anatomy() {
+            // Arrange
+            let biosample = doc! {
+                "id_namespace": "4dn",
+                "local_id": "bio-001",
+                "anatomy": "",
+            };
+            let (file, lookups) = lookups_with_biosample(biosample, HashMap::new());
+
+            // Act
+            let result = enrich_file(file, &lookups);
+
+            // Assert
+            let bio = first_biosample(&result);
+            assert!(!bio.contains_key("anatomy"),
+                "anatomy field should be removed when raw value is empty string");
+        }
+
+        #[test]
+        /// Test biosample anatomy replacement when a matching anatomy document exists.
+        ///
+        /// Given:
+        ///     A biosample with a valid anatomy ID and a matching anatomy in the lookup table.
+        /// When:
+        ///     enrich_file processes the file.
+        /// Then:
+        ///     It should replace the anatomy ID string with the full anatomy document.
+        fn test_enrich_file_with_valid_biosample_anatomy() {
+            // Arrange
+            let biosample = doc! {
+                "id_namespace": "4dn",
+                "local_id": "bio-001",
+                "anatomy": "UBERON:0002107",
+            };
+            let mut anatomies: LookupMap = HashMap::new();
+            anatomies.insert(
+                ("4dn".to_string(), "UBERON:0002107".to_string()),
+                doc! { "id": "UBERON:0002107", "name": "liver", "submission": "4dn" },
+            );
+            let (file, lookups) = lookups_with_biosample(biosample, anatomies);
+
+            // Act
+            let result = enrich_file(file, &lookups);
+
+            // Assert
+            let bio = first_biosample(&result);
+            let anatomy = bio.get_document("anatomy")
+                .expect("anatomy should be a document");
+            assert_eq!(anatomy.get_str("id").unwrap(), "UBERON:0002107");
+            assert_eq!(anatomy.get_str("name").unwrap(), "liver");
+        }
+
+        #[test]
+        /// Test biosample anatomy removal when the anatomy ID has no match in lookups.
+        ///
+        /// Given:
+        ///     A biosample with a non-empty anatomy ID that does not exist in the lookup table.
+        /// When:
+        ///     enrich_file processes the file.
+        /// Then:
+        ///     It should remove the anatomy field rather than leaving the raw ID string.
+        fn test_enrich_file_with_unresolved_biosample_anatomy() {
+            // Arrange
+            let biosample = doc! {
+                "id_namespace": "4dn",
+                "local_id": "bio-001",
+                "anatomy": "UBERON:9999999",
+            };
+            let (file, lookups) = lookups_with_biosample(biosample, HashMap::new());
+
+            // Act
+            let result = enrich_file(file, &lookups);
+
+            // Assert
+            let bio = first_biosample(&result);
+            assert!(!bio.contains_key("anatomy"),
+                "anatomy field should be removed when lookup misses");
+        }
+
+        #[test]
+        /// Test biosample without an anatomy field at all.
+        ///
+        /// Given:
+        ///     A biosample with no anatomy field.
+        /// When:
+        ///     enrich_file processes the file.
+        /// Then:
+        ///     It should not add an anatomy field to the biosample.
+        fn test_enrich_file_with_missing_biosample_anatomy() {
+            // Arrange
+            let biosample = doc! {
+                "id_namespace": "4dn",
+                "local_id": "bio-001",
+            };
+            let (file, lookups) = lookups_with_biosample(biosample, HashMap::new());
+
+            // Act
+            let result = enrich_file(file, &lookups);
+
+            // Assert
+            let bio = first_biosample(&result);
+            assert!(!bio.contains_key("anatomy"),
+                "anatomy field should not be added when it was never present");
+        }
+
+        #[test]
+        /// Test that file_format is removed when its raw value is an empty string.
+        ///
+        /// Given:
+        ///     A file document with file_format set to an empty string.
+        /// When:
+        ///     enrich_file processes the file.
+        /// Then:
+        ///     It should remove the file_format field.
+        fn test_enrich_file_with_empty_file_format() {
+            // Arrange
+            let file = doc! {
+                "submission": "4dn",
+                "id_namespace": "4dn",
+                "local_id": "file-001",
+                "filename": "test.fastq",
+                "file_format": "",
+            };
+            let mut lookups = empty_lookups();
+            lookups.dccs.insert(
+                "4dn".to_string(),
+                doc! { "id": "cfde_registry_dcc:4dn", "dcc_name": "4DN" },
+            );
+
+            // Act
+            let result = enrich_file(file, &lookups);
+
+            // Assert
+            assert!(!result.contains_key("file_format"),
+                "file_format should be removed when raw value is empty string");
+        }
+
+        #[test]
+        /// Test that data_type is removed when its raw value is an empty string.
+        ///
+        /// Given:
+        ///     A file document with data_type set to an empty string.
+        /// When:
+        ///     enrich_file processes the file.
+        /// Then:
+        ///     It should remove the data_type field.
+        fn test_enrich_file_with_empty_data_type() {
+            // Arrange
+            let file = doc! {
+                "submission": "4dn",
+                "id_namespace": "4dn",
+                "local_id": "file-001",
+                "filename": "test.fastq",
+                "data_type": "",
+            };
+            let mut lookups = empty_lookups();
+            lookups.dccs.insert(
+                "4dn".to_string(),
+                doc! { "id": "cfde_registry_dcc:4dn", "dcc_name": "4DN" },
+            );
+
+            // Act
+            let result = enrich_file(file, &lookups);
+
+            // Assert
+            assert!(!result.contains_key("data_type"),
+                "data_type should be removed when raw value is empty string");
+        }
+
+        #[test]
+        /// Test that assay_type is removed when its raw value is an empty string.
+        ///
+        /// Given:
+        ///     A file document with assay_type set to an empty string.
+        /// When:
+        ///     enrich_file processes the file.
+        /// Then:
+        ///     It should remove the assay_type field.
+        fn test_enrich_file_with_empty_assay_type() {
+            // Arrange
+            let file = doc! {
+                "submission": "4dn",
+                "id_namespace": "4dn",
+                "local_id": "file-001",
+                "filename": "test.fastq",
+                "assay_type": "",
+            };
+            let mut lookups = empty_lookups();
+            lookups.dccs.insert(
+                "4dn".to_string(),
+                doc! { "id": "cfde_registry_dcc:4dn", "dcc_name": "4DN" },
+            );
+
+            // Act
+            let result = enrich_file(file, &lookups);
+
+            // Assert
+            assert!(!result.contains_key("assay_type"),
+                "assay_type should be removed when raw value is empty string");
+        }
+    }
 
     #[test]
     fn index_keys_returns_expected_set() {

--- a/src/cfdb/models.py
+++ b/src/cfdb/models.py
@@ -92,6 +92,13 @@ class EnrichedFile(BaseModel):
     encode: Optional[EnrichedEncodeFile] = None
     hubmap: Optional[EnrichedHubmapFile] = None
 
+    @field_validator("fourdn", "encode", "hubmap", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
+
 
 class EnrichedHubmapCollection(BaseModel):
     """HuBMAP dataset-level metadata from Search API."""
@@ -128,6 +135,13 @@ class EnrichedSubject(BaseModel):
     """DCC-specific subject-level metadata."""
 
     hubmap: Optional[EnrichedHubmapSubject] = None
+
+    @field_validator("hubmap", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
 
 
 class EnrichedEncodeCollection(BaseModel):
@@ -174,6 +188,13 @@ class EnrichedCollection(BaseModel):
     hubmap: Optional[EnrichedHubmapCollection] = None
     encode: Optional[EnrichedEncodeCollection] = None
 
+    @field_validator("fourdn", "hubmap", "encode", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
+
 
 class EnrichedEncodeBiosample(BaseModel):
     """
@@ -205,6 +226,13 @@ class EnrichedBiosample(BaseModel):
     """
 
     encode: Optional[EnrichedEncodeBiosample] = None
+
+    @field_validator("encode", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
 
 
 class FileMetadataModel(BaseModel):
@@ -347,6 +375,16 @@ class FileMetadataModel(BaseModel):
     assay_info: Optional[str] = None
     condition: Optional[str] = None
     extra: Optional[EnrichedFile] = None
+
+    @field_validator(
+        "file_format", "data_type", "assay_type", "project", "extra",
+        mode="before",
+    )
+    @classmethod
+    def empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
 
 
 class Dcc(BaseModel):
@@ -524,6 +562,13 @@ class Collection(BaseModel):
     subjects: List[Subject] = []
     extra: Optional[EnrichedCollection] = None
 
+    @field_validator("extra", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
+
 
 class Biosample(BaseModel):
     """
@@ -582,6 +627,13 @@ class Biosample(BaseModel):
     biofluid: Optional[str] = None
     subjects: List[Subject] = []
     extra: Optional[EnrichedBiosample] = None
+
+    @field_validator("anatomy", "extra", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        if v == "":
+            return None
+        return v
 
 
 class Anatomy(BaseModel):
@@ -748,7 +800,10 @@ class Subject(BaseModel):
     taxonomy: Optional[NcbiTaxonomy] = None
     extra: Optional[EnrichedSubject] = None
 
-    @field_validator("age_at_enrollment", "age_at_sampling", mode="before")
+    @field_validator(
+        "age_at_enrollment", "age_at_sampling", "taxonomy", "extra",
+        mode="before",
+    )
     @classmethod
     def empty_string_to_none(cls, v):
         if v == "":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,439 @@
+from cfdb.models import (
+    Biosample,
+    Collection,
+    EnrichedBiosample,
+    EnrichedCollection,
+    EnrichedFile,
+    EnrichedSubject,
+    FileMetadataModel,
+    Subject,
+)
+
+
+class TestEnrichedFile:
+    def test_empty_string_to_none_with_empty_fourdn(self):
+        """Test empty string coercion on the fourdn field.
+
+        Given:
+            An EnrichedFile constructed with fourdn set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce fourdn to None.
+        """
+        # Act
+        result = EnrichedFile(fourdn="")
+
+        # Assert
+        assert result.fourdn is None
+
+    def test_empty_string_to_none_with_empty_encode(self):
+        """Test empty string coercion on the encode field.
+
+        Given:
+            An EnrichedFile constructed with encode set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce encode to None.
+        """
+        # Act
+        result = EnrichedFile(encode="")
+
+        # Assert
+        assert result.encode is None
+
+    def test_empty_string_to_none_with_empty_hubmap(self):
+        """Test empty string coercion on the hubmap field.
+
+        Given:
+            An EnrichedFile constructed with hubmap set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce hubmap to None.
+        """
+        # Act
+        result = EnrichedFile(hubmap="")
+
+        # Assert
+        assert result.hubmap is None
+
+    def test_empty_string_to_none_with_valid_dict(self):
+        """Test that valid dicts are not coerced.
+
+        Given:
+            An EnrichedFile constructed with fourdn set to a valid dict.
+        When:
+            The model is instantiated.
+        Then:
+            It should parse the dict into an EnrichedFourdnFile.
+        """
+        # Arrange
+        data = {"genome_assembly": "GRCh38"}
+
+        # Act
+        result = EnrichedFile(fourdn=data)
+
+        # Assert
+        assert result.fourdn is not None
+        assert result.fourdn.genome_assembly == "GRCh38"
+
+
+class TestEnrichedSubject:
+    def test_empty_string_to_none_with_empty_hubmap(self):
+        """Test empty string coercion on the hubmap field.
+
+        Given:
+            An EnrichedSubject constructed with hubmap set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce hubmap to None.
+        """
+        # Act
+        result = EnrichedSubject(hubmap="")
+
+        # Assert
+        assert result.hubmap is None
+
+
+class TestEnrichedCollection:
+    def test_empty_string_to_none_with_empty_fourdn(self):
+        """Test empty string coercion on the fourdn field.
+
+        Given:
+            An EnrichedCollection constructed with fourdn set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce fourdn to None.
+        """
+        # Act
+        result = EnrichedCollection(fourdn="")
+
+        # Assert
+        assert result.fourdn is None
+
+    def test_empty_string_to_none_with_empty_hubmap(self):
+        """Test empty string coercion on the hubmap field.
+
+        Given:
+            An EnrichedCollection constructed with hubmap set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce hubmap to None.
+        """
+        # Act
+        result = EnrichedCollection(hubmap="")
+
+        # Assert
+        assert result.hubmap is None
+
+    def test_empty_string_to_none_with_empty_encode(self):
+        """Test empty string coercion on the encode field.
+
+        Given:
+            An EnrichedCollection constructed with encode set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce encode to None.
+        """
+        # Act
+        result = EnrichedCollection(encode="")
+
+        # Assert
+        assert result.encode is None
+
+
+class TestEnrichedBiosample:
+    def test_empty_string_to_none_with_empty_encode(self):
+        """Test empty string coercion on the encode field.
+
+        Given:
+            An EnrichedBiosample constructed with encode set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce encode to None.
+        """
+        # Act
+        result = EnrichedBiosample(encode="")
+
+        # Assert
+        assert result.encode is None
+
+
+class TestFileMetadataModel:
+    def test_empty_string_to_none_with_empty_file_format(self):
+        """Test empty string coercion on the file_format field.
+
+        Given:
+            A FileMetadataModel constructed with file_format set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce file_format to None.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["file_format"] = ""
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert result.file_format is None
+
+    def test_empty_string_to_none_with_empty_data_type(self):
+        """Test empty string coercion on the data_type field.
+
+        Given:
+            A FileMetadataModel constructed with data_type set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce data_type to None.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["data_type"] = ""
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert result.data_type is None
+
+    def test_empty_string_to_none_with_empty_assay_type(self):
+        """Test empty string coercion on the assay_type field.
+
+        Given:
+            A FileMetadataModel constructed with assay_type set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce assay_type to None.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["assay_type"] = ""
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert result.assay_type is None
+
+    def test_empty_string_to_none_with_empty_project(self):
+        """Test empty string coercion on the project field.
+
+        Given:
+            A FileMetadataModel constructed with project set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce project to None.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["project"] = ""
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert result.project is None
+
+    def test_empty_string_to_none_with_empty_extra(self):
+        """Test empty string coercion on the extra field.
+
+        Given:
+            A FileMetadataModel constructed with extra set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce extra to None.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["extra"] = ""
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert result.extra is None
+
+    def test_empty_string_to_none_with_valid_file_format(self):
+        """Test that valid file_format dicts are not coerced.
+
+        Given:
+            A FileMetadataModel constructed with file_format set to a valid dict.
+        When:
+            The model is instantiated.
+        Then:
+            It should parse the dict into a FileFormat.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["file_format"] = {"id": "format:001", "name": "FASTQ"}
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert result.file_format is not None
+        assert result.file_format.name == "FASTQ"
+
+
+class TestCollection:
+    def test_empty_string_to_none_with_empty_extra(self):
+        """Test empty string coercion on the extra field.
+
+        Given:
+            A Collection constructed with extra set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce extra to None.
+        """
+        # Act
+        result = Collection(biosamples=[], extra="")
+
+        # Assert
+        assert result.extra is None
+
+
+class TestBiosample:
+    def test_empty_string_to_none_with_empty_anatomy(self):
+        """Test empty string coercion on the anatomy field.
+
+        Given:
+            A Biosample constructed with anatomy set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce anatomy to None.
+        """
+        # Act
+        result = Biosample(anatomy="")
+
+        # Assert
+        assert result.anatomy is None
+
+    def test_empty_string_to_none_with_empty_extra(self):
+        """Test empty string coercion on the extra field.
+
+        Given:
+            A Biosample constructed with extra set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce extra to None.
+        """
+        # Act
+        result = Biosample(extra="")
+
+        # Assert
+        assert result.extra is None
+
+    def test_empty_string_to_none_with_valid_anatomy(self):
+        """Test that valid anatomy dicts are not coerced.
+
+        Given:
+            A Biosample constructed with anatomy set to a valid dict.
+        When:
+            The model is instantiated.
+        Then:
+            It should parse the dict into an Anatomy.
+        """
+        # Arrange
+        anatomy_data = {"id": "UBERON:0002107", "name": "liver"}
+
+        # Act
+        result = Biosample(anatomy=anatomy_data)
+
+        # Assert
+        assert result.anatomy is not None
+        assert result.anatomy.name == "liver"
+
+
+class TestSubject:
+    def test_empty_string_to_none_with_empty_age_at_enrollment(self):
+        """Test empty string coercion on the age_at_enrollment field.
+
+        Given:
+            A Subject constructed with age_at_enrollment set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce age_at_enrollment to None.
+        """
+        # Act
+        result = Subject(age_at_enrollment="")
+
+        # Assert
+        assert result.age_at_enrollment is None
+
+    def test_empty_string_to_none_with_empty_taxonomy(self):
+        """Test empty string coercion on the taxonomy field.
+
+        Given:
+            A Subject constructed with taxonomy set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce taxonomy to None.
+        """
+        # Act
+        result = Subject(taxonomy="")
+
+        # Assert
+        assert result.taxonomy is None
+
+    def test_empty_string_to_none_with_empty_extra(self):
+        """Test empty string coercion on the extra field.
+
+        Given:
+            A Subject constructed with extra set to an empty string.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce extra to None.
+        """
+        # Act
+        result = Subject(extra="")
+
+        # Assert
+        assert result.extra is None
+
+    def test_empty_string_to_none_with_valid_taxonomy(self):
+        """Test that valid taxonomy dicts are not coerced.
+
+        Given:
+            A Subject constructed with taxonomy set to a valid dict.
+        When:
+            The model is instantiated.
+        Then:
+            It should parse the dict into an NcbiTaxonomy.
+        """
+        # Arrange
+        taxonomy_data = {"id": "NCBITaxon:9606", "name": "Homo sapiens"}
+
+        # Act
+        result = Subject(taxonomy=taxonomy_data)
+
+        # Assert
+        assert result.taxonomy is not None
+        assert result.taxonomy.name == "Homo sapiens"
+
+
+def _minimal_file_metadata():
+    """Return the minimal required fields for constructing a FileMetadataModel."""
+    return {
+        "dcc": {"id": "cfde_registry_dcc:hubmap", "dcc_name": "HuBMAP"},
+        "collections": [],
+    }


### PR DESCRIPTION
## Summary

Fix Pydantic validation errors when querying 4DN files whose materialized biosample documents contain empty strings where nested model objects are expected. The root cause is in the Rust materializer's `enrich_file` function, which did not clean up raw anatomy ID strings on biosamples when the lookup missed or the ID was empty. A defense-in-depth layer of Pydantic `field_validator` coercion is added to all models with `Optional[SomeModel]` fields to guard against similar issues from other data paths.

Closes #22

## Proposed changes

### Fix the Rust materializer (root cause)

Apply the same empty-string guard pattern already used by `file_format`, `data_type`, and `assay_type` to the biosample `anatomy` lookup in `enrich_file`. When the anatomy ID is empty or the lookup misses, remove the field from the document rather than leaving the raw ID string.

### Add Pydantic empty-string-to-None coercion (defense-in-depth)

Add `@field_validator(..., mode="before")` to every Pydantic model with `Optional[SomeModel]` fields. This converts `""` to `None` before Pydantic attempts to parse the value as a nested model. Covers `EnrichedFile`, `EnrichedSubject`, `EnrichedCollection`, `EnrichedBiosample`, `FileMetadataModel`, `Collection`, `Biosample`, and `Subject`.

## Test cases

### Rust (materialize/src/main.rs)

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `enrich_file_tests` | A biosample with `anatomy: ""` | `enrich_file` processes the file | Anatomy field is removed from the biosample | Empty string cleanup |
| 2 | `enrich_file_tests` | A biosample with a valid anatomy ID and a matching lookup entry | `enrich_file` processes the file | Anatomy ID is replaced with the full anatomy document | Valid lookup replacement |
| 3 | `enrich_file_tests` | A biosample with a non-empty anatomy ID that has no match | `enrich_file` processes the file | Anatomy field is removed | Unresolved ID cleanup |
| 4 | `enrich_file_tests` | A biosample with no anatomy field at all | `enrich_file` processes the file | No anatomy field is added | Missing field passthrough |
| 5 | `enrich_file_tests` | A file with `file_format: ""` | `enrich_file` processes the file | `file_format` field is removed | Existing behavior pin |
| 6 | `enrich_file_tests` | A file with `data_type: ""` | `enrich_file` processes the file | `data_type` field is removed | Existing behavior pin |
| 7 | `enrich_file_tests` | A file with `assay_type: ""` | `enrich_file` processes the file | `assay_type` field is removed | Existing behavior pin |

### Python (tests/test_models.py)

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestEnrichedFile` | `fourdn=""` | Model is instantiated | `fourdn` is None | Empty string coercion |
| 2 | `TestEnrichedFile` | `encode=""` | Model is instantiated | `encode` is None | Empty string coercion |
| 3 | `TestEnrichedFile` | `hubmap=""` | Model is instantiated | `hubmap` is None | Empty string coercion |
| 4 | `TestEnrichedFile` | `fourdn={"genome_assembly": "GRCh38"}` | Model is instantiated | `fourdn` is parsed correctly | Valid dict passthrough |
| 5 | `TestEnrichedSubject` | `hubmap=""` | Model is instantiated | `hubmap` is None | Empty string coercion |
| 6 | `TestEnrichedCollection` | `fourdn=""` | Model is instantiated | `fourdn` is None | Empty string coercion |
| 7 | `TestEnrichedCollection` | `hubmap=""` | Model is instantiated | `hubmap` is None | Empty string coercion |
| 8 | `TestEnrichedCollection` | `encode=""` | Model is instantiated | `encode` is None | Empty string coercion |
| 9 | `TestEnrichedBiosample` | `encode=""` | Model is instantiated | `encode` is None | Empty string coercion |
| 10 | `TestFileMetadataModel` | `file_format=""` | Model is instantiated | `file_format` is None | Empty string coercion |
| 11 | `TestFileMetadataModel` | `data_type=""` | Model is instantiated | `data_type` is None | Empty string coercion |
| 12 | `TestFileMetadataModel` | `assay_type=""` | Model is instantiated | `assay_type` is None | Empty string coercion |
| 13 | `TestFileMetadataModel` | `project=""` | Model is instantiated | `project` is None | Empty string coercion |
| 14 | `TestFileMetadataModel` | `extra=""` | Model is instantiated | `extra` is None | Empty string coercion |
| 15 | `TestFileMetadataModel` | `file_format={"id": "format:001", "name": "FASTQ"}` | Model is instantiated | `file_format` is parsed correctly | Valid dict passthrough |
| 16 | `TestCollection` | `extra=""` | Model is instantiated | `extra` is None | Empty string coercion |
| 17 | `TestBiosample` | `anatomy=""` | Model is instantiated | `anatomy` is None | Empty string coercion |
| 18 | `TestBiosample` | `extra=""` | Model is instantiated | `extra` is None | Empty string coercion |
| 19 | `TestBiosample` | `anatomy={"id": "UBERON:0002107", "name": "liver"}` | Model is instantiated | `anatomy` is parsed correctly | Valid dict passthrough |
| 20 | `TestSubject` | `age_at_enrollment=""` | Model is instantiated | `age_at_enrollment` is None | Empty string coercion |
| 21 | `TestSubject` | `taxonomy=""` | Model is instantiated | `taxonomy` is None | Empty string coercion |
| 22 | `TestSubject` | `extra=""` | Model is instantiated | `extra` is None | Empty string coercion |
| 23 | `TestSubject` | `taxonomy={"id": "NCBITaxon:9606", "name": "Homo sapiens"}` | Model is instantiated | `taxonomy` is parsed correctly | Valid dict passthrough |

## Implementation plan

1. - [x] Fix biosample anatomy lookup in `enrich_file` to remove empty/unresolved strings
2. - [x] Add Rust regression tests for anatomy empty-string, valid, unresolved, and missing cases
3. - [x] Add Rust regression tests pinning existing file_format, data_type, assay_type behavior
4. - [x] Add `empty_string_to_none` field validators to all Pydantic models with `Optional[SomeModel]` fields
5. - [x] Extend `Subject.empty_string_to_none` to cover `taxonomy` and `extra`
6. - [x] Add Python regression tests for all coercion validators