### PR TITLE
Fix 4DN /index 500 on dict-shaped sidecar file_format — Closes #26

### DIFF
--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -222,7 +222,10 @@ async def _try_serve_fourdn_sidecar(
         raw_fmt = candidate.get("file_format")
         if isinstance(raw_fmt, dict):
             raw_fmt = raw_fmt.get("display_title")
-        fmt = (raw_fmt or "").lower()
+        # Only a string carries a usable token; anything else (a dict with
+        # no display_title, None, or an unexpected type) is a non-match,
+        # never an AttributeError on .lower().
+        fmt = raw_fmt.lower() if isinstance(raw_fmt, str) else ""
         if fmt in _SIDECAR_INDEX_FORMATS:
             index_entry = candidate
             break

--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -48,12 +48,15 @@ router = APIRouter(prefix="/index", tags=["index"])
 _PATH_PARAM_PATTERN = r"^[A-Za-z0-9._-]+$"
 _PATH_PARAM_MAX_LEN = 256
 
-#: Index artifact kind → preferred sidecar ``file_format`` tokens used in
-#: 4DN's ``extra.extra_files`` / ``extra.fourdn.extra_files`` arrays. The
-#: lookup is best-effort: if no entry matches we fall back to the first
-#: sidecar entry (legacy behavior) so existing 4DN BED→beddb / BED→tbi
-#: cases keep working.
-_SIDECAR_INDEX_FORMATS = ("bai", "tbi", "beddb", "csi")
+#: Sidecar ``file_format`` tokens (4DN ``display_title`` values or bare
+#: strings) recognized as index artifacts in 4DN's ``extra.extra_files`` /
+#: ``extra.fourdn.extra_files`` arrays: ``bai``/``csi`` (BAM), ``tbi``
+#: (tabix), ``beddb`` (HiGlass BED), and the pairix indexes ``pairs_px2``
+#: (.pairs) and ``bg_px2`` (bedGraph). ``bw`` (bigWig) is deliberately
+#: excluded — it is self-indexed data, not a sidecar index. The lookup is
+#: best-effort: if no entry matches we fall back to the first sidecar entry
+#: (legacy behavior) so existing 4DN BED→beddb / BED→tbi cases keep working.
+_SIDECAR_INDEX_FORMATS = ("bai", "tbi", "beddb", "csi", "pairs_px2", "bg_px2")
 
 
 @router.head("/{dcc}/{local_id}")
@@ -196,7 +199,10 @@ async def _try_serve_fourdn_sidecar(
 
     Looks first at ``extra.extra_files`` (the path used by pre-materialized
     documents) and then at ``extra.fourdn.extra_files`` (the DCC-specific
-    subdocument).
+    subdocument). Each entry's ``file_format`` is normalized from either a
+    ``{display_title: ...}`` CV object (the shape 4DN materializes) or a
+    bare string before matching ``_SIDECAR_INDEX_FORMATS``; an entry whose
+    token is unrecognized falls through to the first-entry fallback.
     """
     extra = file_doc.get("extra") or {}
     extra_files = extra.get("extra_files") or []

--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -23,8 +23,9 @@ async def stream_index_file(
     """
     Stream an index file (e.g., .px2, .bai) associated with a DCC file.
 
-    Index files are discovered during 4DN API enrichment and stored in
-    extra.extra_files on the materialized file document.
+    Index files are discovered during DCC-specific enrichment and stored
+    under a DCC-namespaced key on the materialized file document. For 4DN
+    files, sidecar extras live under ``extra.fourdn.extra_files``.
 
     Path Parameters:
         dcc: DCC abbreviation (e.g., 4dn) - case insensitive
@@ -64,9 +65,15 @@ async def stream_index_file(
         if not file_doc:
             raise HTTPException(status_code=404, detail="File not found")
 
-        # Get extra_files from the extra field
-        extra = file_doc.get("extra", {})
-        extra_files = extra.get("extra_files", [])
+        # Get extra_files from the DCC-namespaced subdocument under ``extra``.
+        # Each DCC enrichment writes sidecar extras under its own key
+        # (e.g. 4DN → ``extra.fourdn.extra_files``) so we dispatch by DCC.
+        extra = file_doc.get("extra") or {}
+        if normalized_dcc == "4dn":
+            dcc_extra = extra.get("fourdn") or {}
+            extra_files = dcc_extra.get("extra_files") or []
+        else:
+            extra_files = []
 
         if not extra_files:
             raise HTTPException(

--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -211,12 +211,18 @@ async def _try_serve_fourdn_sidecar(
     # back to the first entry to preserve legacy behavior for files
     # whose sidecar omits ``file_format``. Iterating defends against
     # future 4DN docs that publish multiple sidecar artifacts where
-    # the data file (not the index) happens to be first.
+    # the data file (not the index) happens to be first. 4DN
+    # materializes ``file_format`` as a CV object carrying the token
+    # under ``display_title``; pre-materialized docs use a bare string,
+    # so normalize both shapes before matching.
     index_entry: Optional[dict] = None
     for candidate in extra_files:
         if not isinstance(candidate, dict):
             continue
-        fmt = (candidate.get("file_format") or "").lower()
+        raw_fmt = candidate.get("file_format")
+        if isinstance(raw_fmt, dict):
+            raw_fmt = raw_fmt.get("display_title")
+        fmt = (raw_fmt or "").lower()
         if fmt in _SIDECAR_INDEX_FORMATS:
             index_entry = candidate
             break

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
 from cfdb.api.routers.index import stream_index_file
+from cfdb.services import drs, locks
 
 
 def _make_request(method: str = "HEAD"):
@@ -58,8 +59,13 @@ def _make_4dn_file_doc(
 
 
 class TestStreamIndexFile:
+    @pytest.fixture(autouse=True)
+    def _patch_cutover(self, mocker):
+        """No-op ``locks.wait_for_cutover`` for every test in this class."""
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
     @pytest.mark.asyncio
-    async def test_stream_index_file_4dn_with_sidecar_head(self, mock_db, mocker):
+    async def test_stream_index_file_4dn_with_sidecar_head(self, mock_db):
         """Test HEAD request returns sidecar headers for a 4DN file.
 
         Given:
@@ -71,7 +77,6 @@ class TestStreamIndexFile:
             and Content-Length headers sourced from the sidecar entry.
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [_make_4dn_file_doc()]
 
         # Act
@@ -89,36 +94,8 @@ class TestStreamIndexFile:
         assert response.headers["Content-Length"] == "1024"
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_4dn_without_fourdn_extras(
-        self, mock_db, mocker
-    ):
-        """Test 4DN file with no fourdn extras raises 404.
-
-        Given:
-            A 4DN file whose materialized document has no extra.fourdn.extra_files entry.
-        When:
-            stream_index_file is called.
-        Then:
-            It should raise an HTTPException with status 404 and detail
-            "No index file available for this file".
-        """
-        # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
-        mock_db.files.docs = [
-            _make_4dn_file_doc(extra_fourdn_extras_present=False)
-        ]
-
-        # Act & assert
-        with pytest.raises(HTTPException) as exc_info:
-            await stream_index_file(
-                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range=None
-            )
-        assert exc_info.value.status_code == 404
-        assert exc_info.value.detail == "No index file available for this file"
-
-    @pytest.mark.asyncio
     async def test_stream_index_file_4dn_with_only_legacy_top_level_extras(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test legacy top-level extras are ignored for 4DN dispatch.
 
@@ -132,7 +109,6 @@ class TestStreamIndexFile:
             only reads the DCC-namespaced path.
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_4dn_file_doc(
                 extra_fourdn_extras_present=False,
@@ -155,7 +131,7 @@ class TestStreamIndexFile:
         assert exc_info.value.detail == "No index file available for this file"
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_4dn_with_range_header(self, mock_db, mocker):
+    async def test_stream_index_file_4dn_with_range_header(self, mock_db):
         """Test valid Range header produces a 206 response with Content-Range.
 
         Given:
@@ -167,7 +143,6 @@ class TestStreamIndexFile:
             the requested byte range.
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [_make_4dn_file_doc()]
 
         # Act
@@ -181,9 +156,7 @@ class TestStreamIndexFile:
         assert response.headers["Content-Length"] == "100"
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_with_missing_file_document(
-        self, mock_db, mocker
-    ):
+    async def test_stream_index_file_with_missing_file_document(self, mock_db):
         """Test missing file document raises 404.
 
         Given:
@@ -195,7 +168,6 @@ class TestStreamIndexFile:
             "File not found".
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = []
 
         # Act & assert
@@ -207,7 +179,7 @@ class TestStreamIndexFile:
         assert exc_info.value.detail == "File not found"
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_with_unknown_dcc(self, mock_db, mocker):
+    async def test_stream_index_file_with_unknown_dcc(self, mock_db):
         """Test an unknown DCC name raises 400.
 
         Given:
@@ -218,9 +190,6 @@ class TestStreamIndexFile:
             It should raise an HTTPException with status 400 and the DB is
             not queried.
         """
-        # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
-
         # Act & assert
         with pytest.raises(HTTPException) as exc_info:
             await stream_index_file(
@@ -229,9 +198,7 @@ class TestStreamIndexFile:
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_4dn_entry_without_href(
-        self, mock_db, mocker
-    ):
+    async def test_stream_index_file_4dn_entry_without_href(self, mock_db):
         """Test sidecar entry without an href raises 404.
 
         Given:
@@ -243,7 +210,6 @@ class TestStreamIndexFile:
             "Index file has no download URL".
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_4dn_file_doc(extra_files=[{"file_size": 123}])
         ]
@@ -257,7 +223,7 @@ class TestStreamIndexFile:
         assert exc_info.value.detail == "Index file has no download URL"
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_with_mixed_case_dcc(self, mock_db, mocker):
+    async def test_stream_index_file_with_mixed_case_dcc(self, mock_db):
         """Test DCC dispatch is case-insensitive.
 
         Given:
@@ -269,7 +235,6 @@ class TestStreamIndexFile:
             confirming case-insensitive DCC normalization.
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [_make_4dn_file_doc()]
 
         # Act
@@ -299,10 +264,7 @@ class TestStreamIndexFile:
             the expected sidecar headers.
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
-        mocker.patch(
-            "cfdb.services.drs.stream_from_url", return_value=iter([b""])
-        )
+        mocker.patch.object(drs, "stream_from_url", return_value=iter([b""]))
         mock_db.files.docs = [_make_4dn_file_doc()]
 
         # Act
@@ -322,7 +284,7 @@ class TestStreamIndexFile:
 
     @pytest.mark.asyncio
     async def test_stream_index_file_4dn_range_when_entry_has_no_file_size(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test Range request on sidecar without file_size raises 500.
 
@@ -335,7 +297,6 @@ class TestStreamIndexFile:
             "Cannot process range request: index file size unavailable".
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_4dn_file_doc(
                 extra_files=[
@@ -360,7 +321,7 @@ class TestStreamIndexFile:
 
     @pytest.mark.asyncio
     async def test_stream_index_file_4dn_with_malformed_range_header(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test malformed Range header raises 400.
 
@@ -374,7 +335,6 @@ class TestStreamIndexFile:
             starting with "Invalid Range header".
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [_make_4dn_file_doc()]
 
         # Act & assert
@@ -386,9 +346,7 @@ class TestStreamIndexFile:
         assert exc_info.value.detail.startswith("Invalid Range header")
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_4dn_with_unsatisfiable_range(
-        self, mock_db, mocker
-    ):
+    async def test_stream_index_file_4dn_with_unsatisfiable_range(self, mock_db):
         """Test unsatisfiable Range raises 416 with Content-Range header.
 
         Given:
@@ -401,7 +359,6 @@ class TestStreamIndexFile:
             Content-Range header of "bytes */1024".
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [_make_4dn_file_doc()]
 
         # Act & assert
@@ -417,7 +374,7 @@ class TestStreamIndexFile:
 
     @pytest.mark.asyncio
     async def test_stream_index_file_for_non_4dn_dcc_returns_no_index(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test non-4DN DCCs always return no index (router only unpacks 4DN).
 
@@ -431,7 +388,6 @@ class TestStreamIndexFile:
             dispatch only unpacks the 4DN-namespaced path.
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             {
                 "submission": "hubmap",
@@ -460,7 +416,7 @@ class TestStreamIndexFile:
 
     @pytest.mark.asyncio
     async def test_stream_index_file_4dn_with_empty_fourdn_extras_list(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test empty fourdn extras list raises 404.
 
@@ -473,7 +429,6 @@ class TestStreamIndexFile:
             "No index file available for this file".
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [_make_4dn_file_doc(extra_files=[])]
 
         # Act & assert

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -96,6 +96,67 @@ class TestStreamIndexFileFourdnSidecar:
         assert captured_urls[0].endswith("/x/abc.tbi")
 
     @pytest.mark.asyncio
+    async def test_stream_index_file_should_select_dict_shaped_file_format_sidecar(
+        self, mock_db, mocker
+    ):
+        """Test (IX-007) that a 4DN dict-shaped file_format sidecar is read.
+
+        Given:
+            A 4DN file whose ``extra.fourdn.extra_files`` carries
+            ``file_format`` as the CV object the materializer emits
+            (``{"display_title": "beddb"}``) — a non-index ``pairs_px2``
+            entry first and the ``beddb`` index second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            It should read the token from ``display_title``, prefer the
+            ``beddb`` entry, and stream it rather than crashing on the
+            dict (the #26 500).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"beddb-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "pairs_px2"},
+                                "href": "/x/data.px2",
+                            },
+                            {
+                                "file_format": {"display_title": "beddb"},
+                                "href": "/x/abc.beddb",
+                                "file_size": 100,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"beddb-bytes"
+        assert captured_urls[0].endswith("/x/abc.beddb")
+
+    @pytest.mark.asyncio
     async def test_stream_index_file_should_resolve_nested_fourdn_extra_files(
         self, mock_db, mocker
     ):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -96,348 +96,6 @@ class TestStreamIndexFileFourdnSidecar:
         assert captured_urls[0].endswith("/x/abc.tbi")
 
     @pytest.mark.asyncio
-    async def test_stream_index_file_should_select_dict_shaped_file_format_sidecar(
-        self, mock_db, mocker
-    ):
-        """Test (IX-007) that a 4DN dict-shaped file_format sidecar is read.
-
-        Given:
-            A 4DN file whose ``extra.fourdn.extra_files`` carries
-            ``file_format`` as the CV object the materializer emits
-            (``{"display_title": "beddb"}``) — a non-index ``pairs_px2``
-            entry first and the ``beddb`` index second.
-        When:
-            ``stream_index_file`` is called.
-        Then:
-            It should read the token from ``display_title``, prefer the
-            ``beddb`` entry, and stream it rather than crashing on the
-            dict (the #26 500).
-        """
-        # Arrange
-        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
-
-        captured_urls: list[str] = []
-
-        async def fake_stream(url, _range):
-            captured_urls.append(url)
-            yield b"beddb-bytes"
-
-        mocker.patch.object(drs, "stream_from_url", fake_stream)
-
-        mock_db.files.docs = []
-        mock_db.file.docs = [
-            _make_file_doc(
-                extra={
-                    "fourdn": {
-                        "extra_files": [
-                            {
-                                "file_format": {"display_title": "pairs_px2"},
-                                "href": "/x/data.px2",
-                            },
-                            {
-                                "file_format": {"display_title": "beddb"},
-                                "href": "/x/abc.beddb",
-                                "file_size": 100,
-                            },
-                        ]
-                    }
-                }
-            )
-        ]
-
-        # Act
-        resp = await stream_index_file(
-            "4dn", "4DNFIBED01", _make_request(), range=None
-        )
-
-        # Assert
-        assert resp.status_code == 200
-        body = b"".join([chunk async for chunk in resp.body_iterator])
-        assert body == b"beddb-bytes"
-        assert captured_urls[0].endswith("/x/abc.beddb")
-
-    @pytest.mark.asyncio
-    async def test_stream_index_file_should_fall_back_when_dict_file_format_lacks_display_title(
-        self, mock_db, mocker
-    ):
-        """Test (IX-008) that a dict file_format with no display_title falls back.
-
-        Given:
-            A 4DN file whose sole ``extra.fourdn.extra_files`` entry has
-            ``file_format`` as a dict carrying no ``display_title`` key.
-        When:
-            ``stream_index_file`` is called.
-        Then:
-            The missing token resolves to no-match, the entry is served
-            via the first-entry fallback, and no AttributeError is raised
-            (the #26 crash line).
-        """
-        # Arrange
-        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
-
-        captured_urls: list[str] = []
-
-        async def fake_stream(url, _range):
-            captured_urls.append(url)
-            yield b"fallback-bytes"
-
-        mocker.patch.object(drs, "stream_from_url", fake_stream)
-
-        mock_db.files.docs = []
-        mock_db.file.docs = [
-            _make_file_doc(
-                extra={
-                    "fourdn": {
-                        "extra_files": [
-                            {
-                                "file_format": {"@id": "/file-formats/beddb/"},
-                                "href": "/x/only.beddb",
-                                "file_size": 50,
-                            },
-                        ]
-                    }
-                }
-            )
-        ]
-
-        # Act
-        resp = await stream_index_file(
-            "4dn", "4DNFIBED01", _make_request(), range=None
-        )
-
-        # Assert
-        assert resp.status_code == 200
-        body = b"".join([chunk async for chunk in resp.body_iterator])
-        assert body == b"fallback-bytes"
-        assert captured_urls[0].endswith("/x/only.beddb")
-
-    @pytest.mark.asyncio
-    async def test_stream_index_file_should_reject_non_index_dict_token(
-        self, mock_db, mocker
-    ):
-        """Test (IX-009) that a non-index dict display_title does not match.
-
-        Given:
-            A 4DN file with two dict-shaped sidecar entries: a non-index
-            ``pairs_px2`` entry first and a ``bai`` index entry second.
-        When:
-            ``stream_index_file`` is called.
-        Then:
-            The non-index dict token must not match the canonical index
-            formats; the ``bai`` index entry is selected and streamed.
-        """
-        # Arrange
-        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
-
-        captured_urls: list[str] = []
-
-        async def fake_stream(url, _range):
-            captured_urls.append(url)
-            yield b"bai-bytes"
-
-        mocker.patch.object(drs, "stream_from_url", fake_stream)
-
-        mock_db.files.docs = []
-        mock_db.file.docs = [
-            _make_file_doc(
-                extra={
-                    "fourdn": {
-                        "extra_files": [
-                            {
-                                "file_format": {"display_title": "pairs_px2"},
-                                "href": "/x/data.px2",
-                            },
-                            {
-                                "file_format": {"display_title": "bai"},
-                                "href": "/x/y.bai",
-                                "file_size": 80,
-                            },
-                        ]
-                    }
-                }
-            )
-        ]
-
-        # Act
-        resp = await stream_index_file(
-            "4dn", "4DNFIBED01", _make_request(), range=None
-        )
-
-        # Assert
-        assert resp.status_code == 200
-        body = b"".join([chunk async for chunk in resp.body_iterator])
-        assert body == b"bai-bytes"
-        assert captured_urls[0].endswith("/x/y.bai")
-
-    @pytest.mark.asyncio
-    async def test_stream_index_file_should_normalize_mixed_string_and_dict_entries(
-        self, mock_db, mocker
-    ):
-        """Test (IX-010) that string and dict file_format entries coexist.
-
-        Given:
-            A 4DN file with a bare-string non-index entry first and a
-            dict-shaped ``tbi`` index entry second.
-        When:
-            ``stream_index_file`` is called.
-        Then:
-            Both shapes normalize in one pass and the dict ``tbi`` entry
-            is selected and streamed.
-        """
-        # Arrange
-        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
-
-        captured_urls: list[str] = []
-
-        async def fake_stream(url, _range):
-            captured_urls.append(url)
-            yield b"tbi-bytes"
-
-        mocker.patch.object(drs, "stream_from_url", fake_stream)
-
-        mock_db.files.docs = []
-        mock_db.file.docs = [
-            _make_file_doc(
-                extra={
-                    "fourdn": {
-                        "extra_files": [
-                            {"file_format": "data", "href": "/x/data"},
-                            {
-                                "file_format": {"display_title": "tbi"},
-                                "href": "/x/abc.tbi",
-                                "file_size": 100,
-                            },
-                        ]
-                    }
-                }
-            )
-        ]
-
-        # Act
-        resp = await stream_index_file(
-            "4dn", "4DNFIBED01", _make_request(), range=None
-        )
-
-        # Assert
-        assert resp.status_code == 200
-        body = b"".join([chunk async for chunk in resp.body_iterator])
-        assert body == b"tbi-bytes"
-        assert captured_urls[0].endswith("/x/abc.tbi")
-
-    @pytest.mark.asyncio
-    async def test_stream_index_file_should_match_dict_token_case_insensitively(
-        self, mock_db, mocker
-    ):
-        """Test (IX-011) that a dict display_title token matches regardless of case.
-
-        Given:
-            A 4DN file with a non-index entry first and a dict index entry
-            whose ``display_title`` is upper-case (``TBI``).
-        When:
-            ``stream_index_file`` is called.
-        Then:
-            The token is lowercased before matching, so the ``TBI`` entry
-            is selected and streamed.
-        """
-        # Arrange
-        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
-
-        captured_urls: list[str] = []
-
-        async def fake_stream(url, _range):
-            captured_urls.append(url)
-            yield b"tbi-bytes"
-
-        mocker.patch.object(drs, "stream_from_url", fake_stream)
-
-        mock_db.files.docs = []
-        mock_db.file.docs = [
-            _make_file_doc(
-                extra={
-                    "fourdn": {
-                        "extra_files": [
-                            {
-                                "file_format": {"display_title": "pairs_px2"},
-                                "href": "/x/data.px2",
-                            },
-                            {
-                                "file_format": {"display_title": "TBI"},
-                                "href": "/x/abc.tbi",
-                                "file_size": 100,
-                            },
-                        ]
-                    }
-                }
-            )
-        ]
-
-        # Act
-        resp = await stream_index_file(
-            "4dn", "4DNFIBED01", _make_request(), range=None
-        )
-
-        # Assert
-        assert resp.status_code == 200
-        body = b"".join([chunk async for chunk in resp.body_iterator])
-        assert body == b"tbi-bytes"
-        assert captured_urls[0].endswith("/x/abc.tbi")
-
-    @pytest.mark.parametrize("bad_format", [None, 123, ["tbi"]])
-    @pytest.mark.asyncio
-    async def test_stream_index_file_should_tolerate_non_string_file_format(
-        self, mock_db, mocker, bad_format
-    ):
-        """Test (IX-012) that an unexpected file_format type does not 500.
-
-        Given:
-            A 4DN file whose sole sidecar entry has ``file_format`` as a
-            non-dict, non-string value (None, an int, or a list).
-        When:
-            ``stream_index_file`` is called.
-        Then:
-            The value is treated as a non-match, the entry is served via
-            the first-entry fallback, and no AttributeError/500 occurs.
-        """
-        # Arrange
-        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
-
-        captured_urls: list[str] = []
-
-        async def fake_stream(url, _range):
-            captured_urls.append(url)
-            yield b"fallback-bytes"
-
-        mocker.patch.object(drs, "stream_from_url", fake_stream)
-
-        mock_db.files.docs = []
-        mock_db.file.docs = [
-            _make_file_doc(
-                extra={
-                    "fourdn": {
-                        "extra_files": [
-                            {
-                                "file_format": bad_format,
-                                "href": "/x/only.tbi",
-                                "file_size": 40,
-                            },
-                        ]
-                    }
-                }
-            )
-        ]
-
-        # Act
-        resp = await stream_index_file(
-            "4dn", "4DNFIBED01", _make_request(), range=None
-        )
-
-        # Assert
-        assert resp.status_code == 200
-        body = b"".join([chunk async for chunk in resp.body_iterator])
-        assert body == b"fallback-bytes"
-        assert captured_urls[0].endswith("/x/only.tbi")
-
-    @pytest.mark.asyncio
     async def test_stream_index_file_should_resolve_nested_fourdn_extra_files(
         self, mock_db, mocker
     ):
@@ -654,6 +312,421 @@ class TestStreamIndexFileFourdnSidecar:
         assert body == b"idx-bytes"
         assert len(captured_urls) == 1
         assert captured_urls[0].endswith("/x/abc.tbi")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_select_dict_shaped_file_format_sidecar(
+        self, mock_db, mocker
+    ):
+        """Test (IX-007) that a 4DN dict-shaped file_format sidecar is read.
+
+        Given:
+            A 4DN file whose ``extra.fourdn.extra_files`` carries
+            ``file_format`` as the CV object the materializer emits — a
+            non-index ``bw`` entry first and the ``beddb`` index second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            It should read the token from ``display_title``, prefer the
+            ``beddb`` entry, and stream it rather than crashing on the
+            dict (the #26 500).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"beddb-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "bw"},
+                                "href": "/x/data.bw",
+                            },
+                            {
+                                "file_format": {"display_title": "beddb"},
+                                "href": "/x/abc.beddb",
+                                "file_size": 100,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"beddb-bytes"
+        assert captured_urls[0].endswith("/x/abc.beddb")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_fall_back_when_dict_file_format_lacks_display_title(
+        self, mock_db, mocker
+    ):
+        """Test (IX-008) that a dict file_format with no display_title falls back.
+
+        Given:
+            A 4DN file with two non-index entries: one whose ``file_format``
+            dict carries no ``display_title`` key (first) and a ``bw`` entry
+            (second), so nothing matches the index allowlist.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The missing token resolves to no-match, the first-entry fallback
+            serves the first entry (not the second), and no AttributeError
+            is raised (the #26 crash line).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"fallback-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"@id": "/file-formats/beddb/"},
+                                "href": "/x/first.beddb",
+                                "file_size": 50,
+                            },
+                            {
+                                "file_format": {"display_title": "bw"},
+                                "href": "/x/second.bw",
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"fallback-bytes"
+        assert captured_urls[0].endswith("/x/first.beddb")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_reject_non_index_dict_token(
+        self, mock_db, mocker
+    ):
+        """Test (IX-009) that a non-index dict display_title does not match.
+
+        Given:
+            A 4DN file with two dict-shaped sidecar entries: a non-index
+            ``bw`` entry first and a ``bai`` index entry second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The non-index dict token must not match the canonical index
+            formats; the ``bai`` index entry is selected and streamed.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"bai-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "bw"},
+                                "href": "/x/data.bw",
+                            },
+                            {
+                                "file_format": {"display_title": "bai"},
+                                "href": "/x/y.bai",
+                                "file_size": 80,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"bai-bytes"
+        assert captured_urls[0].endswith("/x/y.bai")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_match_bare_string_index_alongside_dict_entry(
+        self, mock_db, mocker
+    ):
+        """Test (IX-010) that a bare-string index token is matched.
+
+        Given:
+            A 4DN file with a non-index dict ``bw`` entry first and a
+            bare-string ``tbi`` index entry second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The bare-string entry is normalized and matched, so the ``tbi``
+            entry is selected and streamed — exercising the string branch
+            alongside the dict branch in one pass.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"tbi-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "bw"},
+                                "href": "/x/data.bw",
+                            },
+                            {
+                                "file_format": "tbi",
+                                "href": "/x/abc.tbi",
+                                "file_size": 100,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"tbi-bytes"
+        assert captured_urls[0].endswith("/x/abc.tbi")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_match_dict_token_case_insensitively(
+        self, mock_db, mocker
+    ):
+        """Test (IX-011) that a dict display_title token matches regardless of case.
+
+        Given:
+            A 4DN file with a non-index ``bw`` entry first and a dict index
+            entry whose ``display_title`` is upper-case (``TBI``).
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The token is lowercased before matching, so the ``TBI`` entry
+            is selected and streamed.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"tbi-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "bw"},
+                                "href": "/x/data.bw",
+                            },
+                            {
+                                "file_format": {"display_title": "TBI"},
+                                "href": "/x/abc.tbi",
+                                "file_size": 100,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"tbi-bytes"
+        assert captured_urls[0].endswith("/x/abc.tbi")
+
+    @pytest.mark.parametrize("bad_format", [None, 123, ["tbi"]])
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_tolerate_non_string_file_format(
+        self, mock_db, mocker, bad_format
+    ):
+        """Test (IX-012) that an unexpected file_format type does not 500.
+
+        Given:
+            A 4DN file with two non-matching entries: one whose
+            ``file_format`` is a non-dict, non-string value (None, an int,
+            or a list) first, and a ``bw`` entry second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The value is treated as a non-match, the first-entry fallback
+            serves the first entry, and no AttributeError/500 occurs.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"fallback-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": bad_format,
+                                "href": "/x/first.dat",
+                                "file_size": 40,
+                            },
+                            {
+                                "file_format": {"display_title": "bw"},
+                                "href": "/x/second.bw",
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"fallback-bytes"
+        assert captured_urls[0].endswith("/x/first.dat")
+
+    @pytest.mark.parametrize("index_token", ["pairs_px2", "bg_px2"])
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_match_pairix_index_tokens(
+        self, mock_db, mocker, index_token
+    ):
+        """Test (IX-013) that 4DN pairix index tokens are matched by format.
+
+        Given:
+            A 4DN file with a non-index ``bw`` entry first and a pairix
+            index entry (``pairs_px2`` or ``bg_px2``) second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The pairix token matches the index allowlist and wins over array
+            order, so the index entry is selected and streamed rather than
+            the first-entry fallback serving the ``bw``.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"px2-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "bw"},
+                                "href": "/x/data.bw",
+                            },
+                            {
+                                "file_format": {"display_title": index_token},
+                                "href": "/x/abc.px2",
+                                "file_size": 100,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"px2-bytes"
+        assert captured_urls[0].endswith("/x/abc.px2")
 
 
 class TestStreamIndexFileWorkflowPaths:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -157,6 +157,287 @@ class TestStreamIndexFileFourdnSidecar:
         assert captured_urls[0].endswith("/x/abc.beddb")
 
     @pytest.mark.asyncio
+    async def test_stream_index_file_should_fall_back_when_dict_file_format_lacks_display_title(
+        self, mock_db, mocker
+    ):
+        """Test (IX-008) that a dict file_format with no display_title falls back.
+
+        Given:
+            A 4DN file whose sole ``extra.fourdn.extra_files`` entry has
+            ``file_format`` as a dict carrying no ``display_title`` key.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The missing token resolves to no-match, the entry is served
+            via the first-entry fallback, and no AttributeError is raised
+            (the #26 crash line).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"fallback-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"@id": "/file-formats/beddb/"},
+                                "href": "/x/only.beddb",
+                                "file_size": 50,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"fallback-bytes"
+        assert captured_urls[0].endswith("/x/only.beddb")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_reject_non_index_dict_token(
+        self, mock_db, mocker
+    ):
+        """Test (IX-009) that a non-index dict display_title does not match.
+
+        Given:
+            A 4DN file with two dict-shaped sidecar entries: a non-index
+            ``pairs_px2`` entry first and a ``bai`` index entry second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The non-index dict token must not match the canonical index
+            formats; the ``bai`` index entry is selected and streamed.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"bai-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "pairs_px2"},
+                                "href": "/x/data.px2",
+                            },
+                            {
+                                "file_format": {"display_title": "bai"},
+                                "href": "/x/y.bai",
+                                "file_size": 80,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"bai-bytes"
+        assert captured_urls[0].endswith("/x/y.bai")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_normalize_mixed_string_and_dict_entries(
+        self, mock_db, mocker
+    ):
+        """Test (IX-010) that string and dict file_format entries coexist.
+
+        Given:
+            A 4DN file with a bare-string non-index entry first and a
+            dict-shaped ``tbi`` index entry second.
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            Both shapes normalize in one pass and the dict ``tbi`` entry
+            is selected and streamed.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"tbi-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {"file_format": "data", "href": "/x/data"},
+                            {
+                                "file_format": {"display_title": "tbi"},
+                                "href": "/x/abc.tbi",
+                                "file_size": 100,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"tbi-bytes"
+        assert captured_urls[0].endswith("/x/abc.tbi")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_match_dict_token_case_insensitively(
+        self, mock_db, mocker
+    ):
+        """Test (IX-011) that a dict display_title token matches regardless of case.
+
+        Given:
+            A 4DN file with a non-index entry first and a dict index entry
+            whose ``display_title`` is upper-case (``TBI``).
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The token is lowercased before matching, so the ``TBI`` entry
+            is selected and streamed.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"tbi-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": {"display_title": "pairs_px2"},
+                                "href": "/x/data.px2",
+                            },
+                            {
+                                "file_format": {"display_title": "TBI"},
+                                "href": "/x/abc.tbi",
+                                "file_size": 100,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"tbi-bytes"
+        assert captured_urls[0].endswith("/x/abc.tbi")
+
+    @pytest.mark.parametrize("bad_format", [None, 123, ["tbi"]])
+    @pytest.mark.asyncio
+    async def test_stream_index_file_should_tolerate_non_string_file_format(
+        self, mock_db, mocker, bad_format
+    ):
+        """Test (IX-012) that an unexpected file_format type does not 500.
+
+        Given:
+            A 4DN file whose sole sidecar entry has ``file_format`` as a
+            non-dict, non-string value (None, an int, or a list).
+        When:
+            ``stream_index_file`` is called.
+        Then:
+            The value is treated as a non-match, the entry is served via
+            the first-entry fallback, and no AttributeError/500 occurs.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        captured_urls: list[str] = []
+
+        async def fake_stream(url, _range):
+            captured_urls.append(url)
+            yield b"fallback-bytes"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={
+                    "fourdn": {
+                        "extra_files": [
+                            {
+                                "file_format": bad_format,
+                                "href": "/x/only.tbi",
+                                "file_size": 40,
+                            },
+                        ]
+                    }
+                }
+            )
+        ]
+
+        # Act
+        resp = await stream_index_file(
+            "4dn", "4DNFIBED01", _make_request(), range=None
+        )
+
+        # Assert
+        assert resp.status_code == 200
+        body = b"".join([chunk async for chunk in resp.body_iterator])
+        assert body == b"fallback-bytes"
+        assert captured_urls[0].endswith("/x/only.tbi")
+
+    @pytest.mark.asyncio
     async def test_stream_index_file_should_resolve_nested_fourdn_extra_files(
         self, mock_db, mocker
     ):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,485 @@
+"""Tests for the /index/{dcc}/{local_id} streaming router."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+
+from cfdb.api.routers.index import stream_index_file
+
+
+def _make_request(method: str = "HEAD"):
+    """Return a minimal mock request object."""
+
+    class FakeRequest:
+        def __init__(self):
+            self.method = method
+
+    return FakeRequest()
+
+
+def _make_4dn_file_doc(
+    *,
+    local_id: str = "4DNFI1234ABC",
+    extra_files: list | None = None,
+    extra_fourdn_extras_present: bool = True,
+    extra_top_level_extras: list | None = None,
+) -> dict:
+    """Build a materialized 4DN file document.
+
+    By default produces a document with a single sidecar entry under the
+    DCC-namespaced path ``extra.fourdn.extra_files``.
+    """
+    doc: dict = {
+        "submission": "4dn",
+        "local_id": local_id,
+        "filename": "4DNFI1234ABC.mcool",
+    }
+    extra: dict = {}
+    if extra_fourdn_extras_present:
+        extra["fourdn"] = {
+            "extra_files": extra_files
+            if extra_files is not None
+            else [
+                {
+                    "href": "/files-processed/4DNFI1234ABC/@@download/4DNFI1234ABC.mcool.px2",
+                    "file_size": 1024,
+                    "file_format": "pairs_px2",
+                    "md5sum": "deadbeef",
+                }
+            ]
+        }
+    if extra_top_level_extras is not None:
+        extra["extra_files"] = extra_top_level_extras
+    if extra:
+        doc["extra"] = extra
+    return doc
+
+
+class TestStreamIndexFile:
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_with_sidecar_head(self, mock_db, mocker):
+        """Test HEAD request returns sidecar headers for a 4DN file.
+
+        Given:
+            A 4DN file whose materialized document has extra.fourdn.extra_files populated.
+        When:
+            stream_index_file is called with a HEAD request and no Range header.
+        Then:
+            It should return a 200 response with Content-Disposition, Accept-Ranges,
+            and Content-Length headers sourced from the sidecar entry.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [_make_4dn_file_doc()]
+
+        # Act
+        response = await stream_index_file(
+            "4dn", "4DNFI1234ABC", _make_request("HEAD"), range=None
+        )
+
+        # Assert
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Disposition"]
+            == 'attachment; filename="4DNFI1234ABC.mcool.px2"'
+        )
+        assert response.headers["Accept-Ranges"] == "bytes"
+        assert response.headers["Content-Length"] == "1024"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_without_fourdn_extras(
+        self, mock_db, mocker
+    ):
+        """Test 4DN file with no fourdn extras raises 404.
+
+        Given:
+            A 4DN file whose materialized document has no extra.fourdn.extra_files entry.
+        When:
+            stream_index_file is called.
+        Then:
+            It should raise an HTTPException with status 404 and detail
+            "No index file available for this file".
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [
+            _make_4dn_file_doc(extra_fourdn_extras_present=False)
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range=None
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "No index file available for this file"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_with_only_legacy_top_level_extras(
+        self, mock_db, mocker
+    ):
+        """Test legacy top-level extras are ignored for 4DN dispatch.
+
+        Given:
+            A 4DN file with only the legacy top-level extra.extra_files shape and
+            no extra.fourdn.extra_files.
+        When:
+            stream_index_file is called.
+        Then:
+            It should raise an HTTPException with status 404 because the router
+            only reads the DCC-namespaced path.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [
+            _make_4dn_file_doc(
+                extra_fourdn_extras_present=False,
+                extra_top_level_extras=[
+                    {
+                        "href": "/should/not/be/used.px2",
+                        "file_size": 99,
+                        "file_format": "pairs_px2",
+                    }
+                ],
+            )
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range=None
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "No index file available for this file"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_with_range_header(self, mock_db, mocker):
+        """Test valid Range header produces a 206 response with Content-Range.
+
+        Given:
+            A 4DN file with a sidecar entry in extra.fourdn.extra_files.
+        When:
+            stream_index_file is called with a HEAD request and a valid Range header.
+        Then:
+            It should return a 206 response with a Content-Range header matching
+            the requested byte range.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [_make_4dn_file_doc()]
+
+        # Act
+        response = await stream_index_file(
+            "4dn", "4DNFI1234ABC", _make_request("HEAD"), range="bytes=0-99"
+        )
+
+        # Assert
+        assert response.status_code == 206
+        assert response.headers["Content-Range"] == "bytes 0-99/1024"
+        assert response.headers["Content-Length"] == "100"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_with_missing_file_document(
+        self, mock_db, mocker
+    ):
+        """Test missing file document raises 404.
+
+        Given:
+            No file document matching the requested 4DN local_id.
+        When:
+            stream_index_file is called.
+        Then:
+            It should raise an HTTPException with status 404 and detail
+            "File not found".
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = []
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range=None
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "File not found"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_with_unknown_dcc(self, mock_db, mocker):
+        """Test an unknown DCC name raises 400.
+
+        Given:
+            A request with an unknown DCC name.
+        When:
+            stream_index_file is called.
+        Then:
+            It should raise an HTTPException with status 400 and the DB is
+            not queried.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "not-a-dcc", "whatever", _make_request("HEAD"), range=None
+            )
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_entry_without_href(
+        self, mock_db, mocker
+    ):
+        """Test sidecar entry without an href raises 404.
+
+        Given:
+            A 4DN file whose extra.fourdn.extra_files entry has no href field.
+        When:
+            stream_index_file is called.
+        Then:
+            It should raise an HTTPException with status 404 and detail
+            "Index file has no download URL".
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [
+            _make_4dn_file_doc(extra_files=[{"file_size": 123}])
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range=None
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Index file has no download URL"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_with_mixed_case_dcc(self, mock_db, mocker):
+        """Test DCC dispatch is case-insensitive.
+
+        Given:
+            A 4DN file with a sidecar entry in extra.fourdn.extra_files.
+        When:
+            stream_index_file is called with DCC "4DN" (mixed case) via HEAD.
+        Then:
+            It should return a 200 response with the correct sidecar headers,
+            confirming case-insensitive DCC normalization.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [_make_4dn_file_doc()]
+
+        # Act
+        response = await stream_index_file(
+            "4DN", "4DNFI1234ABC", _make_request("HEAD"), range=None
+        )
+
+        # Assert
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Disposition"]
+            == 'attachment; filename="4DNFI1234ABC.mcool.px2"'
+        )
+        assert response.headers["Accept-Ranges"] == "bytes"
+        assert response.headers["Content-Length"] == "1024"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_with_get_method(self, mock_db, mocker):
+        """Test GET request returns a StreamingResponse with correct headers.
+
+        Given:
+            A 4DN file with a sidecar entry in extra.fourdn.extra_files.
+        When:
+            stream_index_file is called with a GET request (not HEAD).
+        Then:
+            It should return a StreamingResponse with status 200 and
+            the expected sidecar headers.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mocker.patch(
+            "cfdb.services.drs.stream_from_url", return_value=iter([b""])
+        )
+        mock_db.files.docs = [_make_4dn_file_doc()]
+
+        # Act
+        response = await stream_index_file(
+            "4dn", "4DNFI1234ABC", _make_request("GET"), range=None
+        )
+
+        # Assert
+        assert isinstance(response, StreamingResponse)
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Disposition"]
+            == 'attachment; filename="4DNFI1234ABC.mcool.px2"'
+        )
+        assert response.headers["Accept-Ranges"] == "bytes"
+        assert response.headers["Content-Length"] == "1024"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_range_when_entry_has_no_file_size(
+        self, mock_db, mocker
+    ):
+        """Test Range request on sidecar without file_size raises 500.
+
+        Given:
+            A 4DN sidecar entry that is missing the file_size field.
+        When:
+            stream_index_file is called with a HEAD request and a Range header.
+        Then:
+            It should raise an HTTPException with status 500 and detail
+            "Cannot process range request: index file size unavailable".
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [
+            _make_4dn_file_doc(
+                extra_files=[
+                    {
+                        "href": "/files-processed/4DNFI1234ABC/@@download/4DNFI1234ABC.mcool.px2",
+                        "file_format": "pairs_px2",
+                    }
+                ]
+            )
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range="bytes=0-99"
+            )
+        assert exc_info.value.status_code == 500
+        assert (
+            exc_info.value.detail
+            == "Cannot process range request: index file size unavailable"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_with_malformed_range_header(
+        self, mock_db, mocker
+    ):
+        """Test malformed Range header raises 400.
+
+        Given:
+            A 4DN file with a sidecar entry in extra.fourdn.extra_files.
+        When:
+            stream_index_file is called with a HEAD request and a malformed
+            Range header "bananas".
+        Then:
+            It should raise an HTTPException with status 400 and a detail
+            starting with "Invalid Range header".
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [_make_4dn_file_doc()]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range="bananas"
+            )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail.startswith("Invalid Range header")
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_with_unsatisfiable_range(
+        self, mock_db, mocker
+    ):
+        """Test unsatisfiable Range raises 416 with Content-Range header.
+
+        Given:
+            A 4DN sidecar entry with file_size=1024.
+        When:
+            stream_index_file is called with a HEAD request and Range
+            "bytes=2000-3000".
+        Then:
+            It should raise an HTTPException with status 416 and a
+            Content-Range header of "bytes */1024".
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [_make_4dn_file_doc()]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn",
+                "4DNFI1234ABC",
+                _make_request("HEAD"),
+                range="bytes=2000-3000",
+            )
+        assert exc_info.value.status_code == 416
+        assert exc_info.value.headers["Content-Range"] == "bytes */1024"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_for_non_4dn_dcc_returns_no_index(
+        self, mock_db, mocker
+    ):
+        """Test non-4DN DCCs always return no index (router only unpacks 4DN).
+
+        Given:
+            A hubmap file document in the DB (with any extra shape).
+        When:
+            stream_index_file is called for the hubmap DCC.
+        Then:
+            It should raise an HTTPException with status 404 and detail
+            "No index file available for this file", because the router's
+            dispatch only unpacks the 4DN-namespaced path.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [
+            {
+                "submission": "hubmap",
+                "local_id": "HBM123.ABCD.456",
+                "filename": "dataset.zip",
+                "extra": {
+                    "fourdn": {
+                        "extra_files": [
+                            {"href": "/x.px2", "file_size": 10}
+                        ]
+                    },
+                    "extra_files": [
+                        {"href": "/y.px2", "file_size": 20}
+                    ],
+                },
+            }
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "hubmap", "HBM123.ABCD.456", _make_request("HEAD"), range=None
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "No index file available for this file"
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_4dn_with_empty_fourdn_extras_list(
+        self, mock_db, mocker
+    ):
+        """Test empty fourdn extras list raises 404.
+
+        Given:
+            A 4DN file with extra.fourdn.extra_files set to an empty list.
+        When:
+            stream_index_file is called with a HEAD request.
+        Then:
+            It should raise an HTTPException with status 404 and detail
+            "No index file available for this file".
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+        mock_db.files.docs = [_make_4dn_file_doc(extra_files=[])]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file(
+                "4dn", "4DNFI1234ABC", _make_request("HEAD"), range=None
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "No index file available for this file"


### PR DESCRIPTION
## Summary

Fix the `HTTP 500` that `/index/{dcc}/{local_id}` raised for 4DN files carrying a sidecar index. The selection loop in `_try_serve_fourdn_sidecar` called `.lower()` on each sidecar entry's `file_format`, assuming it was a bare string. 4DN actually materializes `file_format` as a C2M2 controlled-vocabulary object — `{"display_title": "beddb"}` — so the attribute access raised `AttributeError`, which surfaced to the client as a 500 instead of a streamed index.

Normalize `file_format` from either shape (CV dict or bare string) before matching, harden the loop against non-string/None/odd types so a malformed entry is a clean non-match rather than a crash, and — while the selection contract is in view — extend `_SIDECAR_INDEX_FORMATS` to recognize 4DN's pairix index tokens (`pairs_px2`, `bg_px2`). A live-corpus check of 943 4DN sidecar files found 654 (69%) — every `pairs_px2`/`bg_px2` file — previously matched no allowlisted token and were served only by the first-entry fallback, which is correct today purely because the index happens to be listed first. Matching them by format makes that selection intentional rather than incidental. `bw` (bigWig) stays excluded — it is self-indexed data, not a sidecar index.

Closes #26

## Proposed changes

### Normalize `file_format` before matching (`src/cfdb/api/routers/index.py`)

In `_try_serve_fourdn_sidecar`, read the token from `raw_fmt["display_title"]` when `file_format` is a dict, and otherwise lower-case it only when it is a string. Any other value (a dict lacking `display_title`, `None`, an int, a list) normalizes to `""` — a guaranteed non-match that falls through to the first-entry fallback instead of raising. The docstring and inline comment now document that both the CV-dict and bare-string shapes are accepted.

### Recognize 4DN pairix index sidecars (`src/cfdb/api/routers/index.py`)

Extend `_SIDECAR_INDEX_FORMATS` from `("bai", "tbi", "beddb", "csi")` to also include `pairs_px2` (`.pairs` pairix index) and `bg_px2` (bedGraph pairix index). The module-level comment explains each token and why `bw` is deliberately left out.

### Strengthen sidecar normalization coverage (`tests/test_index.py`)

Add seven public-API tests under `TestStreamIndexFileFourdnSidecar` exercising the normalization branches and the extended allowlist, and order them after the foundational sidecar tests so the file reads foundational → derived.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestStreamIndexFileFourdnSidecar` | A sidecar whose `file_format` is a `{"display_title": ...}` CV dict | `/index` is requested | The dict-shaped index entry is selected and streamed | Dict `file_format` normalization |
| 2 | `TestStreamIndexFileFourdnSidecar` | A dict `file_format` lacking `display_title` as the first entry | `/index` is requested | Selection falls back to the first sidecar entry without raising | Missing-`display_title` fallback |
| 3 | `TestStreamIndexFileFourdnSidecar` | A dict token that is not an index format (`bw`) ahead of a real index | `/index` is requested | The non-index dict entry is skipped and the index entry served | Non-index dict rejection |
| 4 | `TestStreamIndexFileFourdnSidecar` | A bare-string `tbi` index alongside a dict-shaped entry | `/index` is requested | The bare-string index entry is matched | Bare-string branch normalization |
| 5 | `TestStreamIndexFileFourdnSidecar` | A dict token differing only in case | `/index` is requested | The token matches case-insensitively | Case-insensitive matching |
| 6 | `TestStreamIndexFileFourdnSidecar` | A non-string `file_format` (`None`, `123`, `["tbi"]`) | `/index` is requested | The entry is a clean non-match rather than an `AttributeError` | Non-string hardening |
| 7 | `TestStreamIndexFileFourdnSidecar` | A `pairs_px2`/`bg_px2` index after a non-index `bw` entry | `/index` is requested | The pairix index wins over array order | Pairix allowlist extension |