### PR TITLE
Expand distinctValues allowlist to cover EDAM/OBI subdocument sub-paths — Closes #28

### DIFF
--- a/src/cfdb/api/gql/schema.py
+++ b/src/cfdb/api/gql/schema.py
@@ -20,11 +20,15 @@ from cfdb.services import locks
 
 ALLOWED_DISTINCT_FIELDS: frozenset[str] = frozenset(
     {
+        "dcc.id",
         "dcc.dcc_name",
         "dcc.dcc_abbreviation",
-        "data_type",
-        "assay_type",
-        "file_format",
+        "data_type.id",
+        "data_type.name",
+        "assay_type.id",
+        "assay_type.name",
+        "file_format.id",
+        "file_format.name",
         "compression_format",
         "mime_type",
         "analysis_type",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -359,3 +359,82 @@ class TestDistinctValuesQuery:
         # Assert
         assert result.errors is not None
         assert "secret_field" in result.errors[0].message
+
+    @pytest.mark.asyncio
+    async def test_distinct_values_returns_unique_subdoc_names(
+        self, mock_db, mocker
+    ):
+        """Test distinct values for an EDAM subdocument sub-path.
+
+        Given:
+            Three files whose file_format subdocuments carry two distinct names
+        When:
+            The distinctValues query is executed with fields: ["file_format.name"]
+        Then:
+            It should return one entry containing the two distinct format names
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+
+        def doc_with_format(local_id: str, fmt_id: str, fmt_name: str) -> dict:
+            doc = _make_distinct_doc(local_id, "ENCODE", "encode")
+            doc["file_format"] = {"id": fmt_id, "name": fmt_name}
+            return doc
+
+        mock_db.files.docs = [
+            doc_with_format("f1", "format:3003", "BED"),
+            doc_with_format("f2", "format:3003", "BED"),
+            doc_with_format("f3", "format:3004", "bigBed"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                distinctValues(fields: ["file_format.name"]) {
+                    field
+                    values
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        entry = result.data["distinctValues"][0]
+        assert entry["field"] == "file_format.name"
+        assert sorted(entry["values"]) == ["BED", "bigBed"]
+
+    @pytest.mark.asyncio
+    async def test_distinct_values_rejects_bare_subdocument_field(
+        self, mock_db, mocker
+    ):
+        """Test that the bare top-level subdocument name is no longer allowlisted.
+
+        Given:
+            The bare ``file_format`` field returned subdocuments rather than scalar
+            values, so it has been removed from ALLOWED_DISTINCT_FIELDS in favor of
+            the indexed ``file_format.id`` and ``file_format.name`` sub-paths.
+        When:
+            The distinctValues query is executed with fields: ["file_format"]
+        Then:
+            It should return an error naming the disallowed field.
+        """
+        # Arrange
+        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                distinctValues(fields: ["file_format"]) {
+                    field
+                    values
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is not None
+        assert "file_format" in result.errors[0].message

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from cfdb.api.gql.schema import schema
+from cfdb.services import locks
 
 
 def _make_file_doc(local_id: str, submission: str = "hubmap") -> dict:
@@ -44,21 +45,30 @@ def _make_distinct_doc(local_id: str, dcc_name: str, submission: str = "hubmap")
 
 
 class TestFilesQuery:
-    @pytest.mark.asyncio
-    async def test_returns_files_via_simple_pagination(self, mock_db, mocker):
-        """
-        GIVEN 3 files in the database
-        WHEN the GraphQL files query is executed with page=0, page_size=2
-        THEN exactly 2 files are returned (no access-level over-fetch logic)
-        """
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+    @pytest.fixture(autouse=True)
+    def _patch_cutover(self, mocker):
+        """No-op ``locks.wait_for_cutover`` for every test in this class."""
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
 
+    @pytest.mark.asyncio
+    async def test_returns_files_via_simple_pagination(self, mock_db):
+        """Test pagination cap is applied to the files query.
+
+        Given:
+            Three files in the database
+        When:
+            The GraphQL files query is executed with page=0, page_size=2
+        Then:
+            Exactly 2 files are returned (no access-level over-fetch logic)
+        """
+        # Arrange
         mock_db.files.docs = [
             _make_file_doc("f1"),
             _make_file_doc("f2"),
             _make_file_doc("f3"),
         ]
 
+        # Act
         result = await schema.execute(
             """
             query {
@@ -69,24 +79,29 @@ class TestFilesQuery:
             """
         )
 
+        # Assert
         assert result.errors is None
         assert len(result.data["files"]) == 2
 
     @pytest.mark.asyncio
-    async def test_returns_all_submissions_without_filtering(self, mock_db, mocker):
-        """
-        GIVEN files from multiple DCCs including HuBMAP
-        WHEN the GraphQL files query is executed with no input filter
-        THEN files from all DCCs are returned without access-level filtering
-        """
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
+    async def test_returns_all_submissions_without_filtering(self, mock_db):
+        """Test the files query returns all DCCs when no filter is supplied.
 
+        Given:
+            Files from multiple DCCs including HuBMAP
+        When:
+            The GraphQL files query is executed with no input filter
+        Then:
+            Files from all DCCs are returned without access-level filtering
+        """
+        # Arrange
         mock_db.files.docs = [
             _make_file_doc("h1", "hubmap"),
             _make_file_doc("f1", "4dn"),
             _make_file_doc("e1", "encode"),
         ]
 
+        # Act
         result = await schema.execute(
             """
             query {
@@ -97,14 +112,20 @@ class TestFilesQuery:
             """
         )
 
+        # Assert
         assert result.errors is None
         assert len(result.data["files"]) == 3
 
 
 class TestDistinctValuesQuery:
+    @pytest.fixture(autouse=True)
+    def _patch_cutover(self, mocker):
+        """No-op ``locks.wait_for_cutover`` for every test in this class."""
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
     @pytest.mark.asyncio
     async def test_distinct_values_returns_all_unique_values_for_single_field(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test distinct values for a single nested field without filtering.
 
@@ -116,7 +137,6 @@ class TestDistinctValuesQuery:
             It should return one entry containing all three distinct DCC names
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_distinct_doc("f1", "HuBMAP", "hubmap"),
             _make_distinct_doc("f2", "4DN", "4dn"),
@@ -144,7 +164,7 @@ class TestDistinctValuesQuery:
 
     @pytest.mark.asyncio
     async def test_distinct_values_returns_entries_for_multiple_fields(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test distinct values for multiple fields in one call.
 
@@ -156,7 +176,6 @@ class TestDistinctValuesQuery:
             It should return two entries, each with the correct distinct values
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_distinct_doc("f1", "HuBMAP", "hubmap"),
             _make_distinct_doc("f2", "HuBMAP", "hubmap"),
@@ -184,7 +203,7 @@ class TestDistinctValuesQuery:
         assert sorted(by_field["dcc.dcc_abbreviation"]) == ["4dn", "hubmap"]
 
     @pytest.mark.asyncio
-    async def test_distinct_values_applies_input_filter(self, mock_db, mocker):
+    async def test_distinct_values_applies_input_filter(self, mock_db):
         """Test distinct values with a DCC filter applied.
 
         Given:
@@ -195,7 +214,6 @@ class TestDistinctValuesQuery:
             It should return only the abbreviations from HuBMAP files
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_distinct_doc("h1", "HuBMAP", "hubmap"),
             _make_distinct_doc("h2", "HuBMAP", "hubmap"),
@@ -224,7 +242,7 @@ class TestDistinctValuesQuery:
 
     @pytest.mark.asyncio
     async def test_distinct_values_returns_empty_list_for_missing_field(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test distinct values for a field absent from all documents.
 
@@ -236,7 +254,6 @@ class TestDistinctValuesQuery:
             It should return one entry with an empty values list
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_distinct_doc("f1", "HuBMAP"),
             _make_distinct_doc("f2", "4DN"),
@@ -262,7 +279,7 @@ class TestDistinctValuesQuery:
 
     @pytest.mark.asyncio
     async def test_distinct_values_returns_empty_list_for_empty_database(
-        self, mock_db, mocker
+        self, mock_db
     ):
         """Test distinct values against an empty collection.
 
@@ -274,7 +291,6 @@ class TestDistinctValuesQuery:
             It should return one entry with an empty values list
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = []
 
         # Act
@@ -295,7 +311,7 @@ class TestDistinctValuesQuery:
         assert entry["values"] == []
 
     @pytest.mark.asyncio
-    async def test_distinct_values_deduplicates_values(self, mock_db, mocker):
+    async def test_distinct_values_deduplicates_values(self, mock_db):
         """Test that duplicate values are collapsed to unique entries.
 
         Given:
@@ -306,7 +322,6 @@ class TestDistinctValuesQuery:
             It should return only the deduplicated values
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
         mock_db.files.docs = [
             _make_distinct_doc("f1", "HuBMAP", "hubmap"),
             _make_distinct_doc("f2", "HuBMAP", "hubmap"),
@@ -331,7 +346,7 @@ class TestDistinctValuesQuery:
         assert sorted(entry["values"]) == ["4DN", "HuBMAP"]
 
     @pytest.mark.asyncio
-    async def test_distinct_values_rejects_disallowed_field(self, mock_db, mocker):
+    async def test_distinct_values_rejects_disallowed_field(self, mock_db):
         """Test that fields outside the allowlist are rejected.
 
         Given:
@@ -341,9 +356,6 @@ class TestDistinctValuesQuery:
         Then:
             It should return an error naming the disallowed field
         """
-        # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
-
         # Act
         result = await schema.execute(
             """
@@ -361,9 +373,7 @@ class TestDistinctValuesQuery:
         assert "secret_field" in result.errors[0].message
 
     @pytest.mark.asyncio
-    async def test_distinct_values_returns_unique_subdoc_names(
-        self, mock_db, mocker
-    ):
+    async def test_distinct_values_returns_unique_subdoc_names(self, mock_db):
         """Test distinct values for an EDAM subdocument sub-path.
 
         Given:
@@ -374,8 +384,6 @@ class TestDistinctValuesQuery:
             It should return one entry containing the two distinct format names
         """
         # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
-
         def doc_with_format(local_id: str, fmt_id: str, fmt_name: str) -> dict:
             doc = _make_distinct_doc(local_id, "ENCODE", "encode")
             doc["file_format"] = {"id": fmt_id, "name": fmt_name}
@@ -406,9 +414,7 @@ class TestDistinctValuesQuery:
         assert sorted(entry["values"]) == ["BED", "bigBed"]
 
     @pytest.mark.asyncio
-    async def test_distinct_values_rejects_bare_subdocument_field(
-        self, mock_db, mocker
-    ):
+    async def test_distinct_values_rejects_bare_subdocument_field(self, mock_db):
         """Test that the bare top-level subdocument name is no longer allowlisted.
 
         Given:
@@ -418,11 +424,8 @@ class TestDistinctValuesQuery:
         When:
             The distinctValues query is executed with fields: ["file_format"]
         Then:
-            It should return an error naming the disallowed field.
+            It should return an error naming the disallowed field
         """
-        # Arrange
-        mocker.patch("cfdb.services.locks.wait_for_cutover", return_value=None)
-
         # Act
         result = await schema.execute(
             """


### PR DESCRIPTION
## Summary

Replace the bare top-level `data_type`, `assay_type`, and `file_format` entries in `ALLOWED_DISTINCT_FIELDS` with their indexed `.id` and `.name` sub-paths, and add `dcc.id` alongside the existing `dcc.dcc_name` and `dcc.dcc_abbreviation`. The bare names returned full subdocument dicts and were not indexed in the materialized `files` collection, so they were not useful for the `distinctValues` endpoint anyway; the sub-path forms are what UI clients need to populate filter dropdowns over format/assay/data-type names. The `analysis_type` field is a plain string in the schema and stays as the bare name. Closes #28.

This is a contract change for any client that was calling `distinctValues` over the bare top-level subdocument fields — those calls will now return the standard `Field(s) not queryable: <field>` error and must switch to the `.id` or `.name` form.

## Proposed changes

### `src/cfdb/api/gql/schema.py`

Adjust the `ALLOWED_DISTINCT_FIELDS` frozenset:

- Add `dcc.id`, `data_type.id`, `data_type.name`, `assay_type.id`, `assay_type.name`, `file_format.id`, `file_format.name`
- Remove the bare `data_type`, `assay_type`, `file_format` entries (no underlying index, returned dicts)
- Leave `analysis_type` (string field), `compression_format`, `mime_type`, `genome_assembly`, `genome_annotation`, `output_type`, `status`, `data_access_level`, `dcc.dcc_name`, and `dcc.dcc_abbreviation` unchanged

### `tests/test_schema.py`

Add two tests under `TestDistinctValuesQuery`:

- A positive case for `file_format.name` returning the distinct format names
- A regression guard that the now-removed bare `file_format` field is rejected with a `Field(s) not queryable` error

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestDistinctValuesQuery` | Three files whose `file_format` subdocuments carry two distinct names | The distinctValues query is executed with fields `["file_format.name"]` | One entry is returned containing the two distinct format names | New sub-path positive case |
| 2 | `TestDistinctValuesQuery` | The bare `file_format` field has been removed from the allowlist | The distinctValues query is executed with fields `["file_format"]` | An error is returned naming the disallowed field | Regression guard for removed bare-name entry |