### PR TITLE
Add CI workflow to run test suite on Python 3.11, 3.12, and 3.13 — Closes #24

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -14,17 +14,17 @@ jobs:
         contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: us-east-2
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
       - name: Build and push to ECR
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: uv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ requires = ["setuptools>=64", "setuptools-scm>=8"]
 [project]
 authors = [{ name = "Conrad Bzura", email = "conradbzura@gmail.com" }]
 classifiers = [
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "aiohttp",


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that runs the pytest suite against Python 3.11, 3.12, and 3.13 on every push and pull request targeting `master`, and align the `pyproject.toml` classifiers with `requires-python = ">=3.11"` so the declared supported versions match both the minimum interpreter requirement and the CI matrix.

The repository previously had no CI for tests — `.github/workflows/` only contained `deploy-to-ecr.yml` — so regressions and version-specific breakage could land on `master` undetected. This workflow validates the existing test suite in `tests/` (`test_cors.py`, `test_data.py`, `test_ontology_mappings.py`, `test_schema.py`, `test_sync.py`) against every supported interpreter on every change.

Closes #24

## Proposed changes

- Add `.github/workflows/test.yml` with a `Test` workflow that:
  - Triggers on `push` and `pull_request` events targeting `master`.
  - Runs on `ubuntu-24.04` with a `fail-fast: false` matrix over Python `3.11`, `3.12`, and `3.13`.
  - Uses `astral-sh/setup-uv@v5` to install `uv`, pin the matrix Python version, and cache the `uv` environment keyed on `uv.lock`.
  - Installs dev dependencies with `uv sync --extra dev` and executes the suite with `uv run pytest`.
  - Declares a concurrency group scoped to `workflow` + `ref` that cancels in-progress runs only for pull requests, so pushes to `master` always run to completion.
- Update `pyproject.toml` classifiers to drop `Programming Language :: Python :: 3.10` and add `Programming Language :: Python :: 3.13`, matching `requires-python = ">=3.11"` and the new matrix.

## Notes for reviewers

- This PR only changes CI configuration and packaging metadata; no production code or tests were added or modified.
- Making the `Test` check **required** for merges to `master` needs a branch-protection settings change on the repository and is out of scope for this PR — a repo admin will need to enable it once the workflow has run green at least once on `master`.