### PR TITLE
Deploy workflow workers as an ephemeral ECS Fargate fleet — Closes #33

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -10,6 +10,21 @@ ARG PYTHON_BASE_DIGEST=sha256:d193c6f51a7dbd10395d6328de3a7edb0516fb0608ca138036
 
 # Build stage for the Rust materializer
 FROM rust:1.88-slim-bookworm@${RUST_BASE_DIGEST} AS builder
+# The materializer's mongodb crate uses openssl-tls, so openssl-sys must
+# be able to link against system OpenSSL. The slim image ships only the
+# Rust toolchain; install pkg-config and libssl-dev so the build can
+# locate the headers and library.
+#
+# Fetch over HTTPS rather than the image default of plain HTTP: HTTP
+# (port 80) egress to the Debian mirrors is blocked in some build
+# environments (corporate firewalls, restricted CI) where HTTPS (443) is
+# allowed. The rewrite covers both deb822 (*.sources) and classic
+# (sources.list) layouts so it survives a base-image bump.
+RUN find /etc/apt -type f \( -name '*.sources' -o -name 'sources.list' \) \
+        -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
 COPY materialize/ .
 RUN cargo build --release
@@ -42,7 +57,9 @@ ARG RDS_BUNDLE_SHA256=e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9d
 # against the hash pinned in the ARG above so a MITM or silent tip
 # change cannot substitute an unexpected binary that then executes on
 # attacker-supplied bigBed bytes via the workflow shell pipelines.
-RUN apt-get update \
+RUN find /etc/apt -type f \( -name '*.sources' -o -name 'sources.list' \) \
+        -exec sed -i 's|http://deb.debian.org|https://deb.debian.org|g' {} + \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
         samtools \
@@ -65,6 +82,12 @@ COPY --from=builder /build/target/release/materialize /usr/local/bin/materialize
 # Install Python dependencies — non-editable, production extras only.
 # Dev dependencies (test frameworks, linters) are NOT shipped to the
 # runtime image; install them in CI via ``pip install '.[dev]'``.
+# setuptools_scm derives the version from git, which the slim runtime
+# doesn't carry. Pretend a version so the wheel builds without git or the
+# .git tree; CI can inject the real tag via
+# ``--build-arg SETUPTOOLS_SCM_PRETEND_VERSION=…``.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+docker
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 COPY . /app
 RUN pip install --no-cache-dir . uvicorn
 

--- a/Dockerfile.wool
+++ b/Dockerfile.wool
@@ -1,0 +1,113 @@
+# check=skip=FromPlatformFlagConstDisallowed
+# The constant ``FROM --platform=linux/amd64`` below is intentional, not an
+# oversight — UCSC ships ``bigBedToBed`` only as a linux.x86_64 binary, so the
+# worker image is deliberately amd64 on every build host. See the FROM comment.
+
+# Worker image for the cfdb preprocessing/indexing pool.
+#
+# This is the image ECS Fargate runs as the worker task (CMD
+# ``python -m cfdb.workflows.worker_main``). Workers boot a wool gRPC
+# server, expose a tiny HTTP ``/health`` endpoint, and shell out to the
+# bioinformatics tools the workflow processors drive (samtools sort/index,
+# bgzip+tabix, gffread, bigBedToBed). ``EcsDiscovery`` on the API side
+# surfaces running tasks by ListTasks/DescribeTasks, so the worker itself
+# registers nothing — it only needs to bind its gRPC port and answer the
+# health probe.
+#
+# Deliberately leaner than Dockerfile.api: no Rust materializer stage (the
+# materializer runs API/sync-side, never on a worker), no uvicorn (the
+# worker serves gRPC + an aiohttp health endpoint, not the HTTP API), and
+# no RDS CA bundle (the routine streams events back to the API process and
+# never opens a Mongo connection itself).
+
+# Base image pin. Uses a sha256 digest so a tip retag at Docker Hub cannot
+# silently swap the build base. Kept in lockstep with Dockerfile.api's
+# runtime stage; update both together during a maintenance window:
+#   docker pull python:3.12-slim-bookworm
+#   docker inspect --format='{{index .RepoDigests 0}}' python:3.12-slim-bookworm
+ARG PYTHON_BASE_DIGEST=sha256:d193c6f51a7dbd10395d6328de3a7edb0516fb0608ca138036576f574c3e07d2
+
+# Pin the image to linux/amd64. The bigBed workflow shells out to UCSC's
+# ``bigBedToBed``, which UCSC publishes only as a linux.x86_64 binary (no
+# arm64 build exists). Without this pin the image inherits the build
+# host's arch, and on arm64 (Apple Silicon dev, Graviton) that x86_64
+# binary fails at exec with ``rosetta error: failed to open elf
+# /lib64/ld-linux-x86-64.so.2``, breaking bigBed preprocessing. Pinning
+# amd64 makes the worker run native on x86_64 Fargate and emulated (but
+# correct) on arm64 hosts. The digest above is a multi-arch index, so
+# ``--platform`` selects its amd64 variant.
+FROM --platform=linux/amd64 python:3.12-slim-bookworm@${PYTHON_BASE_DIGEST}
+
+# gRPC worker port (CFDB_WORKER_GRPC_PORT) and HTTP health port
+# (CFDB_WORKER_HEALTH_PORT). Documented for operators; the actual values
+# come from worker_main's CLI/env defaults at runtime.
+EXPOSE 50051
+EXPOSE 8080
+
+WORKDIR /app
+
+# sha256 of the linux.x86_64 ``bigBedToBed`` binary UCSC currently
+# publishes. UCSC does not expose pre-built versioned binaries (only
+# source tarballs), so the rolling URL is bound by content hash. Kept in
+# lockstep with Dockerfile.api. When UCSC ships a new build the layer
+# rebuilds with the new hash after maintainers re-verify out-of-band.
+# Updating: download the binary, run ``sha256sum``, paste here.
+ARG UCSC_BIGBEDTOBED_SHA256=9d1ea2158f5aa958fd8820fb7a2e5fb0947a9da7b183b8f9237429b8fbacd386
+
+# Install curl (for the container/ECS health check) and the bioinformatics
+# tools the workflow subsystem shells out to. samtools/tabix/bcftools/
+# gffread ship in Debian main; the ``tabix`` package also provides
+# ``bgzip``. UCSC kent tools come from the upstream release URL over HTTPS
+# with sha256 verification against the hash pinned above so a MITM or
+# silent tip change cannot substitute an unexpected binary that then
+# executes on attacker-supplied bigBed bytes via the workflow shell
+# pipelines.
+# Fetch the Debian package index and tools over HTTPS rather than the
+# image default of plain HTTP. apt verifies package signatures with GPG
+# regardless, but HTTP (port 80) egress to the mirrors is blocked in some
+# build environments (corporate firewalls, restricted CI) where HTTPS
+# (443) is allowed; the rewrite makes the build portable. The base image
+# pins the deb822-format sources at debian.sources; ca-certificates ship
+# in the base, and bookworm's apt speaks HTTPS natively.
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' \
+        /etc/apt/sources.list.d/debian.sources \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        samtools \
+        tabix \
+        bcftools \
+        gffread \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --fail -sSL -o /usr/local/bin/bigBedToBed \
+        https://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bigBedToBed \
+    && echo "${UCSC_BIGBEDTOBED_SHA256}  /usr/local/bin/bigBedToBed" | sha256sum -c - \
+    && chmod +x /usr/local/bin/bigBedToBed
+
+# Install the cfdb package — non-editable, production deps only (wool,
+# aiohttp, boto3, click, motor, pymongo). uvicorn is intentionally omitted;
+# the worker does not serve the HTTP API. Dev extras (test frameworks,
+# linters) are not shipped to the runtime image.
+#
+# The project derives its version from git via setuptools_scm, but the
+# slim runtime carries no ``git`` binary (and we don't want the .git tree
+# in the image). Pretend a version so the wheel builds hermetically; CI
+# can inject the real tag with ``--build-arg SETUPTOOLS_SCM_PRETEND_VERSION=…``.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+docker
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
+COPY . /app
+RUN pip install --no-cache-dir .
+
+# Create non-root user. /tmp remains writable for per-job scratch workdirs
+# the executor hands the routine.
+RUN useradd app
+USER app
+
+# Surface worker liveness to ``docker ps`` and any orchestrator that reads
+# the image HEALTHCHECK. ECS task definitions typically declare their own
+# healthCheck, but mirroring it here keeps local runs observable. Probes
+# the aiohttp ``/health`` endpoint worker_main serves on the health port.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl --fail http://localhost:8080/health || exit 1
+
+CMD ["python", "-m", "cfdb.workflows.worker_main"]

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,12 @@ api:
 	@echo "Starting the API container in DEVELOPMENT mode (no TLS)..."
 	docker run -d --name api --network cvh-backend-network --network-alias cvh-backend -p 8000:8000 -e SYNC_DATA_DIR=/tmp/sync-data api
 	@echo "API container is up and running on port 8000 (http://0.0.0.0:8000/metadata)."
+
+wool:
+	@echo "Building the wool worker Docker image (cfdb-wool, linux/amd64)..."
+	docker build --platform linux/amd64 -t cfdb-wool -f Dockerfile.wool .
+	@echo "Worker image built. CMD is 'python -m cfdb.workflows.worker_main' (ECS entrypoint)."
+
+worker-local:
+	@echo "Starting a local LAN worker pool (namespace=$${WORKFLOW_POOL_NAMESPACE:-cfdb-workers}, workers=$${WORKFLOW_WORKER_COUNT:-2})..."
+	uv run python -m cfdb.workflows.worker_lan

--- a/README.md
+++ b/README.md
@@ -569,18 +569,44 @@ Required environment variables:
 
 Optional tunables (with defaults):
 
-- `CFDB_WORKFLOW_DURATION_CAP_S` — per-workflow wall-clock cap (default `1200`).
+- `CFDB_WORKFLOW_DURATION_CAP_S` — per-workflow wall-clock cap (default `14400`, i.e. 4 h — sized for multi-hour preprocessing runs; lower it for fixture-bound dev).
 - `CFDB_WORKFLOW_DISPATCH_WAIT_S` — how long `ensure_workflow` waits for a free worker before giving up (default `60`).
 - `CFDB_WORKFLOW_HEARTBEAT_INTERVAL_S` — cadence at which the wool routine emits heartbeat events during quiet stages so the API can refresh `JobRecord.updated_at` (default `300`). The stale-reclaim threshold below is sized as `2 × heartbeat + safety_margin`; lowering this knob without also lowering the threshold widens the false-reclaim window.
 - `CFDB_WORKFLOW_STALE_THRESHOLD_S` — `updated_at` age beyond which an active row is reclaimable (default `900`; sized as `2 × heartbeat_interval + safety_margin` so a single missed heartbeat does not falsely reclaim a healthy worker).
 - `CFDB_SAMTOOLS_THREADS` (default `1`), `CFDB_SORT_PARALLEL` (default `2`) — CPU/thread caps for `samtools sort/index` and GNU `sort` respectively.
 - `CFDB_SAMTOOLS_MEMORY_CAP_PER_THREAD` (default `256M`), `CFDB_SORT_MEMORY_CAP` (default `256M`) — memory caps passed to the same tools. **`CFDB_SAMTOOLS_MEMORY_CAP_PER_THREAD` is per-thread**: total samtools RSS is bounded by `CFDB_SAMTOOLS_THREADS × CFDB_SAMTOOLS_MEMORY_CAP_PER_THREAD`. (The previous name `CFDB_SAMTOOLS_MEMORY_CAP` is rejected at import to surface deployments that haven't migrated; rename the env var.)
 
-Required tools on `PATH` for the **worker pool** (not the API): `samtools`, `bgzip`, `tabix`, `bcftools`, `gffread`, `bigBedToBed`. The `api` Docker image already installs all of these — the simplest local-dev / single-host deployment is to reuse `Dockerfile.api` as the worker image and override the `CMD` (or run the wool worker entrypoint via `python -m wool`). On the worker host, set `WORKFLOW_POOL_NAMESPACE` to match the API's value.
+Required tools on `PATH` for the **worker pool** (not the API): `samtools`, `bgzip`, `tabix`, `bcftools`, `gffread`, `bigBedToBed`. The dedicated worker image `Dockerfile.wool` installs all of these and is the image ECS runs (build it with `make wool`, tagged `cfdb-wool`; its `CMD` is the ECS entrypoint `python -m cfdb.workflows.worker_main`). For single-host local dev where the toolchain is already on your `PATH`, skip the image entirely and run the LAN worker pool directly — see "Running a local worker pool" below.
+
+#### ECS Fargate profile
+
+When the API runs on ECS Fargate (or LocalStack-backed dev that mirrors prod end-to-end), the lifespan switches from `LocalFsCache` + `LanDiscovery` to `S3Cache` + `EcsDiscovery` + `EcsProvisioner`. The selection is env-driven; with none of the variables below set the API runs the local PoC profile unchanged.
+
+- `AWS_ENDPOINT_URL` — boto3 endpoint override. Unset in production (boto3 hits real AWS); set to `http://localstack:4566` (or similar) for LocalStack-backed dev. The same application code runs in both environments — only this variable differs.
+- `AWS_REGION` — AWS region for the boto3 client (default `us-east-1`).
+- `WORKFLOW_S3_BUCKET` — when set, the lifespan instantiates `S3Cache` instead of `LocalFsCache`. The bucket must already exist (creation is out of band). When unset, the API stays on the local filesystem cache.
+- `WORKFLOW_S3_PREFIX` — optional key prefix the S3 backend prepends to every cache key (default empty). Lets a single bucket host multiple environments (`dev/`, `staging/`, `prod/`) without collisions.
+- `ECS_CLUSTER` — ECS cluster name or ARN. Gates the ECS-backed provisioner and discovery profile; unset means the PoC profile stays on `LanDiscovery` with no provisioner.
+- `ECS_WORKER_TASK_DEFINITION` — task definition for the worker container, as a family name (`cfdb-worker`) or `family:revision`. The provisioner passes it through to `RunTask` verbatim.
+- `ECS_WORKER_TASK_FAMILY` — family used by `EcsDiscovery` to filter `ListTasks`. Defaults to `ECS_WORKER_TASK_DEFINITION` with any `:revision` suffix stripped; set explicitly only when the discovery family differs from the provisioner task-def family (rare).
+- `ECS_WORKER_SUBNETS` — comma-separated awsvpc subnet IDs the worker ENIs land in. Required for the ECS profile; an empty list with `ECS_CLUSTER` set is a misconfiguration.
+- `ECS_WORKER_SECURITY_GROUPS` — comma-separated awsvpc security group IDs. Optional — when empty, ECS applies the VPC default SG.
+- `ECS_WORKER_ASSIGN_PUBLIC_IP` — `ENABLED` or `DISABLED` (default `DISABLED`). Production should leave this disabled and reach AWS via VPC endpoints; LocalStack accepts either value.
+
+The worker container's `CMD` is `python -m cfdb.workflows.worker_main`. Worker-side knobs (gRPC port, health port, max lifetime, drain grace) are documented under `--help` on that command; their env vars are `CFDB_WORKER_GRPC_PORT`, `CFDB_WORKER_HEALTH_PORT`, `CFDB_WORKER_MAX_LIFETIME_SECONDS`, and `CFDB_WORKER_DRAIN_GRACE_SECONDS`. The worker task definition MUST declare a `healthCheck` against the gRPC port; without one ECS reports `healthStatus: UNKNOWN` indefinitely and the worker is never advertised to discovery.
 
 #### Running a local worker pool
 
-For single-host development, start a wool worker pool in a separate process before launching the API, with `WORKFLOW_POOL_NAMESPACE` matching what the API uses. The API connects via LAN discovery (zeroconf/mDNS) and dispatches workflows to whatever workers are publishing under that namespace. With no worker pool running, `/data` and `/index` requests for processable formats will hang on the dispatch retry budget (60s by default) before failing with `NoWorkersAvailable`.
+For single-host development, start a wool worker pool in a separate process *before* launching the API, with `WORKFLOW_POOL_NAMESPACE` matching what the API uses:
+
+```bash
+# Publishes WORKFLOW_WORKER_COUNT workers (default 2) under
+# WORKFLOW_POOL_NAMESPACE (default cfdb-workers) over LAN discovery.
+python -m cfdb.workflows.worker_lan --namespace cfdb-workers --workers 2
+# or, with defaults: make worker-local
+```
+
+This is the local-dev counterpart to the ECS entrypoint (`python -m cfdb.workflows.worker_main`): `worker_lan` spawns a `wool.WorkerPool` wired to `LanDiscovery` so the pool advertises its workers over zeroconf/mDNS, whereas `worker_main` boots a bare worker that `EcsDiscovery` finds by polling the ECS control plane. The API connects via LAN discovery and dispatches workflows to whatever workers are publishing under that namespace. With no worker pool running, `/data` and `/index` requests for processable formats will hang on the dispatch retry budget (60s by default) before failing with `NoWorkersAvailable`.
 
 **URL:** `GET /jobs/{job_id}`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,18 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp",
+    "boto3",
     "click",
     "debugpy",
     "fastapi",
+    "grpcio>=1.81.1",
     "motor",
     "pydantic>=2,<3",
     "pymongo",
     "requests",
     "strawberry-graphql",
     "uvicorn",
-    "wool>=0.9.0rc1,<0.10",
+    "wool==0.9.3",
 ]
 description = "A Python utility for parsing and normalizing various DCC datapackages."
 dynamic = ["version"]
@@ -30,7 +32,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-dev = ["allpairspy", "debugpy", "httpx", "hypothesis", "mongomock-motor", "pytest-asyncio", "pytest-mock", "ruff"]
+dev = ["allpairspy", "debugpy", "httpx", "hypothesis", "mongomock-motor", "moto[ecs,s3]", "pytest-asyncio", "pytest-mock", "ruff"]
 
 [project.scripts]
 cfdb = "cfdb.cli:cli"

--- a/src/cfdb/api/__init__.py
+++ b/src/cfdb/api/__init__.py
@@ -79,9 +79,136 @@ WORKFLOW_WORKER_COUNT: Final = _parse_int_env(
 #: same string; otherwise the API's discovery service won't see the
 #: worker registrations and the pool will start with zero leasable
 #: workers. The default ``"cfdb-workers"`` matches what the worker pool
-#: needs to publish under; an ECS-aware variant may supplant LAN
-#: discovery in a future PR.
+#: needs to publish under. Ignored when the ECS-discovery profile is
+#: active (see ``ECS_CLUSTER`` / ``ECS_WORKER_TASK_DEFINITION``); the
+#: ECS path discovers workers by polling the ECS control plane directly
+#: and does not need a shared zeroconf namespace.
 WORKFLOW_POOL_NAMESPACE: Final = os.getenv("WORKFLOW_POOL_NAMESPACE", "cfdb-workers")
+
+# AWS / ECS profile. These knobs are optional — when none of them are
+# set the API runs the PoC profile (``LocalFsCache`` + ``LanDiscovery``
+# + no worker provisioner) and behaves exactly as it did before the
+# Fargate work landed. Production / LocalStack-backed dev sets the
+# bucket + cluster + task-def + subnets to activate the ECS-backed
+# profile; the same code path serves both because boto3 honors
+# ``AWS_ENDPOINT_URL`` to redirect at LocalStack.
+
+#: boto3 endpoint override. In production this is unset and boto3
+#: targets real AWS endpoints; LocalStack-backed dev sets it to
+#: ``http://localstack:4566`` so the same code talks to the local
+#: container. Threaded through to ``_build_s3_client`` /
+#: ``build_ecs_client`` (in ``cfdb.workflows.cache`` /
+#: ``cfdb.workflows.provisioner``) via the boto3 ``Session`` default
+#: chain, so no per-client wiring is needed here.
+AWS_ENDPOINT_URL: Final = os.getenv("AWS_ENDPOINT_URL")
+
+#: AWS region. Defaults to ``us-east-1`` so a missing ``AWS_REGION`` in
+#: dev doesn't surface as an opaque boto3 ``NoRegionError`` at first
+#: request — operators get a working default and override it in
+#: production deployments.
+AWS_REGION: Final = os.getenv("AWS_REGION", "us-east-1")
+
+#: When set, the lifespan instantiates ``S3Cache`` instead of
+#: ``LocalFsCache``. Unset means the API stays on the local
+#: filesystem cache.
+WORKFLOW_S3_BUCKET: Final = os.getenv("WORKFLOW_S3_BUCKET")
+
+#: Optional key prefix the S3 backend prepends to every cache key.
+#: Lets a single bucket host multiple environments (``dev/``,
+#: ``staging/``, ``prod/``) without collisions.
+WORKFLOW_S3_PREFIX: Final = os.getenv("WORKFLOW_S3_PREFIX", "")
+
+#: ECS cluster name or ARN. Gates the ECS-backed provisioner and
+#: discovery profile; unset means the PoC profile stays on
+#: ``LanDiscovery`` with no provisioner.
+ECS_CLUSTER: Final = os.getenv("ECS_CLUSTER")
+
+#: ECS worker task definition. Accepts either a family name
+#: (``cfdb-worker``) or a ``family:revision`` string. The provisioner
+#: passes it through to ``RunTask`` verbatim; the discovery loop
+#: strips any ``:revision`` suffix to derive its
+#: ``family`` filter (see ``ECS_WORKER_TASK_FAMILY`` override below).
+ECS_WORKER_TASK_DEFINITION: Final = os.getenv("ECS_WORKER_TASK_DEFINITION")
+
+
+def _ecs_default_task_family() -> str | None:
+    """Derive the discovery ``family`` filter from the task definition.
+
+    ``RunTask`` accepts ``family[:revision]``; ``ListTasks`` accepts
+    only the family (no revision). The default split strips the
+    revision when present, with ``ECS_WORKER_TASK_FAMILY`` available as
+    an explicit override for environments that pin a non-default
+    family name.
+    """
+    explicit = os.getenv("ECS_WORKER_TASK_FAMILY")
+    if explicit:
+        return explicit
+    if ECS_WORKER_TASK_DEFINITION:
+        return ECS_WORKER_TASK_DEFINITION.split(":", 1)[0]
+    return None
+
+
+#: Family used by ``EcsDiscovery`` to filter ``ListTasks``. Derived
+#: from ``ECS_WORKER_TASK_DEFINITION`` by default; set explicitly via
+#: ``ECS_WORKER_TASK_FAMILY`` only when the discovery family differs
+#: from the provisioner task-def family (rare).
+ECS_WORKER_TASK_FAMILY: Final = _ecs_default_task_family()
+
+
+def _parse_csv_env(name: str, default: str = "") -> list[str]:
+    """Parse a comma-separated env var into a list of trimmed strings.
+
+    Empty strings are dropped so a trailing comma or double comma
+    doesn't propagate as an empty subnet/SG entry that boto3 would
+    later reject with a less informative error.
+    """
+    raw = os.getenv(name, default)
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+#: Awsvpc subnet IDs the worker ENIs land in. Required for the ECS
+#: profile; an empty list with ``ECS_CLUSTER`` set is a misconfiguration
+#: that the lifespan refuses to start under.
+ECS_WORKER_SUBNETS: Final = _parse_csv_env("ECS_WORKER_SUBNETS")
+
+#: Awsvpc security groups attached to the worker ENIs. Optional —
+#: when empty, ECS applies the VPC default SG.
+ECS_WORKER_SECURITY_GROUPS: Final = _parse_csv_env("ECS_WORKER_SECURITY_GROUPS")
+
+def _parse_assign_public_ip(name: str, default: str) -> str:
+    """Parse an ECS ``assignPublicIp`` env var with explicit validation.
+
+    ECS rejects anything other than ``ENABLED`` / ``DISABLED``; we
+    surface the misconfiguration at module-import time so the lifespan
+    doesn't get to Mongo + S3 init before tripping on it. The
+    allowed-values set is sourced from
+    :data:`cfdb.workflows.provisioner._ASSIGN_PUBLIC_IP_VALUES` (which
+    derives it from the :data:`~cfdb.workflows.provisioner.AssignPublicIp`
+    Literal) so the two stay in lockstep without duplication.
+    """
+    # Lazy import: ``cfdb.workflows.provisioner`` pulls boto3, which is
+    # heavyweight and unused on lifespan paths that never construct an
+    # ECS provisioner. Deferring the import keeps PoC-profile startup
+    # snappy.
+    from cfdb.workflows.provisioner import _ASSIGN_PUBLIC_IP_VALUES
+
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    if raw not in _ASSIGN_PUBLIC_IP_VALUES:
+        raise ImportError(
+            f"Environment variable {name}={raw!r} must be one of "
+            f"{sorted(_ASSIGN_PUBLIC_IP_VALUES)}"
+        )
+    return raw
+
+
+#: Whether the worker ENI gets a public IPv4 address. Production
+#: should leave this DISABLED and reach AWS via VPC endpoints;
+#: LocalStack accepts either value.
+ECS_WORKER_ASSIGN_PUBLIC_IP: Final = _parse_assign_public_ip(
+    "ECS_WORKER_ASSIGN_PUBLIC_IP", "DISABLED"
+)
 
 db: AsyncIOMotorDatabase | None = None
 cache: "CacheBackend | None" = None

--- a/src/cfdb/api/main.py
+++ b/src/cfdb/api/main.py
@@ -1,9 +1,10 @@
+import asyncio
 import contextvars
 import logging
 import os
 import re
-from contextlib import asynccontextmanager
-from pathlib import Path
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import AsyncIterator, Optional
 
 import wool
 from wool.runtime.discovery.lan import LanDiscovery
@@ -15,16 +16,25 @@ from strawberry.fastapi import GraphQLRouter
 
 from cfdb import api
 from cfdb.api.gql.schema import schema
+from cfdb.api.profile import WorkflowProfile
 from cfdb.api.routers.data import router as data_router
 from cfdb.api.routers.index import router as index_router
 from cfdb.api.routers.jobs import router as jobs_router
 from cfdb.api.routers.sync import router as sync_router
-from cfdb.workflows.cache import LocalFsCache
+from cfdb.workflows.cache import (
+    CacheBackend,
+    LocalFsCache,
+    S3Cache,
+    _build_s3_client,
+    check_s3_bucket_or_raise,
+)
+from cfdb.workflows.discovery import EcsDiscovery
 from cfdb.workflows.executor import WoolExecutor
 from cfdb.workflows.models import ACTIVE_STATUSES
 from cfdb.workflows.processors.bam import BamIndexProcessor
 from cfdb.workflows.processors.registry import default_registry
 from cfdb.workflows.processors.tabix import TabixIntervalProcessor
+from cfdb.workflows.provisioner import EcsProvisioner
 
 logging.basicConfig(level=logging.INFO)
 
@@ -38,6 +48,53 @@ SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 10.0
 def redact_url(url: str) -> str:
     """Redact password from a MongoDB connection string for safe logging."""
     return re.sub(r"://([^:]+):([^@]+)@", r"://\1:***@", url)
+
+
+async def _drain_executor(
+    executor_handle: "WoolExecutor", log: logging.Logger
+) -> None:
+    """Drain the workflow executor with the shared shutdown budget."""
+    drained = await executor_handle.drain(timeout=SHUTDOWN_DRAIN_TIMEOUT_SECONDS)
+    if drained:
+        log.info("Drained %d workflow task(s) on shutdown", drained)
+
+
+async def _aclose_provisioner_bounded(
+    provisioner: EcsProvisioner, log: logging.Logger
+) -> None:
+    """Close the provisioner under a wall-clock cap.
+
+    ``EcsProvisioner.aclose`` awaits cancelled ``RunTask`` tasks; if
+    boto3 is configured without socket timeouts and the AWS endpoint is
+    unreachable during shutdown, the join can hang indefinitely. Bound
+    the wait to the shared shutdown drain budget so a stuck endpoint
+    doesn't stall the lifespan until uvicorn SIGKILLs us — accept the
+    leak as the price of bounded shutdown.
+    """
+    try:
+        await asyncio.wait_for(
+            provisioner.aclose(), timeout=SHUTDOWN_DRAIN_TIMEOUT_SECONDS
+        )
+    except asyncio.TimeoutError:
+        log.warning(
+            "provisioner.aclose() exceeded %.1fs shutdown budget; "
+            "leaking in-flight RunTasks for stale-task reclaim",
+            SHUTDOWN_DRAIN_TIMEOUT_SECONDS,
+        )
+
+
+async def _reset_api_globals() -> None:
+    """Clear module-level pointers held by ``cfdb.api``.
+
+    Runs last in the teardown stack so the globals are nulled even when
+    earlier steps fail. Tests rely on this so a lifespan exception
+    doesn't leak the executor / cache / processor registry / wool
+    context into a subsequent app instantiation.
+    """
+    api.executor = None
+    api.cache = None
+    api.processor_registry = None
+    api.wool_context = None
 
 
 async def _assert_jobs_indexes(db, log: logging.Logger) -> None:
@@ -86,6 +143,78 @@ async def _assert_jobs_indexes(db, log: logging.Logger) -> None:
     )
 
 
+async def _build_cache(profile: WorkflowProfile) -> CacheBackend:
+    """Build the cache backend dictated by ``profile``.
+
+    For the ``s3-cached`` and ``ecs`` profiles, the boto3 client is
+    built once and threaded into both :class:`S3Cache` and
+    :func:`check_s3_bucket_or_raise` so the probe targets the same
+    endpoint and we don't reach into ``cache._client`` from outside.
+    For the ``local`` profile, a :class:`LocalFsCache` rooted at
+    ``profile.cache_root`` is returned.
+    """
+    if profile.s3 is not None:
+        client = _build_s3_client(
+            endpoint_url=profile.aws_endpoint_url,
+            region_name=profile.aws_region,
+        )
+        cache = S3Cache(
+            bucket=profile.s3.bucket,
+            prefix=profile.s3.prefix,
+            client=client,
+        )
+        await check_s3_bucket_or_raise(profile.s3.bucket, client=client)
+        return cache
+    return LocalFsCache(profile.cache_root)
+
+
+def _build_provisioner(profile: WorkflowProfile) -> Optional[EcsProvisioner]:
+    """Build the :class:`EcsProvisioner` for the ``ecs`` profile.
+
+    Returns ``None`` for ``local`` and ``s3-cached`` profiles.
+    Partial-ECS validation lives in :meth:`WorkflowProfile.from_env`,
+    so by the time this runs the ECS fields are either complete or
+    absent.
+    """
+    if profile.ecs is None:
+        return None
+    return EcsProvisioner(
+        cluster=profile.ecs.cluster,
+        task_definition=profile.ecs.task_definition,
+        subnets=profile.ecs.subnets,
+        security_groups=profile.ecs.security_groups,
+        assign_public_ip=profile.ecs.assign_public_ip,
+        endpoint_url=profile.aws_endpoint_url,
+        region_name=profile.aws_region,
+    )
+
+
+@asynccontextmanager
+async def _build_discovery(profile: WorkflowProfile) -> AsyncIterator[object]:
+    """Build the wool-compatible discovery layer for ``profile``.
+
+    The ``ecs`` profile yields an :class:`EcsDiscovery` context — the
+    background ``ListTasks`` / ``DescribeTasks`` poller starts on
+    ``__aenter__`` and is cancelled on ``__aexit__``. The ``local``
+    and ``s3-cached`` profiles fall through to :class:`LanDiscovery`
+    over zeroconf/mDNS against a manually-started wool pool.
+
+    Either branch yields a shape ``wool.WorkerPool`` accepts via its
+    ``discovery=`` arg so the lifespan wires it through without
+    branching at the call site.
+    """
+    if profile.ecs is not None and profile.ecs.task_family is not None:
+        async with EcsDiscovery(
+            cluster=profile.ecs.cluster,
+            task_definition_family=profile.ecs.task_family,
+            endpoint_url=profile.aws_endpoint_url,
+            region_name=profile.aws_region,
+        ) as discovery:
+            yield discovery
+        return
+    yield LanDiscovery(api.WORKFLOW_POOL_NAMESPACE)
+
+
 def create_mongodb_client() -> AsyncIOMotorClient:
     """Create MongoDB client with optional TLS authentication."""
     log = logging.getLogger(__name__)
@@ -119,106 +248,114 @@ async def lifespan(_: FastAPI):
     client = create_mongodb_client()
     api.db = client[api.DATABASE_NAME]
     try:
+        # ``WorkflowProfile.from_env`` returns None when SYNC_DATA_DIR is
+        # unset (workflow subsystem stays disabled; routers fall back to
+        # direct-streaming) and raises on partial ECS config so a typo
+        # cannot silently degrade to PoC fallback.
+        profile = WorkflowProfile.from_env()
+
         # Fail-fast if the workflow mutex index is missing. The partial
         # unique index on ``jobs.workflow_key`` is the database-side
         # enforcement of "exactly one active workflow per source file";
         # without it, ``claim_workflow`` silently degrades to "no mutex"
         # and every miss dispatches a duplicate workflow.
-        if api.SYNC_DATA_DIR:
+        if profile is not None:
             await _assert_jobs_indexes(api.db, log)
 
-        # When SYNC_DATA_DIR is unset, skip workflow initialization
-        # entirely. Routers detect the None state and fall back to their
-        # direct-streaming paths.
-        if api.SYNC_DATA_DIR:
-            sync_root = Path(api.SYNC_DATA_DIR)
-            cache_root = sync_root / "cache"
-            workdir_root = sync_root / "jobs"
             # Fail-fast on mkdir error: an operator who explicitly set
             # SYNC_DATA_DIR has signalled "workflows on"; silently
             # degrading to disabled hides misconfiguration (wrong path,
             # bad perms, read-only mount) until later 5xx surprises.
-            cache_root.mkdir(parents=True, exist_ok=True)
-            workdir_root.mkdir(parents=True, exist_ok=True)
+            profile.cache_root.mkdir(parents=True, exist_ok=True)
+            profile.workdir_root.mkdir(parents=True, exist_ok=True)
 
             # ``LocalFsCache.put`` uses ``os.replace`` for atomicity,
             # which only works when source and destination live on the
             # same filesystem (otherwise the kernel raises
             # ``OSError(EXDEV)``). Verify the precondition at startup so
             # a multi-volume deployment fails fast with a clear message
-            # instead of dying mid-pipeline on the first cache.put.
-            cache_st = os.stat(cache_root)
-            workdir_st = os.stat(workdir_root)
-            if cache_st.st_dev != workdir_st.st_dev:
-                raise RuntimeError(
-                    "SYNC_DATA_DIR subdirectories must share a filesystem "
-                    f"(cache={cache_root!s} st_dev={cache_st.st_dev}, "
-                    f"workdir={workdir_root!s} st_dev={workdir_st.st_dev}). "
-                    "LocalFsCache.put relies on os.replace atomicity; "
-                    "cross-device renames raise OSError(EXDEV). Mount both "
-                    "paths under a single volume or set SYNC_DATA_DIR to a "
-                    "parent that contains both."
-                )
+            # instead of dying mid-pipeline on the first cache.put. Only
+            # the local profile needs this — S3Cache.put goes over the
+            # network and has no rename-atomicity requirement.
+            if profile.kind == "local":
+                cache_st = os.stat(profile.cache_root)
+                workdir_st = os.stat(profile.workdir_root)
+                if cache_st.st_dev != workdir_st.st_dev:
+                    raise RuntimeError(
+                        "SYNC_DATA_DIR subdirectories must share a filesystem "
+                        f"(cache={profile.cache_root!s} st_dev={cache_st.st_dev}, "
+                        f"workdir={profile.workdir_root!s} st_dev={workdir_st.st_dev}). "
+                        "LocalFsCache.put relies on os.replace atomicity; "
+                        "cross-device renames raise OSError(EXDEV). Mount both "
+                        "paths under a single volume or set SYNC_DATA_DIR to a "
+                        "parent that contains both."
+                    )
 
-            api.cache = LocalFsCache(cache_root)
+            api.cache = await _build_cache(profile)
             api.processor_registry = default_registry()
             api.processor_registry.register(BamIndexProcessor())
             api.processor_registry.register(TabixIntervalProcessor())
+            provisioner = _build_provisioner(profile)
 
             # Lease workers from the surrounding pool rather than spawning
-            # them in-process. In production the workers run as separate
-            # ECS tasks discovered via wool's discovery layer; the API's
-            # job is to dispatch to whatever capacity exists. Scaling the
-            # ECS service is out of band (e.g., on ``NoWorkersAvailable``
-            # bursts or on a queue-depth metric).
+            # them in-process. The ``ecs`` profile launches workers on
+            # demand via ``EcsProvisioner`` and discovers them through
+            # ``EcsDiscovery``'s poll over ``ListTasks`` /
+            # ``DescribeTasks``. The ``local`` and ``s3-cached`` profiles
+            # fall back to ``LanDiscovery`` (zeroconf/mDNS) against a
+            # manually-started wool pool.
             #
             # The explicit ``discovery=`` is required to keep wool out of
             # its default ephemeral mode — ``WorkerPool(lease=N)`` alone
             # falls into the ``(spawn=None, discovery=None)`` branch which
-            # spawns CPU-count workers locally. Pairing ``lease=N`` with a
-            # shared ``LanDiscovery`` namespace puts the pool in
-            # discovery-only mode (no spawning); the worker-pool process
-            # publishes workers via the same namespace. ``LanDiscovery``
-            # rides over zeroconf/mDNS, which sidesteps the macOS
-            # ``watchdog``/FSEvents fork-unsafety we hit with
-            # ``LocalDiscovery``.
-            async with wool.WorkerPool(
-                discovery=LanDiscovery(api.WORKFLOW_POOL_NAMESPACE),
-                lease=api.WORKFLOW_WORKER_COUNT,
-            ):
-                # Snapshot the lifespan task's contextvars after the
-                # pool's ``__aenter__`` has populated wool's internals.
-                api.wool_context = contextvars.copy_context()
-                api.executor = WoolExecutor(
-                    api.db,
-                    api.cache,
-                    cache_root,
-                    api.processor_registry,
-                    workdir_root=workdir_root,
-                )
-                executor_handle = api.executor
-                log.info(
-                    "Workflow subsystem enabled: cache=%s workdir=%s "
-                    "lease=%d namespace=%s",
-                    cache_root,
-                    workdir_root,
-                    api.WORKFLOW_WORKER_COUNT,
-                    api.WORKFLOW_POOL_NAMESPACE,
-                )
-                try:
-                    yield
-                finally:
-                    drained = await executor_handle.drain(
-                        timeout=SHUTDOWN_DRAIN_TIMEOUT_SECONDS
+            # spawns CPU-count workers locally.
+            async with _build_discovery(profile) as discovery:
+                async with wool.WorkerPool(
+                    discovery=discovery,
+                    lease=api.WORKFLOW_WORKER_COUNT,
+                ):
+                    # Snapshot the lifespan task's contextvars after the
+                    # pool's ``__aenter__`` has populated wool's internals.
+                    api.wool_context = contextvars.copy_context()
+                    api.executor = WoolExecutor(
+                        api.db,
+                        api.cache,
+                        api.processor_registry,
+                        workdir_root=profile.workdir_root,
+                        provisioner=provisioner,
                     )
-                    if drained:
-                        log.info(
-                            "Drained %d workflow task(s) on shutdown", drained
+                    executor_handle = api.executor
+                    log.info(
+                        "Workflow subsystem enabled: profile=%s cache=%s "
+                        "workdir=%s lease=%d discovery=%s provisioner=%s",
+                        profile.kind,
+                        type(api.cache).__name__,
+                        profile.workdir_root,
+                        api.WORKFLOW_WORKER_COUNT,
+                        type(discovery).__name__,
+                        "EcsProvisioner" if provisioner is not None else "none",
+                    )
+                    # Stack each teardown step as an async callback so a
+                    # failure earlier in the chain (e.g. ``drain`` raises
+                    # on a Mongo blip) cannot skip later steps. Without
+                    # this an ``executor.drain`` exception would leave
+                    # ``provisioner.aclose`` and the api-global resets
+                    # unrun — the very billable-leak bug that
+                    # ``provisioner.aclose`` exists to prevent.
+                    async with AsyncExitStack() as teardown:
+                        teardown.push_async_callback(
+                            _reset_api_globals
                         )
-                    api.executor = None
-                    api.cache = None
-                    api.processor_registry = None
-                    api.wool_context = None
+                        if provisioner is not None:
+                            teardown.push_async_callback(
+                                _aclose_provisioner_bounded,
+                                provisioner,
+                                log,
+                            )
+                        teardown.push_async_callback(
+                            _drain_executor, executor_handle, log
+                        )
+                        yield
         else:
             log.info(
                 "SYNC_DATA_DIR unset — workflow subsystem disabled; "

--- a/src/cfdb/api/profile.py
+++ b/src/cfdb/api/profile.py
@@ -1,0 +1,155 @@
+"""Validated workflow deployment-profile snapshot.
+
+The lifespan probes a handful of env vars to decide which subsystem
+shape to wire (LocalFsCache vs S3Cache, LanDiscovery vs EcsDiscovery,
+no provisioner vs EcsProvisioner). Encoding the decision as a single
+``WorkflowProfile.from_env()`` call at boot lets the helpers branch
+once on ``profile.kind`` instead of re-probing the env globals in
+five different places.
+
+Three profiles:
+
+* ``"local"`` — :class:`LocalFsCache` + :class:`LanDiscovery` + no
+  provisioner. The PoC / laptop-dev path; workers are started by hand
+  via ``wool pool --spawn``.
+* ``"s3-cached"`` — :class:`S3Cache` + :class:`LanDiscovery` + no
+  provisioner. S3 artifacts but workers still LAN-discovered; useful
+  for staging environments where workers run on EC2.
+* ``"ecs"`` — :class:`S3Cache` + :class:`EcsDiscovery` +
+  :class:`EcsProvisioner`. The production Fargate path.
+
+A partial ECS config (``ECS_CLUSTER`` set without
+``ECS_WORKER_TASK_DEFINITION`` or ``ECS_WORKER_SUBNETS``) raises at
+``from_env()`` time so a typo cannot silently degrade to PoC.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional
+
+from cfdb import api
+from cfdb.workflows.provisioner import AssignPublicIp
+
+
+@dataclass(frozen=True)
+class _S3Config:
+    """S3-backed cache configuration."""
+
+    bucket: str
+    prefix: str
+
+
+@dataclass(frozen=True)
+class _EcsConfig:
+    """ECS Fargate provisioner + discovery configuration."""
+
+    cluster: str
+    task_definition: str
+    task_family: Optional[str]
+    subnets: tuple[str, ...]
+    security_groups: tuple[str, ...]
+    assign_public_ip: AssignPublicIp
+
+
+@dataclass(frozen=True)
+class WorkflowProfile:
+    """Workflow deployment profile snapshot taken at lifespan boot.
+
+    Use :meth:`from_env` to validate and snapshot the env once. The
+    lifespan helpers then branch on ``self.kind`` (or on the presence
+    of ``self.s3`` / ``self.ecs``) rather than re-probing
+    :mod:`cfdb.api` globals.
+    """
+
+    kind: Literal["local", "s3-cached", "ecs"]
+    cache_root: Path
+    workdir_root: Path
+    s3: Optional[_S3Config] = None
+    ecs: Optional[_EcsConfig] = None
+    aws_endpoint_url: Optional[str] = None
+    aws_region: str = "us-east-1"
+
+    @classmethod
+    def from_env(cls) -> Optional["WorkflowProfile"]:
+        """Validate and snapshot the workflow env config.
+
+        Returns ``None`` when ``SYNC_DATA_DIR`` is unset — the workflow
+        subsystem stays disabled and routers fall through to their
+        direct-streaming paths. Raises :class:`RuntimeError` on partial
+        ECS config so misconfiguration surfaces loudly at boot.
+        """
+        if not api.SYNC_DATA_DIR:
+            return None
+
+        sync_root = Path(api.SYNC_DATA_DIR)
+        cache_root = sync_root / "cache"
+        workdir_root = sync_root / "jobs"
+
+        s3 = _s3_config_from_env()
+        ecs = _ecs_config_from_env()
+
+        kind: Literal["local", "s3-cached", "ecs"]
+        if ecs is not None:
+            kind = "ecs"
+        elif s3 is not None:
+            kind = "s3-cached"
+        else:
+            kind = "local"
+
+        return cls(
+            kind=kind,
+            cache_root=cache_root,
+            workdir_root=workdir_root,
+            s3=s3,
+            ecs=ecs,
+            aws_endpoint_url=api.AWS_ENDPOINT_URL,
+            aws_region=api.AWS_REGION,
+        )
+
+
+def _s3_config_from_env() -> Optional[_S3Config]:
+    """Snapshot the S3 cache config from env globals.
+
+    Returns ``None`` when ``WORKFLOW_S3_BUCKET`` is unset.
+    """
+    if not api.WORKFLOW_S3_BUCKET:
+        return None
+    return _S3Config(
+        bucket=api.WORKFLOW_S3_BUCKET,
+        prefix=api.WORKFLOW_S3_PREFIX,
+    )
+
+
+def _ecs_config_from_env() -> Optional[_EcsConfig]:
+    """Snapshot the ECS provisioner + discovery config from env globals.
+
+    Returns ``None`` when ``ECS_CLUSTER`` is unset (PoC / s3-cached
+    paths). Raises :class:`RuntimeError` when ``ECS_CLUSTER`` is set
+    but a required field is missing — partial ECS config is never
+    intentional in production, so failing fast surfaces the
+    misconfiguration at boot rather than degrading to a quietly broken
+    deployment running PoC fallback.
+    """
+    if not api.ECS_CLUSTER:
+        return None
+    missing: list[str] = []
+    if not api.ECS_WORKER_TASK_DEFINITION:
+        missing.append("ECS_WORKER_TASK_DEFINITION")
+    if not api.ECS_WORKER_SUBNETS:
+        missing.append("ECS_WORKER_SUBNETS")
+    if missing:
+        raise RuntimeError(
+            "ECS_CLUSTER is set but the ECS profile is incomplete; "
+            f"missing: {', '.join(missing)}. Set the missing knob(s) "
+            "or unset ECS_CLUSTER to fall back to the PoC profile."
+        )
+    return _EcsConfig(
+        cluster=api.ECS_CLUSTER,
+        task_definition=api.ECS_WORKER_TASK_DEFINITION,
+        task_family=api.ECS_WORKER_TASK_FAMILY,
+        subnets=tuple(api.ECS_WORKER_SUBNETS),
+        security_groups=tuple(api.ECS_WORKER_SECURITY_GROUPS),
+        assign_public_ip=api.ECS_WORKER_ASSIGN_PUBLIC_IP,
+    )

--- a/src/cfdb/api/routers/cache_stream.py
+++ b/src/cfdb/api/routers/cache_stream.py
@@ -18,10 +18,8 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from cfdb import api
 from cfdb.services import drs
-from cfdb.workflows import keys as key_utils
 from cfdb.workflows.cache import CacheBackend
 from cfdb.workflows.executor import ExecutorDraining, WorkflowNotApplicable
-from cfdb.workflows.keys import extract_identity
 from cfdb.workflows.models import ArtifactKind
 
 logger = logging.getLogger(__name__)
@@ -101,6 +99,96 @@ def stream_cache_entry(
     )
 
 
+def stream_upstream_url(
+    download_url: str,
+    file_size: Optional[int],
+    filename: str,
+    request: Request,
+    range_header: Optional[str],
+    *,
+    media_type: str = "application/octet-stream",
+):
+    """Return a Response streaming an upstream URL, honoring Range.
+
+    The upstream-URL twin of :func:`stream_cache_entry`: same parse-range
+    / 200-vs-206 / HEAD ritual, but the bytes come from ``download_url``
+    via :func:`drs.stream_from_url` instead of a ``CacheBackend``. The
+    DRS/HTTPS, ENCODE, and 4DN-sidecar paths all delegate here so the
+    range contract stays in one place.
+
+    Args:
+        download_url: Absolute URL to stream from (already allowlist-validated
+            by the caller where applicable).
+        file_size: Total size in bytes, or ``None`` when unknown. A range
+            request against an unknown size yields ``416`` per RFC 9110
+            §15.5.17 (not ``500``).
+        filename: Used for the ``Content-Disposition`` header.
+        request: FastAPI request — used to detect HEAD vs GET.
+        range_header: Raw value of the incoming ``Range`` header, if any.
+        media_type: Content-Type to return.
+
+    Raises:
+        HTTPException(416): size unknown on a range request, or the range
+            is valid but out of bounds.
+        HTTPException(400): Range header has invalid syntax.
+    """
+    response_headers = {
+        "Content-Disposition": f'attachment; filename="{filename or "file"}"',
+        "Accept-Ranges": "bytes",
+    }
+    status_code = status.HTTP_200_OK
+    range_to_send: Optional[str] = None
+
+    if range_header:
+        if not file_size:
+            # RFC 9110 §15.5.17: a range request the server cannot satisfy
+            # because the total size is unknown produces 416 with
+            # ``Content-Range: bytes */*`` so the client can fall back to a
+            # plain GET. (The 4DN sidecar path previously mis-signalled 500.)
+            raise HTTPException(
+                status_code=status.HTTP_416_RANGE_NOT_SATISFIABLE,
+                detail="File size unknown; range cannot be satisfied",
+                headers={"Content-Range": "bytes */*"},
+            )
+        try:
+            start, end, content_length = drs.parse_range_header(
+                range_header, file_size
+            )
+            range_to_send = range_header
+            status_code = status.HTTP_206_PARTIAL_CONTENT
+            response_headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
+            response_headers["Content-Length"] = str(content_length)
+        except drs.RangeNotSatisfiableError as e:
+            raise HTTPException(
+                status_code=status.HTTP_416_RANGE_NOT_SATISFIABLE,
+                headers={
+                    "Content-Range": f"bytes */{e.file_size}",
+                    "Accept-Ranges": "bytes",
+                },
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid Range header: {str(e)}",
+            )
+    elif file_size:
+        response_headers["Content-Length"] = str(file_size)
+
+    if request.method == "HEAD":
+        return Response(
+            status_code=status_code,
+            media_type=media_type,
+            headers=response_headers,
+        )
+
+    return StreamingResponse(
+        drs.stream_from_url(download_url, range_to_send),
+        status_code=status_code,
+        media_type=media_type,
+        headers=response_headers,
+    )
+
+
 async def serve_workflow_artifact_or_dispatch(
     file_doc: dict[str, Any],
     artifact_kind: ArtifactKind,
@@ -150,7 +238,10 @@ async def serve_workflow_artifact_or_dispatch(
         return None
 
     try:
-        dcc, local_id, md5 = extract_identity(file_doc)
+        # Single cache-key authority: the processor derives the key it
+        # writes under; the router probes the same key here. Re-deriving
+        # the formula independently is what let producer/consumer drift.
+        cache_key = processor.cache_key_for(file_doc, artifact_kind)
     except ValueError as exc:
         # Treat incomplete file_meta as "workflow not applicable" so
         # the caller falls through. The DCC ingest contract guarantees
@@ -158,14 +249,6 @@ async def serve_workflow_artifact_or_dispatch(
         # stale or hand-edited document, not a request to 500 on.
         logger.warning(f"Cannot dispatch workflow — file_meta incomplete: {exc}")
         return None
-
-    cache_key = key_utils.cache_key(
-        dcc=dcc,
-        local_id=local_id,
-        artifact_kind=artifact_kind,
-        md5=md5,
-        processor_version=processor.processor_version,
-    )
 
     entry = await api.cache.head(cache_key)
     if entry is not None:

--- a/src/cfdb/api/routers/data.py
+++ b/src/cfdb/api/routers/data.py
@@ -4,11 +4,13 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Header, HTTPException, Path, Request, status
-from fastapi.responses import Response, StreamingResponse
 
 from cfdb import api
 from cfdb.api.routers._helpers import enforce_hubmap_access, lookup_file_doc
-from cfdb.api.routers.cache_stream import serve_workflow_artifact_or_dispatch
+from cfdb.api.routers.cache_stream import (
+    serve_workflow_artifact_or_dispatch,
+    stream_upstream_url,
+)
 from cfdb.models import FileMetadataModel
 from cfdb.services import drs, locks
 from cfdb.services.drs import (
@@ -242,93 +244,13 @@ async def stream_file(
                 )
                 logger.info(f"Streaming HTTPS file: {drs_object.name}")
 
-                # Prepare response headers
-                response_headers = {
-                    "Content-Disposition": f'attachment; filename="{drs_object.name or "file"}"',
-                    "Accept-Ranges": "bytes",
-                }
-
-                status_code = 200
-                range_header_to_send = None
-
-                # Handle Range request if present
-                if range:
-                    # Validate that file size is available. RFC 9110 §15.5.17
-                    # says a range request the server cannot satisfy because
-                    # the total size is unknown should produce 416 with
-                    # ``Content-Range: bytes */*`` so the client can fall
-                    # back to a plain GET; 500 mis-signals a server fault.
-                    if not drs_object.size:
-                        logger.warning(
-                            f"Range request for file without size metadata: {local_id}"
-                        )
-                        raise HTTPException(
-                            status_code=status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE,
-                            detail="File size unknown; range cannot be satisfied",
-                            headers={"Content-Range": "bytes */*"},
-                        )
-
-                    try:
-                        # Parse and validate the Range header
-                        start, end, content_length = drs.parse_range_header(
-                            range, drs_object.size
-                        )
-
-                        logger.debug(
-                            f"Range request: bytes {start}-{end}/{drs_object.size}"
-                        )
-
-                        # Set response for partial content
-                        range_header_to_send = range
-                        status_code = 206
-                        response_headers["Content-Range"] = (
-                            f"bytes {start}-{end}/{drs_object.size}"
-                        )
-                        response_headers["Content-Length"] = str(content_length)
-
-                    except drs.RangeNotSatisfiableError as e:
-                        # Range exceeds file bounds - return 416
-                        logger.warning(
-                            f"Range not satisfiable: {range} for file size {e.file_size}"
-                        )
-                        raise HTTPException(
-                            status_code=416,
-                            headers={
-                                "Content-Range": f"bytes */{e.file_size}",
-                                "Accept-Ranges": "bytes",
-                            },
-                        )
-
-                    except ValueError as e:
-                        # Invalid Range header syntax - return 400
-                        logger.warning(f"Invalid Range header syntax: {range}")
-                        raise HTTPException(
-                            status_code=400, detail=f"Invalid Range header: {str(e)}"
-                        )
-
-                # Set Content-Type from DRS metadata
-                media_type = drs_object.mime_type or "application/octet-stream"
-
-                # For full file requests, include Content-Length from DRS metadata if available
-                if not range and drs_object.size:
-                    response_headers["Content-Length"] = str(drs_object.size)
-
-                # HEAD request - return headers only, no body
-                if request.method == "HEAD":
-                    return Response(
-                        status_code=status_code,
-                        media_type=media_type,
-                        headers=response_headers,
-                    )
-
-                # Stream file (with or without range)
-                chunk_gen = drs.stream_from_url(download_url, range_header_to_send)
-
-                return StreamingResponse(
-                    chunk_gen,
-                    status_code=status_code,
-                    media_type=media_type,
-                    headers=response_headers,
+                return stream_upstream_url(
+                    download_url,
+                    drs_object.size,
+                    drs_object.name or "file",
+                    request,
+                    range,
+                    media_type=drs_object.mime_type or "application/octet-stream",
                 )
 
             except HTTPException:
@@ -395,95 +317,26 @@ async def _stream_encode_file(
 
     logger.info(f"Streaming ENCODE file: {filename} from {download_url}")
 
-    # Prepare response headers
-    response_headers = {
-        "Content-Disposition": f'attachment; filename="{filename}"',
-        "Accept-Ranges": "bytes",
-    }
-
-    status_code = 200
-    range_to_send = None
-
-    # Handle Range request if present
-    if range_header:
-        if not file_size:
-            logger.warning("Range request for ENCODE file without size metadata")
-            # See RFC 9110 §15.5.17 — when the server cannot determine
-            # the total size, return 416 with ``Content-Range: bytes */*``
-            # instead of a misleading 500.
-            raise HTTPException(
-                status_code=status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE,
-                detail="File size unknown; range cannot be satisfied",
-                headers={"Content-Range": "bytes */*"},
-            )
-
-        try:
-            start, end, content_length = drs.parse_range_header(range_header, file_size)
-
-            logger.debug(f"Range request: bytes {start}-{end}/{file_size}")
-
-            range_to_send = range_header
-            status_code = 206
-            response_headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
-            response_headers["Content-Length"] = str(content_length)
-
-        except drs.RangeNotSatisfiableError as e:
-            logger.warning(
-                f"Range not satisfiable: {range_header} for file size {e.file_size}"
-            )
-            raise HTTPException(
-                status_code=416,
-                headers={
-                    "Content-Range": f"bytes */{e.file_size}",
-                    "Accept-Ranges": "bytes",
-                },
-            )
-
-        except ValueError as e:
-            logger.warning(f"Invalid Range header syntax: {range_header}")
-            raise HTTPException(
-                status_code=400, detail=f"Invalid Range header: {str(e)}"
-            )
-
-    # Determine media type from filename or default to binary
+    # Determine media type from filename; default to binary. (Branches
+    # that resolve to the default are folded away.)
     media_type = "application/octet-stream"
     if filename:
         if filename.endswith(".gz"):
             media_type = "application/gzip"
-        elif filename.endswith(".bam"):
-            media_type = "application/octet-stream"
-        elif filename.endswith(".fastq") or filename.endswith(".fq"):
+        elif filename.endswith((".fastq", ".fq", ".bed")):
             media_type = "text/plain"
-        elif filename.endswith(".bed"):
-            media_type = "text/plain"
-        elif filename.endswith(".bigWig") or filename.endswith(".bw"):
-            media_type = "application/octet-stream"
-        elif filename.endswith(".bigBed") or filename.endswith(".bb"):
-            media_type = "application/octet-stream"
 
-    # For full file requests, include Content-Length if available
-    if not range_header and file_size:
-        response_headers["Content-Length"] = str(file_size)
-
-    # HEAD request - return headers only, no body
-    if request.method == "HEAD":
-        return Response(
-            status_code=status_code,
-            media_type=media_type,
-            headers=response_headers,
-        )
-
-    # Stream file content
     try:
-        chunk_gen = drs.stream_from_url(download_url, range_to_send)
-
-        return StreamingResponse(
-            chunk_gen,
-            status_code=status_code,
+        return stream_upstream_url(
+            download_url,
+            file_size,
+            filename,
+            request,
+            range_header,
             media_type=media_type,
-            headers=response_headers,
         )
-
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"ENCODE streaming error: {str(e)}")
         raise HTTPException(status_code=502, detail="Failed to stream ENCODE file")

--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -26,16 +26,16 @@ from typing import Optional
 from urllib.parse import urljoin
 
 from fastapi import APIRouter, Header, HTTPException, Path, Request, status
-from fastapi.responses import Response, StreamingResponse
 
 from cfdb import api
 from cfdb.api.routers._helpers import enforce_hubmap_access, lookup_file_doc
-from cfdb.api.routers.cache_stream import serve_workflow_artifact_or_dispatch
+from cfdb.api.routers.cache_stream import (
+    serve_workflow_artifact_or_dispatch,
+    stream_upstream_url,
+)
 from cfdb.dcc_registry import get_all_dcc_names, get_dcc_config, normalize_dcc_name
-from cfdb.services import drs, locks
+from cfdb.services import locks
 from cfdb.workflows.models import ArtifactKind
-from cfdb.workflows.processors.passthrough import PassthroughProcessor
-from cfdb.workflows.processors.tools import format_name
 from cfdb.workflows.urlsafe import UnsafeOutboundURL, validate_outbound_url
 
 logger = logging.getLogger(__name__)
@@ -137,16 +137,23 @@ async def stream_index_file(
         # No sidecar, no workflow handler. Two terminal cases:
         #
         # 1. The format has no index in any state of the world (CSV,
-        #    TSV, bigWig — passthrough formats with no companion
-        #    index file). Return 404 unconditionally; the issue spec
-        #    promises a clean "no index" signal regardless of
-        #    subsystem state.
+        #    TSV, bigWig — passthrough formats whose processor declares no
+        #    artifacts). Return 404 unconditionally; the issue spec
+        #    promises a clean "no index" signal regardless of subsystem
+        #    state. Asking the matched processor whether it produces any
+        #    artifacts keeps the "is this a no-index format?" decision in
+        #    the registry rather than hard-coding PassthroughProcessor's
+        #    format set here.
         # 2. The format could be processed into an index but the
         #    workflow subsystem is disabled — return 503 so operators
         #    can distinguish degraded mode from an inherent no-index
         #    format.
-        fmt = format_name(file_doc)
-        if fmt is not None and fmt in PassthroughProcessor.supported_formats:
+        processor = (
+            api.processor_registry.lookup_for(file_doc)
+            if api.processor_registry is not None
+            else None
+        )
+        if processor is not None and not processor.artifact_kinds_produced(file_doc):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No index file available for this file format",
@@ -257,55 +264,8 @@ async def _try_serve_fourdn_sidecar(
 
     logger.info(f"Streaming 4DN sidecar: {filename} from {download_url}")
 
-    response_headers = {
-        "Content-Disposition": f'attachment; filename="{filename}"',
-        "Accept-Ranges": "bytes",
-    }
-
-    status_code = status.HTTP_200_OK
-    range_to_send: Optional[str] = None
-    if range_header:
-        if not file_size:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Cannot process range request: index file size unavailable",
-            )
-        try:
-            start, end, content_length = drs.parse_range_header(range_header, file_size)
-            range_to_send = range_header
-            status_code = status.HTTP_206_PARTIAL_CONTENT
-            response_headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
-            response_headers["Content-Length"] = str(content_length)
-        except drs.RangeNotSatisfiableError as e:
-            raise HTTPException(
-                status_code=status.HTTP_416_RANGE_NOT_SATISFIABLE,
-                headers={
-                    "Content-Range": f"bytes */{e.file_size}",
-                    "Accept-Ranges": "bytes",
-                },
-            )
-        except ValueError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid Range header: {str(e)}",
-            )
-
-    if not range_header and file_size:
-        response_headers["Content-Length"] = str(file_size)
-
-    if request.method == "HEAD":
-        return Response(
-            status_code=status_code,
-            media_type="application/octet-stream",
-            headers=response_headers,
-        )
-
-    chunk_gen = drs.stream_from_url(download_url, range_to_send)
-    return StreamingResponse(
-        chunk_gen,
-        status_code=status_code,
-        media_type="application/octet-stream",
-        headers=response_headers,
+    return stream_upstream_url(
+        download_url, file_size, filename, request, range_header
     )
 
 

--- a/src/cfdb/workflows/__init__.py
+++ b/src/cfdb/workflows/__init__.py
@@ -27,7 +27,10 @@ Runtime / lifecycle (consumed by the executor and lock modules):
 
 - ``CFDB_WORKFLOW_DURATION_CAP_S`` — per-workflow wall-clock cap, enforced
   via ``asyncio.timeout`` on the API side while consuming the routine's
-  event stream. Default ``1200`` (20 min).
+  event stream. Default ``14400`` (4 h) — sized for multi-hour
+  preprocessing runs (e.g., a ``samtools sort`` on a multi-GB BAM
+  followed by ``samtools index``). Operators running on bounded fixtures
+  in dev should lower this via env.
 - ``CFDB_WORKFLOW_DISPATCH_WAIT_S`` — how long ``ensure_workflow`` waits
   for a wool worker to become available before giving up. Default ``60``.
 - ``CFDB_WORKFLOW_HEARTBEAT_INTERVAL_S`` — how often the routine emits a
@@ -109,7 +112,7 @@ SORT_PARALLEL: Final = _positive_int(
 # look like a hard failure).
 WORKFLOW_DURATION_CAP_S: Final = _positive_int(
     "CFDB_WORKFLOW_DURATION_CAP_S",
-    os.getenv("CFDB_WORKFLOW_DURATION_CAP_S", "1200"),
+    os.getenv("CFDB_WORKFLOW_DURATION_CAP_S", "14400"),
     minimum=1,
 )
 WORKFLOW_DISPATCH_WAIT_S: Final = _positive_int(

--- a/src/cfdb/workflows/cache.py
+++ b/src/cfdb/workflows/cache.py
@@ -1,9 +1,10 @@
 """Pluggable cache backend for workflow artifacts.
 
 The cache is a byte-range-aware content store keyed by strings produced by
-``workflows.keys.cache_key``. ``LocalFsCache`` is the concrete backend used
-in local development and for the initial CVH rollout; an S3-backed
-implementation with the same interface is planned for production.
+``workflows.keys.cache_key``. Two concrete backends ship: ``LocalFsCache``
+for development and unit tests that don't need a network round-trip, and
+``S3Cache`` for production (and for LocalStack-backed dev that mirrors
+production end-to-end via boto3).
 
 Range-aware reads matter because Gosling's client-side fetchers (BAM/tabix
 families, bbi) issue ``Range: bytes=…`` requests against the artifact URL.
@@ -19,7 +20,10 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 
 
 @dataclass(frozen=True)
@@ -31,7 +35,14 @@ class CacheEntry:
 
 
 class CacheBackend(ABC):
-    """Abstract cache backend."""
+    """Abstract cache backend.
+
+    A pure ``head`` / ``get`` / ``put`` / ``delete`` keyed store. The
+    backend is handed across the Wool boundary to the worker so
+    processors persist artifacts through it directly; nothing in the
+    interface assumes a filesystem (``LocalFsCache`` keeps a private
+    root; ``S3Cache`` has none).
+    """
 
     @abstractmethod
     async def head(self, key: str) -> Optional[CacheEntry]:
@@ -74,17 +85,29 @@ class CacheBackend(ABC):
 _CHUNK_SIZE = 1 << 16  # 64 KiB
 
 
-def _safe_key_path(root: Path, key: str) -> Path:
-    """Resolve a cache key to an absolute path under ``root``.
+def _validate_cache_key(key: str) -> None:
+    """Reject path-traversal segments in a cache key.
 
     Rejects empty keys and keys containing path-traversal segments so that
     malformed input cannot escape the cache root or collapse onto the
-    root directory itself.
+    root directory itself. Shared by both backends so the rule (and its
+    error message) stays in one place.
     """
     if not key or not key.strip("/"):
         raise ValueError(f"Cache key must be non-empty: {key!r}")
     if ".." in key.split("/"):
         raise ValueError(f"Invalid cache key: {key!r}")
+    if key.startswith("/"):
+        raise ValueError(f"Cache key must not start with '/': {key!r}")
+
+
+def _safe_key_path(root: Path, key: str) -> Path:
+    """Resolve a cache key to an absolute path under ``root``.
+
+    Validates the key shape and verifies the resolved path stays under
+    ``root`` so a malformed key cannot escape the cache root.
+    """
+    _validate_cache_key(key)
     path = (root / key).resolve()
     root_resolved = root.resolve()
     if root_resolved not in path.parents:
@@ -95,13 +118,18 @@ def _safe_key_path(root: Path, key: str) -> Path:
 class LocalFsCache(CacheBackend):
     """Local-filesystem backend. Keys map directly to relative paths.
 
-    ``put`` writes via a temp sibling + atomic rename. ``get`` supports
-    byte-range reads and chunks by 64 KiB to keep streaming memory-bounded.
+    ``put`` atomically renames the caller's source file into place via
+    ``os.replace``. ``get`` supports byte-range reads and chunks by 64
+    KiB to keep streaming memory-bounded.
     """
 
     def __init__(self, root: Path) -> None:
-        self.root = Path(root)
-        self.root.mkdir(parents=True, exist_ok=True)
+        self._root = Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def root(self) -> Path:
+        return self._root
 
     async def head(self, key: str) -> Optional[CacheEntry]:
         """Return size metadata for a key, or None if absent."""
@@ -141,6 +169,336 @@ class LocalFsCache(CacheBackend):
             return True
         except FileNotFoundError:
             return False
+
+
+class S3Cache(CacheBackend):
+    """Boto3-backed cache for production (and LocalStack-backed dev).
+
+    The same code targets real S3 and LocalStack — the only difference
+    is the ``endpoint_url`` passed to ``boto3.client("s3")``. Keys are
+    stored as object keys (optionally under a configurable prefix);
+    range reads use S3's ``Range`` header verbatim, so the fetcher
+    semantics are identical to ``LocalFsCache``.
+
+    Args:
+        bucket: Bucket name. Must already exist (LocalStack and prod
+            both treat bucket creation as an out-of-band concern).
+        prefix: Optional key prefix; useful for sharing a single bucket
+            across multiple environments. Empty string by default.
+        client: Optional pre-built boto3 ``s3`` client. When omitted,
+            one is constructed via :func:`_build_s3_client` with the
+            ``endpoint_url`` / ``region_name`` kwargs threaded through.
+            Tests inject a moto-backed client through this argument.
+        endpoint_url: Boto3 ``endpoint_url``. Passed to
+            :func:`_build_s3_client` when ``client`` is omitted. The
+            lifespan plumbs :data:`cfdb.api.AWS_ENDPOINT_URL` here so
+            LocalStack vs production differ only at this seam.
+        region_name: Boto3 ``region_name``. Plumbed analogously.
+        chunk_size: Streaming chunk size for ``get`` reads. Defaults to
+            64 KiB to match the local filesystem backend.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        prefix: str = "",
+        client: Optional[Any] = None,
+        endpoint_url: Optional[str] = None,
+        region_name: Optional[str] = None,
+        chunk_size: int = _CHUNK_SIZE,
+    ) -> None:
+        if not bucket:
+            raise ValueError("S3Cache requires a non-empty bucket name")
+        if client is not None and (endpoint_url or region_name):
+            raise ValueError(
+                "S3Cache: pass either client or endpoint_url/region_name, "
+                "not both — the boto kwargs are silently ignored when client is set"
+            )
+        self._bucket = bucket
+        # Normalize so callers can pass either ``"prefix"`` or ``"prefix/"``.
+        self._prefix = prefix.strip("/")
+        self._endpoint_url = endpoint_url
+        self._region_name = region_name
+        self._client = (
+            client
+            if client is not None
+            else _build_s3_client(endpoint_url=endpoint_url, region_name=region_name)
+        )
+        self._chunk_size = chunk_size
+
+    def _object_key(self, key: str) -> str:
+        """Apply the configured prefix to a validated cache key."""
+        _validate_cache_key(key)
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Strip the boto3 client for pickling.
+
+        ``S3Cache`` is dispatched across the cloudpickle boundary into
+        Wool worker processes; botocore's ``BaseClient`` cannot be
+        pickled. ``__setstate__`` rebuilds it via ``_build_s3_client``
+        during unpickling, threading the originally-supplied
+        ``endpoint_url`` / ``region_name`` through so the worker
+        targets the same backend as the API process.
+        """
+        state = self.__dict__.copy()
+        state["_client"] = None
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore state and rebuild the boto3 client on the worker."""
+        self.__dict__.update(state)
+        if self._client is None:
+            self._client = _build_s3_client(
+                endpoint_url=self._endpoint_url,
+                region_name=self._region_name,
+            )
+
+    async def head(self, key: str) -> Optional[CacheEntry]:
+        """Return cache metadata for ``key``, or None if the object is absent.
+
+        ``ClientError`` covers HTTP-level S3 errors with structured
+        response codes; ``BotoCoreError`` covers transport / cred
+        failures with no ``.response``. ``_is_not_found`` returns
+        False for the latter family, so transport failures correctly
+        re-raise rather than masquerade as cache miss.
+
+        Note: S3 ``HEAD`` responses carry no body, so a missing
+        bucket is indistinguishable from a missing object at this
+        endpoint — both surface as a bare ``404``. The lifespan
+        startup probes the bucket separately (see
+        ``check_s3_bucket_or_raise``) so a typo in
+        ``WORKFLOW_S3_BUCKET`` fails fast at boot rather than as a
+        cascade of "permanent cache miss" symptoms.
+        """
+        object_key = self._object_key(key)
+        try:
+            response = await asyncio.to_thread(
+                self._client.head_object,
+                Bucket=self._bucket,
+                Key=object_key,
+            )
+        except (ClientError, BotoCoreError) as exc:
+            if _is_not_found(exc):
+                return None
+            raise
+        return CacheEntry(key=key, size=int(response["ContentLength"]))
+
+    def get(
+        self, key: str, byte_range: Optional[tuple[int, int]] = None
+    ) -> AsyncIterator[bytes]:
+        """Stream cached bytes from S3, optionally restricted to a byte range.
+
+        ``GetObject`` accepts an inclusive ``Range`` header; we forward
+        the tuple verbatim. A missing object yields an empty iterator,
+        matching ``LocalFsCache`` semantics so router code can treat
+        cache misses uniformly across backends.
+        """
+        return _stream_s3_object(
+            self._client,
+            self._bucket,
+            self._object_key(key),
+            byte_range,
+            self._chunk_size,
+        )
+
+    async def put(self, key: str, source_path: Path) -> CacheEntry:
+        """Upload ``source_path`` to S3 under the configured key.
+
+        ``upload_file`` is atomic from the reader's perspective —
+        readers either see the prior object (if any) or the new one,
+        never a partial write. Boto3 streams the file in a thread so
+        the event loop isn't blocked. Size is taken from the source
+        file rather than a follow-up ``HEAD`` to avoid the round-trip.
+
+        When the source file has been torn down between upload
+        completion and the local ``stat`` (workdir cleanup races
+        finalization), we fall back to a ``head_object`` round-trip
+        rather than surface ``FileNotFoundError`` for an upload that
+        is already committed.
+        """
+        object_key = self._object_key(key)
+        await asyncio.to_thread(
+            self._client.upload_file,
+            str(source_path),
+            self._bucket,
+            object_key,
+        )
+        try:
+            size = await asyncio.to_thread(source_path.stat)
+        except FileNotFoundError:
+            try:
+                response = await asyncio.to_thread(
+                    self._client.head_object,
+                    Bucket=self._bucket,
+                    Key=object_key,
+                )
+            except (ClientError, BotoCoreError) as head_exc:
+                raise RuntimeError(
+                    f"S3Cache.put: source file vanished post-upload and "
+                    f"head_object follow-up failed for {object_key!r}"
+                ) from head_exc
+            return CacheEntry(key=key, size=int(response["ContentLength"]))
+        return CacheEntry(key=key, size=size.st_size)
+
+    async def delete(self, key: str) -> bool:
+        """Delete the cache entry. Returns True when the object existed.
+
+        ``DeleteObject`` returns 204 whether or not the key existed, so
+        we probe with HEAD first to give callers the existence signal.
+        The HEAD/DELETE pair is non-atomic — a concurrent ``put`` between
+        them returns ``False`` ("did not exist") yet erases the freshly-
+        uploaded object. Callers MUST serialize ``put``/``delete`` for the
+        same key via the workflow mutex; the cache backend itself does
+        not arbitrate concurrent writers.
+
+        Non-404 ``ClientError`` / ``BotoCoreError`` from the underlying
+        ``head_object`` probe propagate; the boolean return is only
+        meaningful when the probe succeeds.
+        """
+        object_key = self._object_key(key)
+        existed = await self.head(key) is not None
+        await asyncio.to_thread(
+            self._client.delete_object,
+            Bucket=self._bucket,
+            Key=object_key,
+        )
+        return existed
+
+
+def _build_s3_client(
+    *, endpoint_url: Optional[str] = None, region_name: Optional[str] = None
+) -> Any:
+    """Construct a boto3 ``s3`` client with explicit endpoint/region.
+
+    The caller (typically :class:`S3Cache` or the API lifespan) is the
+    single source of truth for ``endpoint_url`` and ``region_name``;
+    this function does not consult :mod:`cfdb.api` for fallback
+    values. Leave both ``None`` to let boto3's default session
+    resolver chain pick them up from the environment.
+    """
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        region_name=region_name,
+    )
+
+
+async def check_s3_bucket_or_raise(bucket: str, *, client: Optional[Any] = None) -> None:
+    """Verify ``bucket`` is reachable; raise on missing/inaccessible.
+
+    Run from the API lifespan so a typo in ``WORKFLOW_S3_BUCKET`` (or
+    a missing IAM grant) fails fast at boot rather than masquerading
+    as a permanent cache-miss cascade once workflows start. ``HEAD``
+    on a missing bucket returns a bare ``404`` that ``S3Cache.head``
+    cannot distinguish from a missing object — this probe asks
+    ``head_bucket`` directly, which gets a structured response.
+    """
+    cli = client if client is not None else _build_s3_client()
+    try:
+        await asyncio.to_thread(cli.head_bucket, Bucket=bucket)
+    except (ClientError, BotoCoreError) as exc:
+        raise RuntimeError(
+            f"S3 bucket {bucket!r} is not reachable: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+#: Object-level "missing" codes only. ``NoSuchBucket`` is deliberately
+#: NOT in this set: a missing bucket is a configuration failure (typo
+#: in WORKFLOW_S3_BUCKET, missing IAM, region mismatch) that should
+#: surface as an exception rather than silently masquerade as a
+#: permanent cache miss.
+_NOT_FOUND_CODES = frozenset({"404", "NoSuchKey", "NotFound"})
+
+
+def _is_not_found(exc: BaseException) -> bool:
+    """Return True when a boto3 exception indicates a missing object.
+
+    ``ClientError`` carries a structured ``response`` dict with both an
+    ``Error.Code`` (string) and ``ResponseMetadata.HTTPStatusCode``
+    (int). We check both: head_object responses use the bare 404 code,
+    get_object uses the named ``NoSuchKey``. ``BotoCoreError`` (network
+    / credential failures) has no ``response`` and is correctly
+    classified as not-a-not-found, so it propagates.
+    """
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return False
+    code = (response.get("Error") or {}).get("Code")
+    if code in _NOT_FOUND_CODES:
+        return True
+    # S3 returns HTTP 404 with ``Error.Code = "NoSuchBucket"`` for a
+    # missing bucket. The status-code fallback below would otherwise undo
+    # the allowlist's deliberate exclusion of ``NoSuchBucket`` — keep
+    # configuration failures loud.
+    if code == "NoSuchBucket":
+        return False
+    status = (response.get("ResponseMetadata") or {}).get("HTTPStatusCode")
+    return status == 404
+
+
+async def _await_close(close: Any) -> None:
+    """Run ``close`` in a worker thread and wait for it under cancellation.
+
+    ``asyncio.shield`` keeps the close-thread's task uncancelled, but a
+    cancel of the surrounding await leaves the future unretrieved (logs
+    "exception was never retrieved" and "Task was destroyed but it is
+    pending" on loop shutdown). Loop until the task finishes, swallowing
+    intermediate cancels; re-raise once at the end so the cancel still
+    propagates to the caller after the FD/connection release completes.
+    """
+    close_task = asyncio.ensure_future(asyncio.to_thread(close))
+    cancelled = False
+    while not close_task.done():
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            cancelled = True
+    if cancelled:
+        raise asyncio.CancelledError
+
+
+async def _stream_s3_object(
+    client: Any,
+    bucket: str,
+    object_key: str,
+    byte_range: Optional[tuple[int, int]],
+    chunk_size: int,
+) -> AsyncIterator[bytes]:
+    """Async generator yielding chunks from an S3 object.
+
+    Diverges from ``_stream_file`` on mid-stream object disappearance:
+    a deletion between the ``GetObject`` response and the body read
+    raises a ``ClientError`` to the consumer rather than truncating
+    silently. Callers serialize put/delete via the workflow mutex
+    (see ``S3Cache.delete``), so the divergence is benign in practice.
+    """
+    kwargs: dict[str, Any] = {"Bucket": bucket, "Key": object_key}
+    if byte_range is not None:
+        start, end = byte_range
+        if start < 0 or end < start:
+            raise ValueError(
+                f"byte_range must satisfy 0 <= start <= end; got {byte_range!r}"
+            )
+        kwargs["Range"] = f"bytes={start}-{end}"
+    try:
+        response = await asyncio.to_thread(client.get_object, **kwargs)
+    except (ClientError, BotoCoreError) as exc:
+        if _is_not_found(exc):
+            return
+        raise
+    body = response["Body"]
+    try:
+        while True:
+            chunk = await asyncio.to_thread(body.read, chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        close = getattr(body, "close", None)
+        if close is not None:
+            await _await_close(close)
 
 
 async def _stream_file(
@@ -188,4 +546,4 @@ async def _stream_file(
                 remaining -= len(chunk)
             yield chunk
     finally:
-        await asyncio.to_thread(fh.close)
+        await _await_close(fh.close)

--- a/src/cfdb/workflows/constants.py
+++ b/src/cfdb/workflows/constants.py
@@ -1,0 +1,17 @@
+"""Constants shared across cfdb.workflows.* modules.
+
+Lives in its own leaf module so ``discovery`` can read
+``DEFAULT_WORKER_PORT`` without importing ``worker_main`` — importing
+``worker_main`` would drag aiohttp into ``discovery``'s import graph
+and impose a runtime dependency that none of ``discovery``'s actual
+consumers (the API lifespan, tests) need.
+"""
+
+from __future__ import annotations
+
+#: Wool gRPC port the worker container binds and clients dial.
+#: ``EcsDiscovery`` uses it to assemble worker addresses;
+#: ``worker_main`` uses it as the bind port. The two MUST agree, and
+#: the ECS task definition's ``portMappings`` / ``healthCheck`` target
+#: MUST match.
+DEFAULT_WORKER_PORT = 50051

--- a/src/cfdb/workflows/discovery.py
+++ b/src/cfdb/workflows/discovery.py
@@ -1,0 +1,598 @@
+"""Worker discovery driven by the ECS control plane.
+
+ECS already owns the lifecycle of every worker task — registration, IP,
+status, health — so we use it as the discovery substrate directly rather
+than maintaining a parallel registry. ``EcsDiscovery`` implements Wool's
+``DiscoveryLike`` protocol with a poll-and-diff loop:
+
+1. ``ecs.list_tasks`` enumerates every task in the cluster matching the
+   worker task family with ``desiredStatus="RUNNING"``.
+2. ``ecs.describe_tasks`` (batched 100 ARNs at a time) hydrates each
+   into its full state, including ``healthStatus`` and ``attachments``.
+3. We filter for ``lastStatus == "RUNNING"`` and (where reported)
+   ``healthStatus == "HEALTHY"`` — tasks whose container definition
+   omits a ``healthCheck`` are accepted as healthy so a deployment that
+   hasn't yet wired up health checks still surfaces workers.
+4. The poller diffs the resolved set against the previous one and
+   publishes ``worker-added`` / ``worker-dropped`` events to a Wool
+   ``DiscoveryPublisherLike``.
+
+The worker side does nothing for discovery — no heartbeat thread, no
+Mongo write, no registration RPC. ECS reports ``healthStatus: HEALTHY``
+once the container's health check passes, which is the "ready to
+dispatch" signal the discovery filters on. The worker task definition
+MUST declare a ``healthCheck`` against the gRPC port; without one
+ECS reports ``healthStatus: UNKNOWN`` indefinitely and the worker is
+never advertised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import AsyncIterator, Iterable
+from typing import Any, Optional
+
+from wool.runtime.discovery.base import (
+    Discovery,
+    DiscoveryEvent,
+    DiscoveryEventType,
+    DiscoveryPublisherLike,
+    DiscoverySubscriberLike,
+    PredicateFunction,
+    WorkerMetadata,
+)
+
+from cfdb.workflows.constants import DEFAULT_WORKER_PORT
+from cfdb.workflows.provisioner import build_ecs_client
+
+logger = logging.getLogger(__name__)
+
+#: ECS ``DescribeTasks`` accepts up to 100 ARNs per call.
+_DESCRIBE_BATCH_SIZE = 100
+
+#: Default poll cadence. ``ListTasks`` and ``DescribeTasks`` are
+#: subject to the ECS cluster-read API quota (see AWS Service Quotas
+#: page "Rate of cluster resource read API calls"). 5s leaves ample
+#: headroom for many concurrent clusters.
+DEFAULT_POLL_INTERVAL_SECONDS = 5.0
+
+
+class EcsDiscovery(Discovery):
+    """Wool-compatible discovery service backed by ECS list/describe.
+
+    Args:
+        cluster: ECS cluster name or ARN to poll.
+        task_definition_family: Worker task definition family (sans
+            revision). Used as the ``family`` filter on ``ListTasks``.
+        client: Optional pre-built boto3 ``ecs`` client. When omitted,
+            one is constructed via :func:`build_ecs_client` with the
+            ``endpoint_url`` / ``region_name`` kwargs threaded through.
+        endpoint_url: Boto3 ``endpoint_url``. Passed to
+            :func:`build_ecs_client` when ``client`` is omitted. The
+            API lifespan threads its configured AWS endpoint here.
+        region_name: Boto3 ``region_name``. Plumbed analogously.
+        poll_interval: Seconds between successive ``ListTasks`` polls.
+        worker_port: gRPC port the worker binds — used to construct
+            the address string passed to Wool. Shares the worker_main
+            default so a deployment that changes one changes both.
+        version: Wool worker version string passed through into
+            ``WorkerMetadata``. Free-form; useful for filtering.
+
+    Lifecycle: enter ``async with EcsDiscovery(...)`` to start the
+    background poller. Exiting the context cancels the poller and
+    releases the publisher.
+    """
+
+    def __init__(
+        self,
+        *,
+        cluster: str,
+        task_definition_family: str,
+        client: Optional[Any] = None,
+        endpoint_url: Optional[str] = None,
+        region_name: Optional[str] = None,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+        worker_port: int = DEFAULT_WORKER_PORT,
+        version: str = "0",
+    ) -> None:
+        if not cluster:
+            raise ValueError("EcsDiscovery requires a cluster name")
+        if not task_definition_family:
+            raise ValueError("EcsDiscovery requires a task_definition_family")
+        if poll_interval <= 0:
+            raise ValueError("poll_interval must be positive")
+        if client is not None and (endpoint_url or region_name):
+            raise ValueError(
+                "EcsDiscovery: pass either client or endpoint_url/region_name, "
+                "not both — the boto kwargs are silently ignored when client is set"
+            )
+
+        self._cluster = cluster
+        self._task_definition_family = task_definition_family
+        self._client = (
+            client
+            if client is not None
+            else build_ecs_client(endpoint_url=endpoint_url, region_name=region_name)
+        )
+        self._poll_interval = poll_interval
+        self._worker_port = worker_port
+        self._version = version
+
+        self._subscribers: list[_EcsSubscriber] = []
+        self._known: dict[str, WorkerMetadata] = {}
+        self._poll_task: Optional[asyncio.Task[None]] = None
+        #: Guards ``_subscribers`` / ``_known`` / ``_closed`` and the
+        #: sentinel-push fan-out during ``__aexit__``. Held only
+        #: across in-memory mutations, never across AWS round-trips.
+        self._state_lock = asyncio.Lock()
+        #: Set inside ``__aexit__`` under ``_state_lock`` so late
+        #: registrations (a subscriber whose ``_register_subscriber``
+        #: was parked on the lock while ``__aexit__`` held it, or a
+        #: fresh registration arriving after exit) receive the
+        #: shutdown sentinel rather than hanging on ``queue.get()``
+        #: forever.
+        self._closed = False
+        #: Serializes the entire ``poll_once`` body so two concurrent
+        #: callers (test fixture + background loop, mostly) cannot
+        #: interleave their list/describe snapshots into the diff and
+        #: regress ``_known``. Separate from ``_state_lock`` so
+        #: subscriber registration is not blocked on the AWS
+        #: round-trip held by an in-flight poll.
+        self._serialize_polls = asyncio.Lock()
+
+    async def __aenter__(self) -> "EcsDiscovery":
+        # Re-entry would orphan the prior poll task and diff against
+        # stale ``_known`` state. ``__aexit__`` nulls ``_poll_task``;
+        # the assert pairs with that to make the misuse loud.
+        assert self._poll_task is None, (
+            "EcsDiscovery context entered twice; create a fresh instance"
+        )
+        # Run an immediate scan so subscribers attached right after
+        # __aenter__ see the initial set of workers without waiting a
+        # full poll interval.
+        await self.poll_once()
+        self._poll_task = asyncio.create_task(self._poll_loop())
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+            self._poll_task = None
+        # Wake any consumer parked on ``await self._queue.get()`` so
+        # ``async for event in subscriber:`` exits cleanly rather than
+        # blocking forever on a queue nothing will publish to again.
+        # ``asyncio.shield`` keeps the cleanup body running even if
+        # ``__aexit__`` itself is cancelled mid-await — without it, a
+        # cancelled exit could skip the sentinel push and leave every
+        # existing subscriber hanging on ``queue.get()``.
+        await asyncio.shield(self._cleanup_subscribers())
+
+    async def _cleanup_subscribers(self) -> None:
+        """Push the shutdown sentinel into every subscriber's queue.
+
+        The sentinel ``None`` is pushed to each subscriber's queue;
+        ``_iter`` breaks out of its loop when it dequeues ``None``.
+        ``_known`` is cleared so a stray re-subscribe after exit
+        doesn't replay stale workers, and ``_closed`` is set so late
+        registrations route via the sentinel path in
+        ``_register_subscriber`` instead of appending.
+
+        Snapshots the subscriber list under the state lock and pushes
+        the sentinels *outside* the lock. ``Queue.put`` on an
+        unbounded queue does not block in practice, but pushing under
+        the lock would still couple the per-subscriber put to lock
+        hold time and order — surfacing the snapshot-then-publish
+        contract structurally avoids that coupling.
+        """
+        async with self._state_lock:
+            self._closed = True
+            subs = list(self._subscribers)
+            self._known.clear()
+            self._subscribers.clear()
+        for sub in subs:
+            await sub._queue.put(None)
+
+    @property
+    def publisher(self) -> DiscoveryPublisherLike:
+        """``EcsDiscovery`` is read-only — workers register implicitly via ECS.
+
+        Returns a guard-rail publisher that raises on ``publish``;
+        production code should never reach for this property.
+        """
+        return _RaisingPublisher()
+
+    @property
+    def subscriber(self) -> DiscoverySubscriberLike:
+        """A subscriber with no filter (sees every healthy worker)."""
+        return self.subscribe()
+
+    def subscribe(
+        self, filter: Optional[PredicateFunction] = None
+    ) -> DiscoverySubscriberLike:
+        """Create a subscriber, optionally filtered by a worker predicate.
+
+        The filter predicate runs inline on the dispatch path while the
+        registration lock is held — keep it cheap and non-blocking.
+        Slow predicates stall delivery to every other subscriber and
+        block concurrent registrations.
+        """
+        return _EcsSubscriber(self, filter)
+
+    async def poll_once(self) -> tuple[list[DiscoveryEvent], dict[str, WorkerMetadata]]:
+        """Run one list/describe cycle and emit diff events.
+
+        Returns the events emitted in this cycle and the resolved set of
+        currently-known healthy workers (keyed by UUID hex string).
+        Callers do not normally need to use the return value — it
+        exists for tests so that polling can be exercised step-by-step
+        without the background loop.
+
+        ``self._serialize_polls`` serializes the entire body so two concurrent
+        callers (test fixture + background loop) cannot interleave
+        their list/describe snapshots into the diff and regress
+        ``_known``. ``self._state_lock`` separately serializes the
+        diff/mutate/dispatch tail against subscriber registration; see
+        the inner ``async with self._state_lock:`` below and
+        ``_register_subscriber`` for the matching critical section.
+
+        On ``list_tasks`` / ``describe_tasks`` failure the previous
+        ``_known`` snapshot is retained — workers added during a multi-
+        cycle ECS outage are invisible until recovery, and workers
+        terminated during the outage continue to be advertised as
+        healthy until the next successful poll. Acceptable degradation
+        next to the cold-start budget; preferable to flapping the whole
+        fleet on a single transient failure.
+        """
+        async with self._serialize_polls:
+            try:
+                arns = await asyncio.to_thread(self._list_task_arns)
+            except Exception:
+                logger.exception(
+                    "EcsDiscovery: list_tasks failed for cluster=%s",
+                    self._cluster,
+                )
+                async with self._state_lock:
+                    return [], dict(self._known)
+
+            resolved: dict[str, WorkerMetadata] = {}
+            if arns:
+                try:
+                    tasks = await asyncio.to_thread(self._describe_tasks_batched, arns)
+                except Exception:
+                    logger.exception(
+                        "EcsDiscovery: describe_tasks failed for cluster=%s",
+                        self._cluster,
+                    )
+                    async with self._state_lock:
+                        return [], dict(self._known)
+                for task in tasks:
+                    metadata = self._task_to_metadata(task)
+                    if metadata is not None:
+                        resolved[str(metadata.uid)] = metadata
+
+            # Diff, mutate, and dispatch under ``self._state_lock`` so a
+            # concurrent ``_register_subscriber`` cannot replay a
+            # snapshot that already contains a freshly-added worker AND
+            # then receive the worker-added event for it from this
+            # dispatch (duplicate delivery). Either the registration
+            # runs entirely before this mutation (replay sees the OLD
+            # known, this dispatch sees the new subscriber) or entirely
+            # after (replay sees the NEW known, this dispatch's events
+            # were already delivered).
+            async with self._state_lock:
+                events = list(_diff(self._known, resolved))
+                self._known = resolved
+                if events:
+                    for sub in self._subscribers:
+                        for event in events:
+                            # A subscriber filter that raises must not
+                            # poison delivery to siblings. ``_known``
+                            # has already been mutated, so a re-throw
+                            # here would permanently drop these events
+                            # for every later subscriber.
+                            try:
+                                sub._publish(event)
+                            except Exception:
+                                logger.warning(
+                                    "EcsDiscovery subscriber filter raised "
+                                    "for event %s; dropping for that "
+                                    "subscriber and continuing",
+                                    event.type,
+                                    exc_info=True,
+                                )
+
+            return events, dict(resolved)
+
+    async def _poll_loop(self) -> None:
+        """Background poll loop. Cancellation-safe."""
+        while True:
+            try:
+                await asyncio.sleep(self._poll_interval)
+                await self.poll_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("EcsDiscovery poll loop iteration failed")
+
+    def _list_task_arns(self) -> list[str]:
+        """Page through ``ListTasks`` and return every task ARN."""
+        arns: list[str] = []
+        paginator_kwargs = {
+            "cluster": self._cluster,
+            "family": self._task_definition_family,
+            "desiredStatus": "RUNNING",
+        }
+        next_token: Optional[str] = None
+        while True:
+            kwargs = dict(paginator_kwargs)
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = self._client.list_tasks(**kwargs)
+            arns.extend(response.get("taskArns") or [])
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+        return arns
+
+    def _describe_tasks_batched(self, arns: list[str]) -> list[dict[str, Any]]:
+        """Call ``DescribeTasks`` in batches of ``_DESCRIBE_BATCH_SIZE``."""
+        out: list[dict[str, Any]] = []
+        for i in range(0, len(arns), _DESCRIBE_BATCH_SIZE):
+            batch = arns[i : i + _DESCRIBE_BATCH_SIZE]
+            response = self._client.describe_tasks(
+                cluster=self._cluster,
+                tasks=batch,
+            )
+            out.extend(response.get("tasks") or [])
+        return out
+
+    def _task_to_metadata(self, task: dict[str, Any]) -> Optional[WorkerMetadata]:
+        """Convert an ECS task description to a Wool ``WorkerMetadata``.
+
+        Returns None when the task is not RUNNING + HEALTHY or we
+        cannot extract a usable IP address. Worker task definitions
+        MUST declare a ``healthCheck``; tasks without one surface as
+        ``healthStatus: UNKNOWN`` and are filtered out, since their
+        gRPC readiness is unknowable. Tasks whose ``healthStatus`` is
+        absent from the describe-tasks response are also filtered —
+        same reason.
+        """
+        if task.get("lastStatus") != "RUNNING":
+            return None
+        if task.get("healthStatus") != "HEALTHY":
+            return None
+
+        ip = _extract_eni_ip(task)
+        if ip is None:
+            return None
+
+        # ECS task ARNs end in ``/<task-id>`` where ``<task-id>`` is a
+        # 32-char hex string. We use it as a stable UUID for the
+        # worker so successive polls produce identical metadata
+        # (otherwise diff would emit add+drop on every cycle). A
+        # missing ARN means we cannot identify the task — drop it
+        # rather than collide every ARN-less task on the same UUID.
+        task_arn = task.get("taskArn") or ""
+        if not task_arn:
+            return None
+        task_id = task_arn.rsplit("/", 1)[-1]
+        try:
+            uid = uuid.UUID(task_id)
+        except (ValueError, AttributeError):
+            uid = uuid.uuid5(uuid.NAMESPACE_URL, task_arn)
+
+        return WorkerMetadata(
+            uid=uid,
+            address=f"{ip}:{self._worker_port}",
+            pid=0,
+            version=self._version,
+        )
+
+    async def _register_subscriber(self, sub: "_EcsSubscriber") -> None:
+        """Append a subscriber and prime its queue with the current snapshot.
+
+        Both steps happen under ``self._state_lock``, paired with
+        ``poll_once`` mutating ``_known`` and dispatching under the
+        same lock: a concurrent poll either runs entirely before the
+        registration (replay sees the OLD ``_known``, the poll's
+        events go to the new subscriber via dispatch) or entirely
+        after (replay sees the NEW ``_known``, no dispatch overlaps).
+        No interleave produces a missed event or a duplicate ``worker-
+        added`` for the same UID.
+
+        Partial snapshots are possible if the consumer task is cancelled
+        mid-replay: the subscriber is appended before the replay loop
+        starts, so a cancel between append and end-of-replay delivers a
+        truncated snapshot. From the consumer's perspective this is
+        consistent with "iteration was cancelled mid-yield"; callers
+        wrapping ``_iter`` in ``asyncio.shield`` should be aware that
+        cancel-during-replay still drops events.
+        """
+        async with self._state_lock:
+            if self._closed:
+                # ``__aexit__`` already ran (or is currently running and
+                # this registration was parked on the lock). Push the
+                # shutdown sentinel so the consumer's ``_iter`` exits
+                # cleanly rather than blocking on a queue nothing else
+                # will publish to.
+                await sub._queue.put(None)
+                return
+            self._subscribers.append(sub)
+            for metadata in self._known.values():
+                sub._publish(DiscoveryEvent("worker-added", metadata=metadata))
+
+    async def _unregister_subscriber(self, sub: "_EcsSubscriber") -> None:
+        """Remove ``sub`` from the subscriber list under the lock.
+
+        Silently ignores already-removed subscribers so the iteration
+        ``finally`` is idempotent.
+        """
+        async with self._state_lock:
+            try:
+                self._subscribers.remove(sub)
+            except ValueError:
+                pass
+
+
+class _EcsSubscriber:
+    """Discovery subscriber backed by an ``asyncio.Queue``.
+
+    The discovery instance pushes events into the queue; consumers
+    iterate via ``async for``. Subscribers are single-use — a second
+    iteration on the same subscriber raises ``RuntimeError``;
+    create a fresh subscriber via ``EcsDiscovery.subscribe()`` instead.
+    """
+
+    def __init__(
+        self,
+        owner: EcsDiscovery,
+        filter: Optional[PredicateFunction],
+    ) -> None:
+        self._owner = owner
+        self._filter = filter
+        #: Discovery events, plus a single ``None`` sentinel that means
+        #: shutdown; the sentinel is written only by
+        #: ``EcsDiscovery.__aexit__`` to wake consumers parked on
+        #: ``get()``.
+        self._queue: asyncio.Queue[Optional[DiscoveryEvent]] = asyncio.Queue()
+        self._exhausted = False
+
+    def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
+        return self._iter()
+
+    def _publish(self, event: DiscoveryEvent) -> None:
+        """Deliver ``event`` to the subscriber's queue, or drop it.
+
+        Synchronous because the queue is unbounded and ``put_nowait``
+        suffices — making the call ``await``-free removes a future-bug
+        surface where a maintainer could otherwise inject a yield
+        point into the dispatch loop and reorder events relative to
+        subsequent state mutations under :data:`_state_lock`. The
+        filter (if any) runs inline; events that don't pass it are
+        dropped silently — the subscriber asked not to see this
+        worker.
+        """
+        if self._filter is not None and not self._filter(event.metadata):
+            return
+        self._queue.put_nowait(event)
+
+    async def _iter(self) -> AsyncIterator[DiscoveryEvent]:
+        """Yield discovery events for the lifetime of this subscriber.
+
+        Single-use: a second call after the iterator has been consumed
+        raises ``RuntimeError``. ``EcsDiscovery.subscribe()`` returns
+        a fresh subscriber per call, so multiple independent consumers
+        are supported by creating multiple subscribers.
+
+        Registers with the owning discovery on the first iteration so
+        the snapshot of currently-known workers is replayed before
+        any new poll events arrive. The ``finally`` always
+        unregisters — ``_unregister_subscriber`` silently ignores
+        already-removed entries, so a partial-registration failure
+        does not leak a stale subscriber.
+
+        ``self._exhausted`` flips synchronously (no ``await`` before
+        line 513), so any subsequent ``__anext__()`` on a second
+        iterator created from the same subscriber observes the flag
+        and raises before re-registering. Covers the framework-
+        introspection case where ``aiter()`` is called before any
+        actual iteration.
+        """
+        if self._exhausted:
+            raise RuntimeError(
+                "EcsDiscovery subscriber already iterated; "
+                "call EcsDiscovery.subscribe() for a fresh one"
+            )
+        self._exhausted = True
+        try:
+            await self._owner._register_subscriber(self)
+            while True:
+                event = await self._queue.get()
+                if event is None:
+                    # Sentinel from ``EcsDiscovery.__aexit__``; exit
+                    # cleanly so the consumer's ``async for`` ends.
+                    break
+                yield event
+        finally:
+            await self._owner._unregister_subscriber(self)
+
+
+class _RaisingPublisher:
+    """Guard-rail publisher returned by ``EcsDiscovery.publisher``.
+
+    ECS owns worker lifecycle, so nothing in cfdb has cause to call
+    ``publish``; raising here surfaces the misuse loudly rather than
+    silently no-op'ing.
+    """
+
+    #: Required by ``DiscoveryPublisherLike`` (wool >=0.9.2): the host a
+    #: pool spawning workers for this discovery would bind them to. Purely
+    #: declarative here — ``EcsDiscovery`` never spawns or publishes, so
+    #: wool never reads it. ``0.0.0.0`` matches what the ECS worker
+    #: entrypoint actually binds (``worker_main`` -> ``LocalWorker(host=
+    #: "0.0.0.0")``), keeping the value truthful rather than arbitrary.
+    bind_host: str = "0.0.0.0"
+
+    async def publish(
+        self, type: DiscoveryEventType, metadata: WorkerMetadata
+    ) -> None:
+        raise RuntimeError(
+            "EcsDiscovery is read-only — workers register implicitly via ECS"
+        )
+
+
+def _extract_eni_ip(task: dict[str, Any]) -> Optional[str]:
+    """Return the awsvpc private IPv4 from an ECS task description.
+
+    ECS attaches one ENI per Fargate awsvpc task; its ``details`` list
+    carries a ``privateIPv4Address`` entry. Older API responses use
+    ``networkInterfaces`` on each container instead — we honor either.
+    When both forms are populated the ``attachments`` value wins; for
+    Fargate awsvpc both report the same IP, so the precedence is
+    moot in practice.
+    """
+    for attachment in task.get("attachments") or []:
+        if attachment.get("type") not in (None, "ElasticNetworkInterface"):
+            continue
+        for detail in attachment.get("details") or []:
+            if detail.get("name") == "privateIPv4Address" and detail.get("value"):
+                return detail["value"]
+    for container in task.get("containers") or []:
+        for nic in container.get("networkInterfaces") or []:
+            ipv4 = nic.get("privateIpv4Address")
+            if ipv4:
+                return ipv4
+    return None
+
+
+def _diff(
+    cached: dict[str, WorkerMetadata],
+    discovered: dict[str, WorkerMetadata],
+) -> Iterable[DiscoveryEvent]:
+    """Yield Wool events describing the cached→discovered transition.
+
+    The ``worker-updated`` branch below is dead code on ECS Fargate
+    today: the UID is derived from the task ARN suffix (unique per
+    task instance), and an ECS task's IP cannot change during its
+    lifetime. The branch is preserved for parity with Wool's
+    ``LocalDiscovery`` so the diff contract stays uniform across
+    backends — a future ECS update that re-uses ARNs or supports
+    IP migration would hit this path and we want the dispatch
+    semantics to already be correct.
+    """
+    for uid, metadata in discovered.items():
+        if uid not in cached:
+            yield DiscoveryEvent("worker-added", metadata=metadata)
+        elif cached[uid].address != metadata.address:
+            # Protocol-parity guard: not reachable on ECS Fargate
+            # today; see module-level note in _diff's docstring.
+            yield DiscoveryEvent("worker-updated", metadata=metadata)
+    for uid, metadata in cached.items():
+        if uid not in discovered:
+            yield DiscoveryEvent("worker-dropped", metadata=metadata)

--- a/src/cfdb/workflows/events.py
+++ b/src/cfdb/workflows/events.py
@@ -1,0 +1,68 @@
+"""Typed events streamed from a processor to the executor.
+
+Processors yield these objects (rather than raw ``{"event": ...}`` dicts)
+so the processor-to-executor wire contract is explicit and type-checked,
+and the executor matches on type instead of parsing stringly-typed dicts.
+
+These cross the Wool cloudpickle boundary as the routine's stream values,
+so they MUST live in this stable module — never in a ``test_*`` module —
+for cloudpickle to resolve them by reference on the worker side (the same
+constraint that keeps cross-boundary stubs in ``tests/integration/routines.py``).
+Plain frozen dataclasses pickle by value without help.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cfdb.workflows.models import ArtifactKind
+
+
+@dataclass(frozen=True)
+class StageComplete:
+    """A pipeline stage finished and committed its artifact to the cache.
+
+    Emitted after each ``cache.put`` so the executor can persist
+    ``stages_done`` / ``artifact_cache_keys`` incrementally. ``key`` is the
+    cache key the processor wrote under — derived via the same
+    ``Processor.cache_key_for`` the router probes with, so the two agree by
+    construction.
+    """
+
+    kind: ArtifactKind
+    key: str
+
+
+@dataclass(frozen=True)
+class Complete:
+    """Terminal success: the full artifact-kind-value -> cache-key map."""
+
+    artifacts: dict[str, str]
+
+
+@dataclass(frozen=True)
+class Progress:
+    """Human-readable progress hint for ``JobRecord.progress``."""
+
+    value: str
+
+
+@dataclass(frozen=True)
+class Heartbeat:
+    """Liveness signal injected by the routine wrapper during quiet stages.
+
+    Lets the API refresh ``JobRecord.updated_at`` without the worker
+    touching Mongo. Never emitted by processors themselves.
+    """
+
+
+@dataclass(frozen=True)
+class Error:
+    """Terminal failure carrying the exception type name and message."""
+
+    type: str
+    error: str
+
+
+#: Union of every event a processor stream (wrapped by the routine) yields.
+WorkflowEvent = StageComplete | Complete | Progress | Heartbeat | Error

--- a/src/cfdb/workflows/executor.py
+++ b/src/cfdb/workflows/executor.py
@@ -53,6 +53,14 @@ from cfdb.workflows import (
     keys as key_utils,
 )
 from cfdb.workflows.cache import CacheBackend
+from cfdb.workflows.events import (
+    Complete,
+    Error,
+    Heartbeat,
+    Progress,
+    StageComplete,
+    WorkflowEvent,
+)
 from cfdb.workflows.lock import (
     claim_workflow,
     heartbeat_workflow,
@@ -61,9 +69,10 @@ from cfdb.workflows.lock import (
     release_workflow,
     update_progress,
 )
-from cfdb.workflows.models import ArtifactKind, JobRecord, JobStatus
+from cfdb.workflows.models import JobRecord, JobStatus
 from cfdb.workflows.processors.base import Processor
 from cfdb.workflows.processors.registry import ProcessorRegistry
+from cfdb.workflows.provisioner import EcsProvisioner, RetryableProvisionerError
 
 logger = logging.getLogger(__name__)
 
@@ -72,11 +81,29 @@ logger = logging.getLogger(__name__)
 #: change to the workflow orchestration itself).
 PIPELINE_VERSION = 1
 
-#: Default job-runtime cap. 20 minutes covers a sort+index on a multi-GB
-#: BAM comfortably; exceptional files that need longer should be
-#: addressed individually. Sourced from the env var so deployments can
-#: override without a code change.
-DEFAULT_WORKFLOW_DURATION_CAP_SECONDS = WORKFLOW_DURATION_CAP_S
+#: Job-runtime cap. 4 hours covers multi-hour preprocessing runs (e.g.,
+#: a ``samtools sort`` on a multi-GB BAM followed by ``samtools index``);
+#: exceptional files that need longer should be addressed individually.
+#: Sourced from ``CFDB_WORKFLOW_DURATION_CAP_S`` (default 14400 s = 4 h)
+#: so deployments can override without a code change. Module-level
+#: rather than a ctor kwarg because tests cap it via ``monkeypatch.setattr``
+#: alongside the other dispatch knobs (``_DISPATCH_WAIT_SECONDS``,
+#: ``_HEARTBEAT_INTERVAL_S``) and uniform module-state keeps fixture
+#: shape consistent.
+_WORKFLOW_DURATION_CAP_SECONDS = WORKFLOW_DURATION_CAP_S
+
+#: Persisted ``error`` prefix surfaced to clients when the dispatch
+#: budget is exhausted with no workers available. The prefix is part
+#: of the on-wire contract — clients parse it to decide whether to
+#: resubmit. Kept as a module constant so tests can import the same
+#: symbol the executor writes.
+_ERR_PREFIX_CAPACITY = "capacity:"
+
+#: Persisted ``error`` prefix surfaced to clients when the provisioner
+#: itself raises a non-retryable exception. Distinct from
+#: :data:`_ERR_PREFIX_CAPACITY` so clients can tell "retry me later,
+#: capacity issue" apart from "the provisioner crashed".
+_ERR_PREFIX_PROVISIONER = "provisioner:"
 
 #: Total wall-clock budget waiting for a leased worker to surface during
 #: dispatch. Sized for an ECS cold start (target ~30-90s on Fargate) so a
@@ -96,6 +123,19 @@ _DISPATCH_RETRY_INTERVAL_SECONDS = 1.0
 #: refreshes ``JobRecord.updated_at`` on each heartbeat so a healthy
 #: long-running stage doesn't get reclaimed as stale.
 _HEARTBEAT_INTERVAL_S = float(WORKFLOW_HEARTBEAT_INTERVAL_S)
+
+#: Grace given to ``_finalize`` tasks during ``drain``'s second phase
+#: after the primary ``_pending_tasks`` gather is done. A workflow that
+#: failed mid-write — Mongo connection blip, S3 cache cleanup blocked
+#: on a slow workdir rmtree — gets this long for its ``release_workflow``
+#: write and ``shutil.rmtree`` to land before the lifespan teardown
+#: closes the Motor client. ``release_workflow`` not completing within
+#: the grace is *recoverable*: the row stays at ``RUNNING`` and
+#: stale-reclamation on next service start releases it as FAILED.
+#: Tuning above ~3s would protect more cases but stretches the lifespan
+#: shutdown budget; operators that want tighter coupling should pair an
+#: increase here with a matching decrease in ``STALE_WORKFLOW_THRESHOLD``.
+_FINALIZE_DRAIN_GRACE_SECONDS = 3.0
 
 
 class WorkflowNotApplicable(ValueError):
@@ -143,27 +183,36 @@ async def _run_processor_routine(
     processor: Processor,
     file_meta: dict[str, Any],
     workdir_str: str,
-    cache_root_str: str,
-) -> AsyncIterator[dict[str, Any]]:
+    cache: CacheBackend,
+) -> AsyncIterator[WorkflowEvent]:
     """Wool routine body: stream processor events back to the dispatcher.
 
     The processor itself is an async generator that yields
-    ``stage_complete`` and ``complete`` events. We wrap its stream with a
-    heartbeat-aware iterator: while waiting on the next event from the
-    processor, every ``_HEARTBEAT_INTERVAL_S`` we inject a
-    ``{"event": "heartbeat"}`` so the API process can refresh
-    ``JobRecord.updated_at`` and signal liveness without requiring the
-    worker to touch Mongo. An exception from the processor is converted
-    to an ``{"event": "error", ...}`` event so the API consumer can
-    record a clean terminal state.
+    :class:`~cfdb.workflows.events.StageComplete` and
+    :class:`~cfdb.workflows.events.Complete` events. We wrap its stream
+    with a heartbeat-aware iterator: while waiting on the next event from
+    the processor, every ``_HEARTBEAT_INTERVAL_S`` we inject a
+    :class:`~cfdb.workflows.events.Heartbeat` so the API process can
+    refresh ``JobRecord.updated_at`` and signal liveness without requiring
+    the worker to touch Mongo. An exception from the processor is
+    converted to an :class:`~cfdb.workflows.events.Error` event so the API
+    consumer can record a clean terminal state.
 
     Arguments are cloudpickle-serializable: ``processor`` is a stateless
     class instance, ``file_meta`` is a plain dict (B1 strips Mongo's
-    ``_id``), and path arguments cross as strings.
+    ``_id``), ``workdir_str`` crosses as a string, and ``cache`` is the
+    configured :class:`CacheBackend` itself — ``LocalFsCache`` carries
+    only its root ``Path``; ``S3Cache`` drops its boto3 client in
+    ``__getstate__`` and rebuilds it on the worker in ``__setstate__``.
+    Handing the real backend across (rather than a bare cache-root path
+    the worker would wrap in a ``LocalFsCache``) is what lets the
+    S3/ECS profile persist artifacts to the shared S3 store the API
+    reads from; otherwise the worker writes to its own local disk and
+    the API's ``cache.head`` never finds the artifact.
     """
     workdir = Path(workdir_str)
     workdir.mkdir(parents=True, exist_ok=True)
-    inner = processor.run(file_meta, workdir, Path(cache_root_str)).__aiter__()
+    inner = processor.run(file_meta, workdir, cache).__aiter__()
     next_task: Optional[asyncio.Task] = None
     try:
         while True:
@@ -180,7 +229,7 @@ async def _run_processor_routine(
                     )
                     break
                 except asyncio.TimeoutError:
-                    yield {"event": "heartbeat"}
+                    yield Heartbeat()
                 except StopAsyncIteration:
                     # ``wait_for`` re-raises whatever the underlying
                     # task raised. Per PEP 479 a StopAsyncIteration
@@ -201,11 +250,7 @@ async def _run_processor_routine(
                 # API process records a clean FAILED status. Re-raising
                 # would interleave with wool's exception-streaming path
                 # and yields a less specific error string to /jobs/{id}.
-                yield {
-                    "event": "error",
-                    "type": type(exc).__name__,
-                    "error": str(exc),
-                }
+                yield Error(type=type(exc).__name__, error=str(exc))
                 return
             next_task = None
             yield event
@@ -223,27 +268,57 @@ async def _run_processor_routine(
 
 
 class WoolExecutor(JobExecutor):
-    """Executor backed by a ``wool.WorkerPool`` and a Mongo jobs collection."""
+    """Executor backed by a ``wool.WorkerPool`` and a Mongo jobs collection.
+
+    When configured with an :class:`EcsProvisioner`, the executor also
+    issues a ``RunTask`` on each fresh claim before opening the routine
+    stream, so a Fargate worker boots before the dispatch retry loop
+    begins polling for it. Without a provisioner (PoC dev profile) the
+    executor relies on workers already published into the discovery
+    namespace.
+
+    A :class:`RetryableProvisionerError` from the provisioner surfaces
+    as a terminal ``FAILED`` job with a ``capacity:``-prefixed error
+    string; any other provisioner failure surfaces with a
+    ``provisioner:`` prefix. Clients parse the prefix to decide
+    whether to resubmit.
+
+    Args:
+        db: Motor database handle holding the ``jobs`` collection.
+        cache: Cache backend for processor artifacts. The executor
+            hands this backend across the Wool boundary to the worker so
+            processors persist artifacts to the deployment's real store
+            (local FS or S3), not a worker-local filesystem.
+        registry: Processor registry mapping artifact kinds to runners.
+        workdir_root: Parent directory under which per-job workdirs land.
+        pipeline_version: Embedded in workflow keys; bump to invalidate
+            every in-flight workflow.
+        provisioner: Optional :class:`EcsProvisioner`. When ``None``
+            (PoC profile), no ``RunTask`` is issued and dispatch
+            relies on pre-existing workers.
+
+    The per-workflow wall-clock cap is module-level
+    (:data:`_WORKFLOW_DURATION_CAP_SECONDS`) so it monkey-patches the
+    same way as the other dispatch-tier knobs.
+    """
 
     def __init__(
         self,
         db,
         cache: CacheBackend,
-        cache_root: Path,
         registry: ProcessorRegistry,
         *,
         workdir_root: Path,
         pipeline_version: int = PIPELINE_VERSION,
-        workflow_duration_cap_seconds: int = DEFAULT_WORKFLOW_DURATION_CAP_SECONDS,
+        provisioner: Optional[EcsProvisioner] = None,
     ) -> None:
         self._db = db
         self._cache = cache
-        self._cache_root = Path(cache_root)
         self._registry = registry
         self._workdir_root = Path(workdir_root)
         self._workdir_root.mkdir(parents=True, exist_ok=True)
         self._pipeline_version = pipeline_version
-        self._workflow_duration_cap_seconds = workflow_duration_cap_seconds
+        self._provisioner = provisioner
         self._pending_tasks: set[asyncio.Task] = set()
         #: Finalize tasks (release_workflow + workdir cleanup) created by
         #: _run_workflow's `finally`. Tracked separately so drain() can
@@ -287,7 +362,9 @@ class WoolExecutor(JobExecutor):
         )
 
         if fresh:
-            task = asyncio.create_task(self._run_workflow(record, processor, file_meta))
+            task = asyncio.create_task(
+                self._run_workflow(record, processor, file_meta)
+            )
             self._pending_tasks.add(task)
             task.add_done_callback(self._pending_tasks.discard)
             task.add_done_callback(_log_unexpected_exception)
@@ -337,16 +414,17 @@ class WoolExecutor(JobExecutor):
                 await asyncio.gather(*pending, return_exceptions=True)
 
         # Second phase: await any finalize tasks that the cancellation
-        # path may have left running under their shield. Bounded by a
-        # short grace so a stuck Mongo write doesn't hold up shutdown
-        # indefinitely; tasks not done after this are abandoned, and
-        # their jobs will be reclaimed as stale on next service start.
+        # path may have left running under their shield. Bounded by
+        # ``_FINALIZE_DRAIN_GRACE_SECONDS`` so a stuck Mongo write
+        # doesn't hold up shutdown indefinitely; tasks not done after
+        # this are abandoned, and their jobs will be reclaimed as
+        # stale on next service start.
         finalize_pending = list(self._finalize_tasks)
         if finalize_pending:
             with contextlib.suppress(Exception):
                 await asyncio.wait_for(
                     asyncio.gather(*finalize_pending, return_exceptions=True),
-                    timeout=3.0,
+                    timeout=_FINALIZE_DRAIN_GRACE_SECONDS,
                 )
         return len(pending)
 
@@ -389,6 +467,56 @@ class WoolExecutor(JobExecutor):
                 final_error = f"mark_running failed: {exc}"
                 return
 
+            # Request a worker via the external provisioner (e.g. ECS
+            # ``RunTask``) before opening the routine stream. The
+            # provisioner dedup-keys on the workflow mutex so two
+            # concurrent fresh claims for the same source file
+            # share one ``RunTask`` and one worker.
+            #
+            # ``RetryableProvisionerError`` is treated as a best-effort
+            # scale-up failure, not a workflow-level failure: the Wool
+            # pool routes ``@wool.routine`` calls to *any* available
+            # worker via the discovery namespace, so an existing idle
+            # worker can still service this job. Log a warning and fall
+            # through to ``_open_stream_with_retry``; the
+            # ``capacity:``-prefixed terminal status is reserved for the
+            # case where dispatch *also* exhausts its budget with no
+            # workers available.
+            if self._provisioner is not None:
+                try:
+                    await self._provisioner.request(dedup_key=record.workflow_key)
+                except asyncio.CancelledError:
+                    final_error = "Workflow cancelled (worker shutdown)"
+                    raise
+                except RetryableProvisionerError as exc:
+                    logger.warning(
+                        "Provisioner reported retryable capacity error for %s; "
+                        "falling through to dispatch against existing workers: %s",
+                        record.job_id,
+                        exc,
+                    )
+                except Exception as exc:
+                    logger.exception(
+                        "Provisioner request failed for %s", record.job_id
+                    )
+                    final_error = f"{_ERR_PREFIX_PROVISIONER} {exc}"
+                    return
+                # Bound the stale-reclaim window across the provisioner
+                # round-trip: ``mark_running`` ran before
+                # ``provisioner.request`` and a Fargate cold start can
+                # plausibly exceed STALE_WORKFLOW_THRESHOLD. Heartbeat
+                # so the row stays fresh through the upcoming dispatch
+                # wait. A failed heartbeat is logged but does not
+                # abort the workflow — the next ``heartbeat`` event in
+                # the stream loop will retry.
+                try:
+                    await heartbeat_workflow(self._db, record.job_id)
+                except Exception:
+                    logger.exception(
+                        "Post-provisioner heartbeat failed for %s; continuing",
+                        record.job_id,
+                    )
+
             try:
                 stream = await self._open_stream_with_retry(
                     processor, file_meta, workdir
@@ -396,16 +524,28 @@ class WoolExecutor(JobExecutor):
             except asyncio.CancelledError:
                 final_error = "Workflow cancelled (worker shutdown)"
                 raise
+            except wool.NoWorkersAvailable as exc:
+                # Dispatch budget exhausted with no workers reachable.
+                # ``capacity:`` is the stable on-wire prefix clients
+                # parse to decide whether to resubmit the job — its
+                # origin shifted from the provisioner-failure branch
+                # (which now falls through) to here, but the wire
+                # contract is unchanged.
+                logger.warning(
+                    "Dispatch budget exhausted for %s with no workers available",
+                    record.job_id,
+                )
+                final_error = f"{_ERR_PREFIX_CAPACITY} {exc}"
+                return
             except Exception as exc:
                 logger.exception("Failed to open routine stream for %s", record.job_id)
                 final_error = str(exc)
                 return
 
             try:
-                async with asyncio.timeout(self._workflow_duration_cap_seconds):
+                async with asyncio.timeout(_WORKFLOW_DURATION_CAP_SECONDS):
                     async for event in stream:
-                        kind = event.get("event")
-                        if kind == "heartbeat":
+                        if isinstance(event, Heartbeat):
                             try:
                                 await heartbeat_workflow(self._db, record.job_id)
                             except Exception:
@@ -413,44 +553,28 @@ class WoolExecutor(JobExecutor):
                                     "Heartbeat failed for %s; continuing",
                                     record.job_id,
                                 )
-                        elif kind == "progress":
-                            value = event.get("value")
-                            if isinstance(value, str) and value:
+                        elif isinstance(event, Progress):
+                            if event.value:
                                 try:
                                     await update_progress(
-                                        self._db, record.job_id, value
+                                        self._db, record.job_id, event.value
                                     )
                                 except Exception:
                                     logger.exception(
                                         "update_progress failed for %s; continuing",
                                         record.job_id,
                                     )
-                        elif kind == "stage_complete":
-                            try:
-                                artifact_kind = ArtifactKind(event["kind"])
-                            except (KeyError, ValueError) as exc:
-                                raise RuntimeError(
-                                    f"Processor {processor.__class__.__name__} "
-                                    f"emitted malformed stage_complete event: "
-                                    f"{event!r}"
-                                ) from exc
-                            cache_key = event.get("key")
-                            if not cache_key:
-                                raise RuntimeError(
-                                    f"Processor {processor.__class__.__name__} "
-                                    f"emitted stage_complete with no key: "
-                                    f"{event!r}"
-                                )
+                        elif isinstance(event, StageComplete):
                             try:
                                 await record_stage_complete(
                                     self._db,
                                     record.job_id,
-                                    stage=artifact_kind.value,
-                                    artifact_kind=artifact_kind,
-                                    cache_key=cache_key,
+                                    stage=event.kind.value,
+                                    artifact_kind=event.kind,
+                                    cache_key=event.key,
                                 )
                             except Exception as exc:
-                                # The cache artifact is already on disk —
+                                # The cache artifact is already committed —
                                 # a retry will hit the cache via ``head()``
                                 # and skip this stage. Fail the workflow so
                                 # the next request re-dispatches cleanly
@@ -466,29 +590,36 @@ class WoolExecutor(JobExecutor):
                                     f"record_stage_complete failed: {exc}"
                                 )
                                 break
-                        elif kind == "complete":
+                        elif isinstance(event, Complete):
                             final_status = JobStatus.COMPLETED
                             final_error = None
                             break
-                        elif kind == "error":
-                            err_type = event.get("type", "Error")
-                            err_text = event.get("error", "")
+                        elif isinstance(event, Error):
                             final_status = JobStatus.FAILED
-                            final_error = f"{err_type}: {err_text}"
+                            final_error = f"{event.type}: {event.error}"
                             break
                         else:
                             logger.warning(
                                 "Unknown routine event %r for job %s",
-                                kind,
+                                event,
                                 record.job_id,
                             )
             except asyncio.TimeoutError:
                 final_error = (
-                    f"Workflow exceeded {self._workflow_duration_cap_seconds}s "
+                    f"Workflow exceeded {_WORKFLOW_DURATION_CAP_SECONDS}s "
                     "runtime cap"
                 )
             except asyncio.CancelledError:
-                final_error = "Workflow cancelled (worker shutdown)"
+                # Only overwrite the cancellation message when the
+                # stream hadn't already reached a terminal status. A
+                # ``complete`` event flips ``final_status`` to
+                # COMPLETED and ``break``s; a cancel delivered between
+                # the ``break`` and this except clause would otherwise
+                # overwrite ``final_error`` with the cancel reason and
+                # persist the contradictory (status=COMPLETED,
+                # error=cancelled) pair via ``release_workflow``.
+                if final_status == JobStatus.FAILED:
+                    final_error = "Workflow cancelled (worker shutdown)"
                 raise
             except Exception as exc:
                 logger.exception(
@@ -568,7 +699,7 @@ class WoolExecutor(JobExecutor):
         ``NoWorkersAvailable`` retries on each attempt to open the
         stream. ``_DISPATCH_WAIT_SECONDS`` caps the total wait so a
         stuck scale-up surfaces as a workflow failure rather than
-        hanging until the much-larger ``workflow_duration_cap_seconds``
+        hanging until the much-larger ``_WORKFLOW_DURATION_CAP_SECONDS``
         cap fires.
 
         Returns an async iterator that yields the first event followed
@@ -586,27 +717,40 @@ class WoolExecutor(JobExecutor):
                 processor,
                 file_meta,
                 str(workdir),
-                str(self._cache_root),
+                self._cache,
             )
+            # ``returning`` flips True only after we've handed the
+            # stream off to ``_prepend_first_event``. Any other exit
+            # from this iteration (NoWorkersAvailable, CancelledError
+            # from __anext__ or the inter-iteration sleep, unexpected
+            # exception) leaves the freshly-constructed stream
+            # unawaited; the finally aclose()s it so wool's pool can
+            # release the lease cleanly on drain.
+            returning = False
             try:
-                first_event = await stream.__anext__()
+                try:
+                    first_event = await stream.__anext__()
+                except wool.NoWorkersAvailable as exc:
+                    last_exc = exc
+                    attempt += 1
+                    if loop.time() >= deadline:
+                        break
+                    if attempt >= 2:
+                        logger.warning(
+                            "No workers available — retrying dispatch "
+                            "(attempt %d, %.1fs of %.1fs budget remaining)",
+                            attempt,
+                            deadline - loop.time(),
+                            _DISPATCH_WAIT_SECONDS,
+                        )
+                    await asyncio.sleep(_DISPATCH_RETRY_INTERVAL_SECONDS)
+                    continue
+                returning = True
                 return _prepend_first_event(first_event, stream)
-            except wool.NoWorkersAvailable as exc:
-                with contextlib.suppress(BaseException):
-                    await stream.aclose()
-                last_exc = exc
-                attempt += 1
-                if loop.time() >= deadline:
-                    break
-                if attempt >= 2:
-                    logger.warning(
-                        "No workers available — retrying dispatch "
-                        "(attempt %d, %.1fs of %.1fs budget remaining)",
-                        attempt,
-                        deadline - loop.time(),
-                        _DISPATCH_WAIT_SECONDS,
-                    )
-                await asyncio.sleep(_DISPATCH_RETRY_INTERVAL_SECONDS)
+            finally:
+                if not returning:
+                    with contextlib.suppress(BaseException):
+                        await stream.aclose()
         assert last_exc is not None
         raise last_exc
 

--- a/src/cfdb/workflows/fetcher.py
+++ b/src/cfdb/workflows/fetcher.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import zlib
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,9 @@ from cfdb.services import drs
 from cfdb.workflows.urlsafe import validate_outbound_url
 
 logger = logging.getLogger(__name__)
+
+#: gzip stream magic number (RFC 1952).
+_GZIP_MAGIC = b"\x1f\x8b"
 
 
 async def download_source(file_meta: dict[str, Any], dest: Path) -> Path:
@@ -64,6 +68,53 @@ async def download_source(file_meta: dict[str, Any], dest: Path) -> Path:
 
     logger.info("Downloaded %s to %s (%d bytes)", download_url, dest, bytes_written)
     return dest
+
+
+async def peek_decompressed_prefix(
+    file_meta: dict[str, Any], *, max_compressed_bytes: int = 262_144
+) -> bytes:
+    """Fetch and decompress only the leading bytes of the source file.
+
+    Streams at most ``max_compressed_bytes`` of the source — via a
+    ``Range`` request, with an early stream break as the fallback when
+    the server ignores ``Range`` — and gunzips them if the source is
+    gzip-compressed. This lets a processor inspect a file's header
+    (e.g. a SAM ``@`` block) and fail fast *before* downloading and
+    processing the whole file. The trailing gzip member of a bounded
+    range is necessarily truncated; the resulting ``zlib`` error is
+    expected and the cleanly-decompressed prefix is returned.
+
+    Raises ``ValueError`` when ``file_meta`` has no ``access_url``.
+    """
+    access_url = file_meta.get("access_url")
+    if not access_url:
+        raise ValueError("file_meta has no access_url — cannot peek source")
+
+    download_url = await _resolve_download_url(access_url)
+    range_header = f"bytes=0-{max_compressed_bytes - 1}"
+
+    decompressor = None
+    is_gzip: bool | None = None
+    out = bytearray()
+    consumed = 0
+    async for chunk in drs.stream_from_url(download_url, range_header=range_header):
+        consumed += len(chunk)
+        if is_gzip is None:
+            is_gzip = chunk[:2] == _GZIP_MAGIC
+            if is_gzip:
+                decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+        if is_gzip:
+            try:
+                out += decompressor.decompress(chunk)
+            except zlib.error:
+                # Bounded range cut the final gzip member mid-stream;
+                # keep whatever decompressed cleanly up to the cut.
+                break
+        else:
+            out += chunk
+        if consumed >= max_compressed_bytes:
+            break
+    return bytes(out)
 
 
 async def _resolve_download_url(access_url: str) -> str:

--- a/src/cfdb/workflows/lock.py
+++ b/src/cfdb/workflows/lock.py
@@ -59,10 +59,6 @@ def _jobs(db) -> Any:
         return coll
     if not callable(getattr(configured, "find_one_and_update", None)):
         return coll
-    try:
-        result = configured.find_one_and_update.__wrapped__  # type: ignore[attr-defined]
-    except AttributeError:
-        result = None
     # Heuristic: real motor collections return a coroutine from these
     # methods. mongomock-motor's `with_options` historically degrades to
     # the sync collection — detect that by sniffing one method.
@@ -426,7 +422,7 @@ async def update_progress(db, job_id: str, value: str) -> None:
     """Set the free-form ``progress`` hint on an active job.
 
     Called by the executor's stream consumer in response to a
-    ``{"event": "progress", "value": str}`` event from the routine.
+    :class:`~cfdb.workflows.events.Progress` event from the routine.
     No-op when the job is no longer active. The value is truncated to
     256 chars to match the JobRecord field cap.
     """

--- a/src/cfdb/workflows/processors/bam.py
+++ b/src/cfdb/workflows/processors/bam.py
@@ -37,10 +37,9 @@ from pathlib import Path
 from typing import Any
 
 from cfdb.workflows import SAMTOOLS_MEMORY_CAP, SAMTOOLS_THREADS
-from cfdb.workflows import keys as key_utils
-from cfdb.workflows.cache import LocalFsCache
-from cfdb.workflows.fetcher import download_source
-from cfdb.workflows.keys import extract_identity
+from cfdb.workflows.cache import CacheBackend
+from cfdb.workflows.events import Complete, StageComplete, WorkflowEvent
+from cfdb.workflows.fetcher import download_source, peek_decompressed_prefix
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.processors.base import Processor
 from cfdb.workflows.processors.tools import (
@@ -51,7 +50,42 @@ from cfdb.workflows.processors.tools import (
     shell_quote,
 )
 
-__all__ = ["BamIndexProcessor", "download_source", "read_bam_header"]
+__all__ = [
+    "BamIndexProcessor",
+    "download_source",
+    "read_bam_header",
+    "validate_sam_header",
+]
+
+#: SAM header records that always carry >= 2 TAB-separated fields. A
+#: ``@CO`` comment is free text and may legitimately hold no tab, so it
+#: is excluded from the delimiter check.
+_SAM_MULTIFIELD_RECORDS = ("@HD", "@SQ", "@RG", "@PG")
+
+
+def validate_sam_header(header_text: str) -> None:
+    """Reject space-delimited (legacy/corrupt) SAM headers up front.
+
+    samtools requires TAB-delimited header records. Legacy modENCODE-era
+    SAMs whose header tabs were expanded to spaces parse-fail deep inside
+    ``samtools view`` with an opaque ``[main_samview] fail to read the
+    header``. Detect the space-delimited shape here so the workflow fails
+    fast with an actionable message instead of after downloading and
+    half-running the convert+sort. ``@HD``/``@SQ``/``@RG``/``@PG`` records
+    always carry at least two fields, so one without a TAB is the tell.
+    No-op for well-formed headers and for headerless input (samtools
+    surfaces that case on its own).
+    """
+    for line in header_text.splitlines():
+        if line[:3] in _SAM_MULTIFIELD_RECORDS and "\t" not in line:
+            raise RuntimeError(
+                "SAM header is space-delimited, not TAB-delimited "
+                f"({line[:60]!r}). samtools cannot read it — this is a "
+                "legacy modENCODE-era file whose header tabs were expanded "
+                "to spaces. Re-publish with a TAB-delimited header (keeping "
+                "spaces inside tag values) or route it through a "
+                "header-repair step."
+            )
 
 
 async def read_bam_header(bam_path: Path) -> str:
@@ -124,9 +158,8 @@ class BamIndexProcessor(Processor):
         self,
         file_meta: dict[str, Any],
         workdir: Path,
-        cache_root: Path,
-    ) -> AsyncIterator[dict[str, Any]]:
-        cache = LocalFsCache(cache_root)
+        cache: CacheBackend,
+    ) -> AsyncIterator[WorkflowEvent]:
         workdir.mkdir(parents=True, exist_ok=True)
 
         fmt = format_name(file_meta) or ""
@@ -141,8 +174,8 @@ class BamIndexProcessor(Processor):
         self,
         file_meta: dict[str, Any],
         workdir: Path,
-        cache: LocalFsCache,
-    ) -> AsyncIterator[dict[str, Any]]:
+        cache: CacheBackend,
+    ) -> AsyncIterator[WorkflowEvent]:
         """Index a pre-sorted BAM, yielding stage_complete + complete events.
 
         Validates the source's ``@HD ... SO:coordinate`` line before
@@ -150,14 +183,7 @@ class BamIndexProcessor(Processor):
         clear failure when an unexpected unsorted BAM arrives, rather
         than silently producing a broken index.
         """
-        dcc, local_id, md5 = extract_identity(file_meta)
-        index_key = key_utils.cache_key(
-            dcc=dcc,
-            local_id=local_id,
-            artifact_kind=ArtifactKind.INDEX,
-            md5=md5,
-            processor_version=self.processor_version,
-        )
+        index_key = self.cache_key_for(file_meta, ArtifactKind.INDEX)
 
         if await cache.head(index_key) is None:
             source_path = workdir / "source.bam"
@@ -165,53 +191,29 @@ class BamIndexProcessor(Processor):
             await self._verify_sorted(source_path)
             bai_path = await self._stage_index(source_path)
             await cache.put(index_key, bai_path)
-        yield {
-            "event": "stage_complete",
-            "kind": ArtifactKind.INDEX.value,
-            "key": index_key,
-        }
-        yield {
-            "event": "complete",
-            "artifacts": {ArtifactKind.INDEX.value: index_key},
-        }
+        yield StageComplete(kind=ArtifactKind.INDEX, key=index_key)
+        yield Complete(artifacts={ArtifactKind.INDEX.value: index_key})
 
     async def _run_sam(
         self,
         file_meta: dict[str, Any],
         workdir: Path,
-        cache: LocalFsCache,
-    ) -> AsyncIterator[dict[str, Any]]:
+        cache: CacheBackend,
+    ) -> AsyncIterator[WorkflowEvent]:
         """Convert + sort + index a SAM, yielding per-stage events.
 
         Caches both the sorted BAM and its BAI. Stage-2 (index) failure
         leaves the stage-1 sorted BAM in cache; on retry stage-1 is
         skipped and only the index is re-run.
         """
-        dcc, local_id, md5 = extract_identity(file_meta)
-        data_key = key_utils.cache_key(
-            dcc=dcc,
-            local_id=local_id,
-            artifact_kind=ArtifactKind.DATA,
-            md5=md5,
-            processor_version=self.processor_version,
-        )
-        index_key = key_utils.cache_key(
-            dcc=dcc,
-            local_id=local_id,
-            artifact_kind=ArtifactKind.INDEX,
-            md5=md5,
-            processor_version=self.processor_version,
-        )
+        data_key = self.cache_key_for(file_meta, ArtifactKind.DATA)
+        index_key = self.cache_key_for(file_meta, ArtifactKind.INDEX)
 
         # Stage 1 — convert + sort if not already cached.
         if await cache.head(data_key) is None:
             sorted_bam = await self._stage_convert_and_sort(file_meta, workdir)
             await cache.put(data_key, sorted_bam)
-        yield {
-            "event": "stage_complete",
-            "kind": ArtifactKind.DATA.value,
-            "key": data_key,
-        }
+        yield StageComplete(kind=ArtifactKind.DATA, key=data_key)
 
         # Stage 2 — produce the BAI from the sorted BAM.
         if await cache.head(index_key) is None:
@@ -220,24 +222,26 @@ class BamIndexProcessor(Processor):
                 await copy_from_cache(cache, data_key, sorted_bam_local)
             bai_path = await self._stage_index(sorted_bam_local)
             await cache.put(index_key, bai_path)
-        yield {
-            "event": "stage_complete",
-            "kind": ArtifactKind.INDEX.value,
-            "key": index_key,
-        }
+        yield StageComplete(kind=ArtifactKind.INDEX, key=index_key)
 
-        yield {
-            "event": "complete",
-            "artifacts": {
+        yield Complete(
+            artifacts={
                 ArtifactKind.DATA.value: data_key,
                 ArtifactKind.INDEX.value: index_key,
-            },
-        }
+            }
+        )
 
     async def _stage_convert_and_sort(
         self, file_meta: dict[str, Any], workdir: Path
     ) -> Path:
         """Convert SAM to BAM and coordinate-sort, in a single pipeline."""
+        # Fail fast on legacy space-delimited SAM headers: peek only the
+        # leading (header) bytes and reject before downloading and
+        # convert+sorting the whole file, turning samtools' opaque
+        # "fail to read the header" into an actionable error.
+        prefix = await peek_decompressed_prefix(file_meta)
+        validate_sam_header(prefix.decode("utf-8", errors="replace"))
+
         source_path = workdir / "source.sam"
         await download_source(file_meta, source_path)
         sorted_path = workdir / "sorted.bam"

--- a/src/cfdb/workflows/processors/base.py
+++ b/src/cfdb/workflows/processors/base.py
@@ -7,6 +7,9 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
+from cfdb.workflows import keys as key_utils
+from cfdb.workflows.cache import CacheBackend
+from cfdb.workflows.events import WorkflowEvent
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.processors.tools import format_name
 
@@ -21,15 +24,15 @@ class Processor(ABC):
     retry, the processor consults the cache and skips any stage whose
     output is already present.
 
-    ``run`` is an async generator that yields a typed event stream:
+    ``run`` is an async generator that yields typed
+    :mod:`cfdb.workflows.events` objects:
 
-    - ``{"event": "stage_complete", "kind": ArtifactKind.<X>.value,
-       "key": <cache_key>}`` — emit after each ``cache.put`` for a stage
-       so the API process can persist ``stages_done`` /
-       ``artifact_cache_keys`` incrementally, not all at the end.
-    - ``{"event": "complete", "artifacts": {kind: key, ...}}`` — emit
-       once at the end with the full artifact map. Subclasses MUST emit
-       this as the last yield.
+    - :class:`~cfdb.workflows.events.StageComplete` — emit after each
+       ``cache.put`` for a stage so the API process can persist
+       ``stages_done`` / ``artifact_cache_keys`` incrementally, not all
+       at the end.
+    - :class:`~cfdb.workflows.events.Complete` — emit once at the end with
+       the full artifact map. Subclasses MUST emit this as the last yield.
 
     The wool routine wrapper composes a heartbeat loop around the
     processor's stream, so the processor itself never has to think
@@ -68,6 +71,31 @@ class Processor(ABC):
         """
         return self.artifact_kinds
 
+    def cache_key_for(
+        self, file_meta: dict[str, Any], artifact_kind: ArtifactKind
+    ) -> str:
+        """Return the cache key this processor writes ``artifact_kind`` under.
+
+        The single authority for cache-key derivation. The router probes
+        the cache with this key, the processor ``put``s under it, and the
+        :class:`~cfdb.workflows.events.StageComplete` event carries it — so
+        all three agree by construction rather than by three independent
+        re-derivations that must be kept in sync. ``processor_version`` is
+        baked in, so bumping it invalidates this processor's cached
+        artifacts without disturbing other processors'.
+
+        Raises ``ValueError`` (via :func:`extract_identity`) when
+        ``file_meta`` is missing dcc / local_id / md5.
+        """
+        dcc, local_id, md5 = key_utils.extract_identity(file_meta)
+        return key_utils.cache_key(
+            dcc=dcc,
+            local_id=local_id,
+            artifact_kind=artifact_kind,
+            md5=md5,
+            processor_version=self.processor_version,
+        )
+
     def needs_processing(self, file_meta: dict[str, Any]) -> bool:
         """Return True when this processor is applicable and has work to do.
 
@@ -86,8 +114,8 @@ class Processor(ABC):
         self,
         file_meta: dict[str, Any],
         workdir: Path,
-        cache_root: Path,
-    ) -> AsyncIterator[dict[str, Any]]:
+        cache: CacheBackend,
+    ) -> AsyncIterator[WorkflowEvent]:
         """Execute the pipeline end-to-end as an event stream.
 
         Args:
@@ -95,14 +123,19 @@ class Processor(ABC):
                 (``FileMetadataModel.model_dump()``).
             workdir: A per-job scratch directory. The processor MAY create
                 files here freely; the caller cleans it up after the job.
-            cache_root: Root directory of the configured ``LocalFsCache``.
-                The processor writes its artifacts directly under keys
-                derived from ``file_meta``.
+            cache: The configured cache backend (``LocalFsCache`` or
+                ``S3Cache``), handed across the Wool boundary so artifacts
+                are persisted to the deployment's real backing store. The
+                processor materialises each artifact locally under
+                ``workdir`` and then ``cache.put``s it under a key derived
+                from ``file_meta``. Reusing the injected backend (rather
+                than constructing a ``LocalFsCache``) is what lets the
+                S3/ECS profile actually persist artifacts to S3.
 
         Yields:
-            ``{"event": "stage_complete", "kind": <str>, "key": <str>}``
-            after each stage's ``cache.put``; one final
-            ``{"event": "complete", "artifacts": {kind: key}}`` event.
-            Implementations MUST be ``async def`` functions that use
-            ``yield`` (i.e., async generators).
+            A :class:`~cfdb.workflows.events.StageComplete` after each
+            stage's ``cache.put``, then one final
+            :class:`~cfdb.workflows.events.Complete`. Implementations MUST
+            be ``async def`` functions that use ``yield`` (i.e., async
+            generators).
         """

--- a/src/cfdb/workflows/processors/passthrough.py
+++ b/src/cfdb/workflows/processors/passthrough.py
@@ -6,6 +6,8 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
+from cfdb.workflows.cache import CacheBackend
+from cfdb.workflows.events import Complete, WorkflowEvent
 from cfdb.workflows.processors.base import Processor
 
 
@@ -30,8 +32,8 @@ class PassthroughProcessor(Processor):
         self,
         file_meta: dict[str, Any],
         workdir: Path,
-        cache_root: Path,
-    ) -> AsyncIterator[dict[str, Any]]:
+        cache: CacheBackend,
+    ) -> AsyncIterator[WorkflowEvent]:
         """Never invoked; included to satisfy the Processor ABC."""
         raise RuntimeError(
             "PassthroughProcessor.run must not be called; these formats "
@@ -39,4 +41,4 @@ class PassthroughProcessor(Processor):
         )
         # Unreachable; kept so the function is syntactically an async
         # generator (matching the ABC contract).
-        yield {"event": "complete", "artifacts": {}}
+        yield Complete(artifacts={})

--- a/src/cfdb/workflows/processors/tabix.py
+++ b/src/cfdb/workflows/processors/tabix.py
@@ -38,10 +38,9 @@ from pathlib import Path
 from typing import Any
 
 from cfdb.workflows import SORT_MEMORY_CAP, SORT_PARALLEL
-from cfdb.workflows import keys as key_utils
-from cfdb.workflows.cache import LocalFsCache
+from cfdb.workflows.cache import CacheBackend
+from cfdb.workflows.events import Complete, StageComplete, WorkflowEvent
 from cfdb.workflows.fetcher import download_source
-from cfdb.workflows.keys import extract_identity
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.processors.base import Processor
 from cfdb.workflows.processors.tools import (
@@ -89,40 +88,22 @@ class TabixIntervalProcessor(Processor):
         self,
         file_meta: dict[str, Any],
         workdir: Path,
-        cache_root: Path,
-    ) -> AsyncIterator[dict[str, Any]]:
-        cache = LocalFsCache(cache_root)
+        cache: CacheBackend,
+    ) -> AsyncIterator[WorkflowEvent]:
         workdir.mkdir(parents=True, exist_ok=True)
 
         fmt = format_name(file_meta) or ""
         preset = _TABIX_PRESET[fmt]
         sort_args = _SORT_ARGS[preset]
 
-        dcc, local_id, md5 = extract_identity(file_meta)
-        data_key = key_utils.cache_key(
-            dcc=dcc,
-            local_id=local_id,
-            artifact_kind=ArtifactKind.DATA,
-            md5=md5,
-            processor_version=self.processor_version,
-        )
-        index_key = key_utils.cache_key(
-            dcc=dcc,
-            local_id=local_id,
-            artifact_kind=ArtifactKind.INDEX,
-            md5=md5,
-            processor_version=self.processor_version,
-        )
+        data_key = self.cache_key_for(file_meta, ArtifactKind.DATA)
+        index_key = self.cache_key_for(file_meta, ArtifactKind.INDEX)
 
         # Stage 1 — produce the bgzipped sorted text artifact.
         if await cache.head(data_key) is None:
             bgz_path = await self._stage_prepare(file_meta, fmt, sort_args, workdir)
             await cache.put(data_key, bgz_path)
-        yield {
-            "event": "stage_complete",
-            "kind": ArtifactKind.DATA.value,
-            "key": data_key,
-        }
+        yield StageComplete(kind=ArtifactKind.DATA, key=data_key)
 
         # Stage 2 — produce the tabix index.
         if await cache.head(index_key) is None:
@@ -131,19 +112,14 @@ class TabixIntervalProcessor(Processor):
                 await copy_from_cache(cache, data_key, bgz_local)
             tbi_path = await self._stage_index(bgz_local, preset)
             await cache.put(index_key, tbi_path)
-        yield {
-            "event": "stage_complete",
-            "kind": ArtifactKind.INDEX.value,
-            "key": index_key,
-        }
+        yield StageComplete(kind=ArtifactKind.INDEX, key=index_key)
 
-        yield {
-            "event": "complete",
-            "artifacts": {
+        yield Complete(
+            artifacts={
                 ArtifactKind.DATA.value: data_key,
                 ArtifactKind.INDEX.value: index_key,
-            },
-        }
+            }
+        )
 
     async def _stage_prepare(
         self,

--- a/src/cfdb/workflows/processors/tools.py
+++ b/src/cfdb/workflows/processors/tools.py
@@ -15,7 +15,7 @@ import signal
 from pathlib import Path
 from typing import Any
 
-from cfdb.workflows.cache import LocalFsCache
+from cfdb.workflows.cache import CacheBackend
 
 logger = logging.getLogger(__name__)
 
@@ -134,8 +134,12 @@ async def run_shell(cmd: str) -> None:
         )
 
 
-async def copy_from_cache(cache: LocalFsCache, key: str, dest: Path) -> None:
-    """Stream a cached artifact into ``dest`` for tool consumption."""
+async def copy_from_cache(cache: CacheBackend, key: str, dest: Path) -> None:
+    """Stream a cached artifact into ``dest`` for tool consumption.
+
+    Accepts any :class:`CacheBackend` (``cache.get`` is the only call) so
+    the S3 profile downloads from S3 here, not just the local FS.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
     with dest.open("wb") as fh:
         async for chunk in cache.get(key):

--- a/src/cfdb/workflows/provisioner.py
+++ b/src/cfdb/workflows/provisioner.py
@@ -1,0 +1,512 @@
+"""ECS on-demand worker provisioning via the ``RunTask`` API.
+
+``EcsProvisioner`` wraps a single boto3 ``RunTask`` call with the cluster,
+task-definition family, and awsvpc networking configuration the workflow
+subsystem needs. The same code targets LocalStack in development and real
+AWS in production — only ``AWS_ENDPOINT_URL`` differs at the boto3 client.
+
+Concurrent ``request`` calls sharing the same ``dedup_key`` (typically
+the workflow key) attach to a single in-flight ``RunTask`` task and
+observe the same outcome. ``asyncio.shield`` insulates each caller's
+cancellation from the others, so a request abandoned by one caller does
+not poison the result for the rest — and again around the dedup-slot
+cleanup so cancellation cannot leak a stale entry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import threading
+from collections.abc import Iterable
+from typing import Any, Literal, Optional, get_args
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+
+#: Acceptable values for ``RunTask`` ``assignPublicIp`` — ECS rejects
+#: anything else. The runtime-validation set is derived from the
+#: ``Literal`` so the two definitions can't drift.
+AssignPublicIp = Literal["ENABLED", "DISABLED"]
+_ASSIGN_PUBLIC_IP_VALUES = frozenset(get_args(AssignPublicIp))
+
+
+class _SubmittedRunTask:
+    """Bookkeeping slot for an in-flight ``RunTask`` future.
+
+    Tracks the underlying ``concurrent.futures.Future`` and whether the
+    awaiting coroutine successfully consumed the result so a late-
+    arriving boto thread can be classified as orphan (caller cancelled,
+    ARN unreachable) vs claimed (caller observed the ARN normally).
+    """
+
+    __slots__ = ("future", "claimed")
+
+    def __init__(self) -> None:
+        self.future: Optional[concurrent.futures.Future[dict[str, Any]]] = None
+        self.claimed: bool = False
+
+
+class RetryableProvisionerError(RuntimeError):
+    """Provisioner failure the caller should resubmit later.
+
+    Covers both ECS-side capacity / ENI exhaustion and transport-level
+    transients (connection timeouts, endpoint unavailability,
+    throttling). The executor's response is identical for both — mark
+    the workflow ``FAILED`` with a retryable error string — so they
+    share one exception type.
+    """
+
+
+class EcsProvisioner:
+    """Launch ephemeral worker tasks on ECS Fargate.
+
+    ``_in_flight`` has two cleanup paths: ``_run_task_owned``'s
+    ``finally`` pops the slot under normal completion; ``request``'s
+    self-heal pops a stale slot whose owning task is already ``done``
+    when the next ``request`` for the same key arrives. The self-heal
+    is the safety net for "the finally pop was skipped" cases —
+    cancellation during event-loop teardown can re-raise out of the
+    awaited shielded pop before the inner coroutine runs.
+
+    Args:
+        cluster: ECS cluster name or ARN.
+        task_definition: Task definition family (or family:revision)
+            for the worker container.
+        subnets: Awsvpc subnet IDs to place worker ENIs into.
+        security_groups: Awsvpc security group IDs to attach.
+        assign_public_ip: ``"ENABLED"`` or ``"DISABLED"`` — whether the
+            ENI gets a public IP. Production should usually leave this
+            disabled and rely on VPC endpoints; LocalStack accepts
+            either value.
+        client: Optional pre-built boto3 ``ecs`` client. When omitted,
+            one is constructed via :func:`build_ecs_client` with the
+            ``endpoint_url`` / ``region_name`` kwargs threaded through.
+        endpoint_url: Boto3 ``endpoint_url``. Passed to
+            :func:`build_ecs_client` when ``client`` is omitted. The
+            lifespan plumbs :data:`cfdb.api.AWS_ENDPOINT_URL` here.
+        region_name: Boto3 ``region_name``. Plumbed analogously.
+        max_in_flight: Soft cap on concurrent ``RunTask`` calls. ECS's
+            ``RunTask`` API is rate-limited to ~20 req/s per account;
+            this guard keeps us well under it.
+    """
+
+    def __init__(
+        self,
+        *,
+        cluster: str,
+        task_definition: str,
+        subnets: Iterable[str],
+        security_groups: Iterable[str] = (),
+        assign_public_ip: AssignPublicIp = "DISABLED",
+        client: Optional[Any] = None,
+        endpoint_url: Optional[str] = None,
+        region_name: Optional[str] = None,
+        max_in_flight: int = 16,
+    ) -> None:
+        if not cluster:
+            raise ValueError("EcsProvisioner requires a cluster name")
+        if not task_definition:
+            raise ValueError("EcsProvisioner requires a task_definition")
+        subnet_list = list(subnets)
+        if not subnet_list:
+            raise ValueError("EcsProvisioner requires at least one subnet")
+        if assign_public_ip not in _ASSIGN_PUBLIC_IP_VALUES:
+            raise ValueError(
+                f"assign_public_ip must be one of {sorted(_ASSIGN_PUBLIC_IP_VALUES)}; "
+                f"got {assign_public_ip!r}"
+            )
+        if client is not None and (endpoint_url or region_name):
+            raise ValueError(
+                "EcsProvisioner: pass either client or endpoint_url/region_name, "
+                "not both — the boto kwargs are silently ignored when client is set"
+            )
+
+        self._cluster = cluster
+        self._task_definition = task_definition
+        self._subnets = subnet_list
+        self._security_groups = list(security_groups)
+        self._assign_public_ip = assign_public_ip
+        self._client = (
+            client
+            if client is not None
+            else build_ecs_client(endpoint_url=endpoint_url, region_name=region_name)
+        )
+        self._semaphore = asyncio.Semaphore(max_in_flight)
+        # Concurrent ``request`` calls sharing a key attach to the
+        # same in-flight Task. ``_run_task_owned``'s ``finally`` block
+        # always pops the entry on completion (success or failure) so
+        # a fresh request after the previous one finishes spawns a new
+        # launch.
+        self._in_flight: dict[str, asyncio.Task[list[str]]] = {}
+        self._in_flight_lock = asyncio.Lock()
+        # Owned threadpool for ``RunTask`` so ``aclose`` can drain
+        # in-flight boto calls deterministically. ``asyncio.to_thread``
+        # submits to the loop's default executor, which we cannot
+        # drain on shutdown — a cancelled awaiter would leave the
+        # boto thread untracked and any ARNs it produced as silent
+        # orphans. Tracking the underlying ``concurrent.futures.Future``
+        # lets the done-callback observe late-arriving ARNs and log
+        # them at WARNING for an external reaper.
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_in_flight,
+            thread_name_prefix="ecs-runtask",
+        )
+        self._pending_lock = threading.Lock()
+        self._pending: set[_SubmittedRunTask] = set()
+
+    async def request(self, *, dedup_key: str) -> list[str]:
+        """Launch a worker task, returning its ARN(s).
+
+        Concurrent callers sharing ``dedup_key`` share one ``RunTask``:
+        only the first launches; the rest await the same result.
+
+        Args:
+            dedup_key: Typically the workflow mutex key. Two callers
+                holding the same workflow-level mutex should not
+                independently launch two workers.
+
+        Returns:
+            List of task ARNs corresponding to the launched worker(s).
+
+        Raises:
+            RetryableProvisionerError: Capacity / ENI exhaustion,
+                throttling, or connection-level transients. Callers
+                should mark the workflow as failed with a retryable
+                status so the client can resubmit.
+        """
+        if not dedup_key:
+            raise ValueError("EcsProvisioner.request requires a non-empty dedup_key")
+
+        async with self._in_flight_lock:
+            existing = self._in_flight.get(dedup_key)
+            # Self-heal: if a previous task finished but its dedup-slot
+            # release was skipped (e.g. event-loop teardown re-raised
+            # ``CancelledError`` out of the awaited shielded pop
+            # before the inner coroutine ran), treat the stale entry
+            # as absent and launch a fresh task. Collapses every
+            # "the finally pop never ran" race into one self-healing
+            # read at registration time.
+            if existing is not None and existing.done():
+                existing = None
+                self._in_flight.pop(dedup_key, None)
+            if existing is None:
+                existing = asyncio.create_task(
+                    self._run_task_owned(dedup_key),
+                    name=f"ecs-runtask-{dedup_key}",
+                )
+                # Retrieve the eventual exception/result so a Task
+                # abandoned by every caller (universal cancellation)
+                # doesn't trigger asyncio's "Task exception was never
+                # retrieved" warning when it's garbage-collected.
+                existing.add_done_callback(_consume_task_outcome)
+                self._in_flight[dedup_key] = existing
+
+        # Shield protects concurrent callers sharing this dedup_key
+        # from each other's cancellation: if one caller is cancelled
+        # mid-await, only that caller sees CancelledError; the
+        # underlying task continues and other callers still observe
+        # the real result.
+        return await asyncio.shield(existing)
+
+    async def _run_task_owned(self, dedup_key: str) -> list[str]:
+        """Body of the dedup-protected RunTask call.
+
+        Split out from ``request`` so the dedup-registration lock is
+        not held across the boto3 thread-pool round-trip. The
+        ``finally`` always pops the in-flight slot so the next
+        ``request`` for the same key can launch a fresh worker. The
+        pop is shielded so a CancelledError delivered to the task
+        itself (event-loop teardown, explicit cancel) cannot skip the
+        cleanup and leak a stale dedup entry pointing at a cancelled
+        task.
+
+        The release captures ``my_task`` and only pops the slot if the
+        current map entry is still its own task. Today the self-heal in
+        ``request`` would already discard a stale entry pointing at a
+        cancelled task, but the identity check makes the invariant
+        local — a future maintainer who inserts into ``_in_flight``
+        directly cannot have their entry nuked by a late release.
+        """
+        my_task = asyncio.current_task()
+        async def _release_dedup_slot() -> None:
+            async with self._in_flight_lock:
+                if self._in_flight.get(dedup_key) is my_task:
+                    self._in_flight.pop(dedup_key, None)
+
+        try:
+            async with self._semaphore:
+                return await self._run_task()
+        finally:
+            await asyncio.shield(_release_dedup_slot())
+
+    async def _run_task(self) -> list[str]:
+        """Single ``RunTask`` invocation translated to a list of task ARNs.
+
+        ``count`` is hardcoded to 1 because the dedup contract is one
+        worker per workflow key: two concurrent ``request(dedup_key=K)``
+        calls share the same task, and once that task finishes a fresh
+        request for the same key launches a fresh worker.
+
+        Three response shapes from ECS:
+
+        * ``failures`` only — no task launched; raise
+          :class:`RetryableProvisionerError` for retryable reasons,
+          :class:`RuntimeError` otherwise.
+        * ``tasks`` only — happy path; return the ARN list.
+        * ``tasks`` + ``failures`` together (rare; ECS occasionally
+          surfaces a secondary placement warning alongside a
+          successfully launched task) — log the failures at WARNING
+          and return the ARNs rather than discard a billable worker.
+        """
+        kwargs: dict[str, Any] = {
+            "cluster": self._cluster,
+            "taskDefinition": self._task_definition,
+            "launchType": "FARGATE",
+            "count": 1,
+            "networkConfiguration": {
+                "awsvpcConfiguration": {
+                    "subnets": list(self._subnets),
+                    "securityGroups": list(self._security_groups),
+                    "assignPublicIp": self._assign_public_ip,
+                }
+            },
+        }
+
+        # Capacity / ENI exhaustion / throttling / boto transport
+        # transients; see the class docstring for the ``capacity:``
+        # prefix contract callers parse off the persisted error.
+        try:
+            response = await self._submit_run_task(kwargs)
+        except (ClientError, BotoCoreError) as exc:
+            if _is_retryable_error(exc):
+                raise RetryableProvisionerError(f"{type(exc).__name__}: {exc}") from exc
+            raise
+
+        failures = response.get("failures") or []
+        tasks = response.get("tasks") or []
+        arns = [t["taskArn"] for t in tasks if t.get("taskArn")]
+
+        if failures and not arns:
+            # No ARN to fall back on — the launch did not happen.
+            reasons = ", ".join(f.get("reason", "?") for f in failures)
+            if any(_is_retryable_failure(f) for f in failures):
+                raise RetryableProvisionerError(f"ECS RunTask failures: {reasons}")
+            raise RuntimeError(f"ECS RunTask failures: {reasons}")
+
+        if failures and arns:
+            # Partial-success edge: ECS occasionally surfaces a
+            # secondary placement warning alongside a successfully
+            # launched task. Log and keep the ARN rather than
+            # discarding a worker that's already running (and
+            # billing) to chase the warning.
+            reasons = ", ".join(f.get("reason", "?") for f in failures)
+            logger.warning(
+                "ECS RunTask succeeded with %d task(s) but reported failures: %s",
+                len(arns),
+                reasons,
+            )
+
+        if not arns:
+            # ECS returned neither a launched task nor a failure entry.
+            # Treat as a retryable transient — the caller has nothing
+            # to dispatch to and the executor's failed-with-retryable
+            # path is the right response.
+            raise RetryableProvisionerError("ECS RunTask returned no tasks and no failures")
+        logger.info(
+            "ECS RunTask launched %d task(s) on cluster=%s family=%s",
+            len(arns),
+            self._cluster,
+            self._task_definition,
+        )
+        return arns
+
+    async def _submit_run_task(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Run ``RunTask`` in the owned executor and track the future.
+
+        The future is recorded in ``_pending`` so ``aclose`` can drain
+        threads mid-flight. A done-callback logs any ARNs the boto
+        thread produced *after* the awaiting coroutine was cancelled —
+        these are orphan workers that no caller can claim, and their
+        only safety net is the worker's own ``CFDB_WORKER_MAX_LIFETIME``
+        ceiling. Surfacing them at WARNING gives operators a chance
+        to reap manually before the ceiling fires.
+        """
+        slot = _SubmittedRunTask()
+        future = self._executor.submit(self._client.run_task, **kwargs)
+        slot.future = future
+        loop = asyncio.get_running_loop()
+        with self._pending_lock:
+            self._pending.add(slot)
+        future.add_done_callback(
+            lambda f, _slot=slot, _loop=loop: self._on_runtask_done(_slot, _loop)
+        )
+        try:
+            result = await asyncio.wrap_future(future)
+        except BaseException:
+            # Awaiter cancelled or wrap_future surfaced a failure; the
+            # done-callback owns the orphan check. Slot stays in
+            # ``_pending`` until the callback fires.
+            raise
+        slot.claimed = True
+        return result
+
+    def _on_runtask_done(
+        self, slot: _SubmittedRunTask, loop: asyncio.AbstractEventLoop
+    ) -> None:
+        """Schedule the orphan check on the loop thread.
+
+        ``add_done_callback`` fires from the boto worker thread (or
+        synchronously from the submitter if the future is already done).
+        Defer the check via ``call_soon_threadsafe`` so the awaiting
+        coroutine has a chance to flip ``slot.claimed`` first — without
+        the deferral every successful launch would race-classify as
+        orphan because the callback runs before the wrap_future
+        resumption.
+        """
+        try:
+            loop.call_soon_threadsafe(self._check_orphan, slot)
+        except RuntimeError:
+            # Loop already closed (interpreter shutdown); inline the
+            # check so the WARNING still surfaces.
+            self._check_orphan(slot)
+
+    def _check_orphan(self, slot: _SubmittedRunTask) -> None:
+        with self._pending_lock:
+            self._pending.discard(slot)
+        future = slot.future
+        if future is None or slot.claimed:
+            return
+        if future.cancelled() or future.exception() is not None:
+            return
+        response = future.result()
+        tasks = response.get("tasks") or []
+        arns = [t["taskArn"] for t in tasks if t.get("taskArn")]
+        if arns:
+            logger.warning(
+                "ECS RunTask launched %d task(s) after the awaiting "
+                "caller was cancelled; ARN(s) %s are orphaned. The "
+                "worker's max-lifetime ceiling caps the cost-leak "
+                "window; reap manually for faster reclaim.",
+                len(arns),
+                arns,
+            )
+
+    async def aclose(self) -> None:
+        """Cancel every in-flight ``RunTask`` and drain the executor.
+
+        Called from the API lifespan's ``finally`` so a shutdown while
+        a ``RunTask`` round-trip is mid-flight doesn't leave the task
+        unrequested-but-billed. ``gather(return_exceptions=True)``
+        absorbs the ``CancelledError`` and any ``RetryableProvisionerError``
+        already in flight. The done-callback that ``request`` attaches
+        separately suppresses "Task exception was never retrieved"
+        warnings for tasks that complete without an awaiter; ``aclose``
+        itself awaits everything it cancels.
+
+        After cancelling the awaiting tasks, drain the owned
+        ``ThreadPoolExecutor`` via ``shutdown(wait=True)`` so any boto
+        thread still on the wire finishes before the client tears down.
+        ``shutdown`` runs in a worker thread so the event loop is not
+        held; orphan ARNs land via the done-callback's WARNING.
+        """
+        async with self._in_flight_lock:
+            tasks = list(self._in_flight.values())
+            # Clearing inside the lock makes any concurrent ``request``
+            # arriving after ``aclose`` get a fresh Task rather than
+            # attach to a doomed in-flight.
+            self._in_flight.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.to_thread(self._executor.shutdown, wait=True)
+
+
+def build_ecs_client(
+    *, endpoint_url: Optional[str] = None, region_name: Optional[str] = None
+) -> Any:
+    """Construct a boto3 ``ecs`` client with explicit endpoint/region.
+
+    The caller (typically :class:`EcsProvisioner`, :class:`EcsDiscovery`,
+    or the API lifespan) is the single source of truth for
+    ``endpoint_url`` and ``region_name``; this function does not
+    consult :mod:`cfdb.api` for fallback values. Leave both ``None``
+    to let boto3's default session resolver chain pick them up from
+    the environment.
+    """
+    return boto3.client(
+        "ecs",
+        endpoint_url=endpoint_url,
+        region_name=region_name,
+    )
+
+
+# Codes ECS returns as ``ClientError.response["Error"]["Code"]`` for a
+# ``RunTask`` failure that a retry can plausibly fix. Capacity-style
+# placement reasons (``RESOURCE:ENI`` / ``RESOURCE:CPU`` /
+# ``RESOURCE:MEMORY`` / ``AWS.ECS.PlacementError``) are NOT in this
+# set because ECS surfaces them via ``failures[].reason``, not as a
+# top-level error code; ``_RETRYABLE_REASON_TOKENS`` catches them on
+# the failure-payload path.
+_RETRYABLE_ERROR_CODES = frozenset({
+    "Capacity",
+    "CapacityProviderException",
+    "ClusterCapacityProviderException",
+    "ThrottlingException",
+    "Throttling",
+    "RequestLimitExceeded",
+    "ServerException",
+    "ServiceUnavailableException",
+    "ServiceUnavailable",
+})
+# Substring match (``token in reason``). ``THROTTL`` is deliberately
+# truncated so it covers any throttling-derived reason — ``THROTTLED``,
+# ``THROTTLING``, ``THROTTLINGEXCEPTION`` — without enumerating every
+# variant AWS might emit.
+_RETRYABLE_REASON_TOKENS = ("CAPACITY", "RESOURCE:", "THROTTL")
+
+
+def _is_retryable_error(exc: BaseException) -> bool:
+    """Return True when an ECS exception is a retryable transient.
+
+    Handles both ``ClientError`` (with a structured response dict) and
+    ``BotoCoreError`` subclasses (transport-level failures without a
+    response) — connection timeouts, endpoint unavailability, and
+    other transport transients are exactly the cases the caller should
+    resubmit.
+    """
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = (response.get("Error") or {}).get("Code")
+        if code in _RETRYABLE_ERROR_CODES:
+            return True
+    # BotoCoreError subclasses (EndpointConnectionError,
+    # ConnectTimeoutError, ReadTimeoutError, HTTPClientError, etc.)
+    # carry no .response; classify the whole family as retryable.
+    return isinstance(exc, BotoCoreError)
+
+
+def _is_retryable_failure(failure: dict[str, Any]) -> bool:
+    """Return True when a ``RunTask`` ``failures`` entry is retryable."""
+    reason = (failure.get("reason") or "").upper()
+    return any(token in reason for token in _RETRYABLE_REASON_TOKENS)
+
+
+def _consume_task_outcome(task: asyncio.Task[Any]) -> None:
+    """Mark a Task's outcome retrieved so asyncio doesn't warn.
+
+    Attached as a done-callback on the in-flight provisioner Task so
+    universal cancellation (every caller cancels before the Task
+    completes) doesn't surface as a noisy "Task exception was never
+    retrieved" warning at GC time. The outcome itself isn't logged
+    here — ``_run_task`` already emits a success line on launch and
+    the caller surfaces failures via the awaiting coroutine.
+    """
+    if task.cancelled():
+        return
+    task.exception()

--- a/src/cfdb/workflows/worker_lan.py
+++ b/src/cfdb/workflows/worker_lan.py
@@ -1,0 +1,127 @@
+"""Local-dev worker pool entrypoint (LAN discovery).
+
+This is the single-host development counterpart to :mod:`worker_main`
+(the ECS entrypoint). The two differ in how workers are *discovered*:
+
+* :mod:`worker_main` boots a bare ``wool.LocalWorker`` and relies on
+  ``EcsDiscovery`` polling the ECS control plane — the worker never
+  advertises itself.
+* This module spawns a ``wool.WorkerPool`` wired to ``LanDiscovery`` so
+  the pool publishes its workers over zeroconf/mDNS under a shared
+  namespace. A co-located API process running the ``local`` or
+  ``s3-cached`` profile leases them via the same namespace.
+
+Run it in a separate process *before* starting the API, with the same
+namespace the API uses (``WORKFLOW_POOL_NAMESPACE``)::
+
+    python -m cfdb.workflows.worker_lan --namespace cfdb-workers --workers 2
+
+SIGINT (Ctrl-C) or SIGTERM drains the pool and exits. With no pool
+running, ``/data`` and ``/index`` requests for processable formats hang
+on the dispatch retry budget before failing with ``NoWorkersAvailable``.
+
+Environment variables (CLI flags mirror them):
+
+* ``WORKFLOW_POOL_NAMESPACE`` — LAN discovery namespace the pool
+  publishes under (default ``cfdb-workers``). MUST match the API's value.
+* ``WORKFLOW_WORKER_COUNT`` — number of workers to spawn and publish
+  (default ``2``). Size it at least as high as the API's lease count or
+  the API blocks waiting for workers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+
+import click
+import wool
+from wool.runtime.discovery.lan import LanDiscovery
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["main", "serve"]
+
+#: Default LAN discovery namespace. Matches the API's
+#: ``WORKFLOW_POOL_NAMESPACE`` default so a bare ``python -m
+#: cfdb.workflows.worker_lan`` pairs with a bare API out of the box.
+DEFAULT_NAMESPACE = "cfdb-workers"
+
+#: Default number of workers to spawn and publish. Matches the API's
+#: ``WORKFLOW_WORKER_COUNT`` default so the publisher supplies at least
+#: as many workers as the API leases.
+DEFAULT_WORKER_COUNT = 2
+
+
+async def serve(*, namespace: str, workers: int) -> int:
+    """Spawn ``workers`` wool workers and publish them under ``namespace``.
+
+    Blocks until SIGTERM/SIGINT, then drains the pool via the
+    ``WorkerPool`` async-context exit and returns ``0``. Bind/spawn
+    failures raise out so the cause surfaces in the process logs rather
+    than as a silent non-zero exit.
+    """
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _signal_handler() -> None:
+        logger.info("Received termination signal — draining worker pool")
+        stop_event.set()
+
+    def _signal_handler_threaded(*_: object) -> None:
+        # Fallback for platforms where ``add_signal_handler`` raises
+        # ``NotImplementedError`` (notably Windows in CI).
+        loop.call_soon_threadsafe(_signal_handler)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _signal_handler)
+        except NotImplementedError:
+            signal.signal(sig, _signal_handler_threaded)
+
+    pool = wool.WorkerPool(
+        spawn=workers, discovery=LanDiscovery(namespace)
+    )
+    async with pool:
+        logger.info(
+            "Published %d wool worker(s) under LAN namespace %r — "
+            "Ctrl-C to drain and exit",
+            workers,
+            namespace,
+        )
+        await stop_event.wait()
+    return 0
+
+
+@click.command()
+@click.option(
+    "--namespace",
+    envvar="WORKFLOW_POOL_NAMESPACE",
+    default=DEFAULT_NAMESPACE,
+    show_default=True,
+    help="LAN discovery namespace to publish under; must match the API.",
+)
+@click.option(
+    "--workers",
+    type=click.IntRange(min=1),
+    envvar="WORKFLOW_WORKER_COUNT",
+    default=DEFAULT_WORKER_COUNT,
+    show_default=True,
+    help="Number of wool workers to spawn and publish.",
+)
+def main(namespace: str, workers: int) -> None:
+    """Local-dev worker pool — publishes workers over LAN discovery.
+
+    Run this in a separate process before starting the API so the API's
+    ``LanDiscovery`` subscriber can lease the published workers. Mirror
+    the API's ``WORKFLOW_POOL_NAMESPACE``.
+    """
+    logging.basicConfig(level=logging.INFO)
+    raise SystemExit(
+        asyncio.run(serve(namespace=namespace, workers=workers))
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/cfdb/workflows/worker_main.py
+++ b/src/cfdb/workflows/worker_main.py
@@ -1,0 +1,306 @@
+"""ECS Fargate worker entrypoint.
+
+This module is the ``CMD`` for the worker container image. It boots a
+``wool.LocalWorker`` on a known port, exposes a tiny HTTP health endpoint
+the ECS health check probes, handles SIGTERM cleanly so ``ecs.stop_task``
+cycles drain in-flight work, and self-terminates after a configurable
+maximum lifetime so workers don't accumulate when the dispatch rate falls.
+
+No discovery registration code lives here. ``EcsDiscovery`` polls ECS's
+own task state to surface running workers; the worker only needs to
+bind its gRPC port and respond ``200 OK`` to the health probe.
+
+Environment variables (single source of truth; CLI flags mirror them):
+
+* ``CFDB_WORKER_GRPC_PORT`` — gRPC port wool binds (default 50051).
+* ``CFDB_WORKER_HEALTH_PORT`` — HTTP ``/health`` port the ECS
+  ``healthCheck`` probes (default 8080).
+* ``CFDB_WORKER_MAX_LIFETIME_SECONDS`` — hard ceiling on worker
+  uptime; 0 disables. One hour above
+  :data:`cfdb.workflows.WORKFLOW_DURATION_CAP_S` so a worker started
+  shortly before a long sort can still outlive the job.
+* ``CFDB_WORKER_DRAIN_GRACE_SECONDS`` — how long ``/health`` returns
+  503 after SIGTERM before tearing down the gRPC port. A second
+  SIGTERM short-circuits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Optional
+
+import click
+import wool
+
+from cfdb.workflows.constants import DEFAULT_WORKER_PORT
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["main", "serve"]
+
+#: Default health probe HTTP port — distinct from the gRPC port so
+#: ``healthCheck`` can ``curl`` it without speaking gRPC.
+DEFAULT_HEALTH_PORT = 8080
+
+#: Default maximum wall-clock lifetime of a worker process. Wool exposes
+#: no per-job activity hook today, so the worker can't tell idle from
+#: busy; this is a hard ceiling — ECS replaces the task after this long.
+#: Sized one hour above :data:`cfdb.workflows.WORKFLOW_DURATION_CAP_S`
+#: (default 4 h) so a worker started shortly before a long sort can
+#: still outlive the job. Note: max-lifetime expiry exits without the
+#: drain-grace window the SIGTERM path provides — operators that want
+#: a cleaner handoff should rely on ECS rolling tasks via service
+#: updates rather than waiting for max-lifetime to fire.
+DEFAULT_MAX_LIFETIME_SECONDS = 5 * 60 * 60
+
+#: How long to keep returning ``503`` on ``/health`` after SIGTERM,
+#: giving ECS a chance to observe ``unhealthy`` and drain at the load
+#: balancer before we tear the gRPC port down. ECS health checks
+#: default to ~30 s interval × 3 unhealthy retries = ~90 s worst case
+#: to mark the task unhealthy; we hold for 120 s by default to leave
+#: real margin even when the task definition uses ECS-default health
+#: check cadence. Operators tightening ``healthCheck.interval`` to
+#: ~10-15 s can lower this further via ``CFDB_WORKER_DRAIN_GRACE_SECONDS``.
+DEFAULT_DRAIN_GRACE_SECONDS = 120.0
+
+#: Cadence of the main loop's wakeup when waiting on ``stop_event``.
+#: One second balances precision (max-lifetime checks fire within ~1 s
+#: of the target) against CPU churn over a multi-hour worker lifetime
+#: (~3600 wakeups/h vs. ~3.6 M at 1 ms). Sub-second granularity is
+#: unnecessary because the upstream coarse-grained signals
+#: (SIGTERM-on-stop_task, ~hours-scale max-lifetime) don't need it.
+_STOP_POLL_INTERVAL_SECONDS = 1.0
+
+
+async def serve(
+    *,
+    worker_port: int = DEFAULT_WORKER_PORT,
+    health_port: int = DEFAULT_HEALTH_PORT,
+    max_lifetime_seconds: float = DEFAULT_MAX_LIFETIME_SECONDS,
+    drain_grace_seconds: float = DEFAULT_DRAIN_GRACE_SECONDS,
+) -> int:
+    """Run the worker until SIGTERM or maximum lifetime elapses.
+
+    Returns ``0`` on clean shutdown (SIGTERM, SIGINT, or max-lifetime).
+    Bind failures and other early-startup errors raise out — ``main``
+    propagates them and the process exits with a Python traceback,
+    which surfaces the cause in container logs more clearly than a
+    silent non-zero status.
+
+    A second SIGTERM during drain short-circuits the grace window
+    (operator impatience or ECS escalating before SIGKILL); the worker
+    stops immediately.
+    """
+    stop_event = asyncio.Event()
+    force_stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    started_at = loop.time()
+
+    def _signal_handler() -> None:
+        if stop_event.is_set():
+            logger.info("Second termination signal — exiting drain immediately")
+            force_stop_event.set()
+        else:
+            logger.info("Received termination signal — draining worker")
+            stop_event.set()
+
+    def _signal_handler_threaded(*_: object) -> None:
+        # Fallback for platforms (notably Windows in CI) where
+        # ``loop.add_signal_handler`` raises ``NotImplementedError``.
+        # Defined once so the closure isn't rebuilt per signal.
+        loop.call_soon_threadsafe(_signal_handler)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _signal_handler)
+        except NotImplementedError:
+            signal.signal(sig, _signal_handler_threaded)
+
+    health_runner = await _start_health_server(
+        health_port, lambda: stop_event.is_set()
+    )
+
+    worker = wool.LocalWorker(host="0.0.0.0", port=worker_port)
+    await worker.start()
+    try:
+        logger.info(
+            "Wool worker listening on port %d (health on %d)",
+            worker_port,
+            health_port,
+        )
+        while True:
+            # Check the self-termination path first. Max-lifetime is a
+            # local hard ceiling: the gap between ``stop_event.set()``
+            # and ``worker.stop()`` is microseconds — no health probe
+            # will actually fire during it, so this is a defense-in-
+            # depth flip rather than a real drain window. Operators
+            # that need a true drain handoff on max-lifetime should
+            # roll tasks via ECS service updates instead of relying
+            # on the self-timeout. Flipping /health to 503 still costs
+            # nothing and keeps the in-process ordering consistent
+            # with the signal path's drain semantics.
+            if (
+                max_lifetime_seconds > 0
+                and (loop.time() - started_at) >= max_lifetime_seconds
+            ):
+                logger.info(
+                    "Max lifetime (%.0fs) reached — exiting",
+                    max_lifetime_seconds,
+                )
+                stop_event.set()
+                break
+            if stop_event.is_set():
+                # Signal-initiated shutdown. Hold the gRPC port open
+                # while ECS observes 503 on /health and stops routing
+                # new dispatches. A second signal flips
+                # force_stop_event and we exit the wait early.
+                if drain_grace_seconds > 0:
+                    logger.info(
+                        "Draining for up to %.0fs before exiting",
+                        drain_grace_seconds,
+                    )
+                    try:
+                        await asyncio.wait_for(
+                            force_stop_event.wait(),
+                            timeout=drain_grace_seconds,
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                break
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(), timeout=_STOP_POLL_INTERVAL_SECONDS
+                )
+            except asyncio.TimeoutError:
+                continue
+        return 0
+    finally:
+        try:
+            await worker.stop()
+        except Exception:
+            logger.exception("worker.stop() failed during shutdown")
+        await _shutdown_health_server(health_runner)
+
+
+async def _start_health_server(
+    port: int, draining: Callable[[], bool]
+) -> "web.AppRunner":
+    """Start a tiny HTTP server returning ``200 OK`` on ``/health``.
+
+    The container's ECS ``healthCheck`` runs ``curl`` against this
+    endpoint, so the response shape doesn't matter — only the status
+    code does. While ``draining`` returns True (i.e. we're shutting
+    down), the endpoint returns ``503`` so ECS can mark the task
+    unhealthy and the load balancer / discovery can drain it before
+    ``ecs.stop_task`` actually kills the gRPC port.
+
+    Cleans up the partial runner on bind failure so the caller's
+    finally doesn't have a half-initialized object to deal with.
+    """
+    from aiohttp import web
+
+    async def _health(_: web.Request) -> web.Response:
+        if draining():
+            return web.Response(status=503, text="draining")
+        return web.Response(status=200, text="ok")
+
+    app = web.Application()
+    app.router.add_get("/health", _health)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        site = web.TCPSite(runner, host="0.0.0.0", port=port)
+        await site.start()
+    except Exception:
+        await runner.cleanup()
+        raise
+    return runner
+
+
+async def _shutdown_health_server(runner: Optional["web.AppRunner"]) -> None:
+    """Tear down the aiohttp ``AppRunner`` started by ``_start_health_server``.
+
+    Tolerates ``runner is None`` so the caller's ``finally`` can run
+    even when the health server failed to start in the first place.
+    Cleanup exceptions are logged but swallowed: the worker is already
+    on its way out, and surfacing a teardown error would mask the
+    upstream cause (whatever triggered the shutdown).
+    """
+    if runner is None:
+        return
+    try:
+        await runner.cleanup()
+    except Exception:
+        logger.exception("health server cleanup failed")
+
+
+@click.command()
+@click.option(
+    "--worker-port",
+    type=click.IntRange(1, 65535),
+    envvar="CFDB_WORKER_GRPC_PORT",
+    default=DEFAULT_WORKER_PORT,
+    show_default=True,
+    help="gRPC port the wool worker binds.",
+)
+@click.option(
+    "--health-port",
+    type=click.IntRange(1, 65535),
+    envvar="CFDB_WORKER_HEALTH_PORT",
+    default=DEFAULT_HEALTH_PORT,
+    show_default=True,
+    help="HTTP port the ECS health-check endpoint binds.",
+)
+@click.option(
+    "--max-lifetime-seconds",
+    type=click.FloatRange(min=0),
+    envvar="CFDB_WORKER_MAX_LIFETIME_SECONDS",
+    default=DEFAULT_MAX_LIFETIME_SECONDS,
+    show_default=True,
+    help="Hard ceiling on worker uptime in seconds; 0 disables.",
+)
+@click.option(
+    "--drain-grace-seconds",
+    type=click.FloatRange(min=0),
+    envvar="CFDB_WORKER_DRAIN_GRACE_SECONDS",
+    default=DEFAULT_DRAIN_GRACE_SECONDS,
+    show_default=True,
+    help=(
+        "Seconds to keep returning 503 on /health after SIGTERM before "
+        "tearing down the gRPC port. A second SIGTERM short-circuits."
+    ),
+)
+def main(
+    worker_port: int,
+    health_port: int,
+    max_lifetime_seconds: float,
+    drain_grace_seconds: float,
+) -> None:
+    """ECS Fargate worker entrypoint — invoked by the container CMD.
+
+    Boots a wool gRPC worker, exposes /health for ECS to probe, and
+    self-terminates after the max-lifetime ceiling. SIGTERM begins a
+    drain grace window during which /health returns 503 so the load
+    balancer can drop the worker before the gRPC port closes.
+    """
+    logging.basicConfig(level=logging.INFO)
+    raise SystemExit(
+        asyncio.run(
+            serve(
+                worker_port=worker_port,
+                health_port=health_port,
+                max_lifetime_seconds=max_lifetime_seconds,
+                drain_grace_seconds=drain_grace_seconds,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -586,7 +586,6 @@ async def integration_executor(
     executor = WoolExecutor(
         install_jobs_index,
         cache,
-        integration_cache_root,
         registry,
         workdir_root=integration_workdir_root,
     )

--- a/tests/integration/routines.py
+++ b/tests/integration/routines.py
@@ -20,6 +20,8 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, Final
 
+from cfdb.workflows.cache import CacheBackend
+from cfdb.workflows.events import Complete, StageComplete, WorkflowEvent
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.processors.base import Processor
 
@@ -87,17 +89,17 @@ class StubProcessor(Processor):
         self,
         file_meta: dict[str, Any],
         workdir: Path,
-        cache_root: Path,
-    ) -> AsyncIterator[dict[str, Any]]:
+        cache: CacheBackend,
+    ) -> AsyncIterator[WorkflowEvent]:
         if self.sleep_seconds > 0:
             await asyncio.sleep(self.sleep_seconds)
         if self.raise_during_stage is not None:
             raise self.raise_during_stage
         for kind, key in self.artifacts.items():
-            yield {"event": "stage_complete", "kind": kind, "key": key}
+            yield StageComplete(kind=ArtifactKind(kind), key=key)
             if self.sleep_between_yields > 0:
                 await asyncio.sleep(self.sleep_between_yields)
-        yield {"event": "complete", "artifacts": dict(self.artifacts)}
+        yield Complete(artifacts=dict(self.artifacts))
 
 
 def stub_file_meta() -> dict[str, Any]:

--- a/tests/integration/test_concurrency.py
+++ b/tests/integration/test_concurrency.py
@@ -33,6 +33,8 @@ from tests.integration.conftest import (
     make_file_meta,
 )
 
+pytestmark = pytest.mark.integration
+
 
 def _job_id_from_202(resp) -> str:
     assert isinstance(resp, JSONResponse)

--- a/tests/integration/test_direct_processors.py
+++ b/tests/integration/test_direct_processors.py
@@ -23,6 +23,7 @@ import subprocess
 import pytest
 
 from cfdb.workflows.cache import LocalFsCache
+from cfdb.workflows.events import Complete, StageComplete
 from cfdb.workflows.processors import bam as bam_module
 from cfdb.workflows.processors import tabix as tabix_module
 from cfdb.workflows.processors.bam import BamIndexProcessor
@@ -91,10 +92,13 @@ class TestBamIndexProcessorDirectCall:
         # Act — drain the processor's async-generator event stream and
         # extract the artifact mapping from the terminal ``complete`` event.
         events = [
-            e async for e in BamIndexProcessor().run(file_meta, workdir, cache_root)
+            e
+            async for e in BamIndexProcessor().run(
+                file_meta, workdir, LocalFsCache(cache_root)
+            )
         ]
-        complete = next(e for e in reversed(events) if e.get("event") == "complete")
-        artifacts = complete["artifacts"]
+        complete = next(e for e in reversed(events) if isinstance(e, Complete))
+        artifacts = complete.artifacts
 
         # Assert — only the index is produced; data falls through to upstream.
         cache = LocalFsCache(cache_root)
@@ -193,24 +197,17 @@ class TestBamIndexProcessorDirectCall:
 
         # Act
         events = [
-            e async for e in BamIndexProcessor().run(file_meta, workdir, cache_root)
+            e
+            async for e in BamIndexProcessor().run(
+                file_meta, workdir, LocalFsCache(cache_root)
+            )
         ]
 
         # Assert
-        kinds = [
-            (e.get("event"), e.get("kind"))
-            for e in events
-            if e.get("event") == "stage_complete"
-        ]
-        assert (
-            "stage_complete",
-            ArtifactKind.DATA.value,
-        ) in kinds
-        assert (
-            "stage_complete",
-            ArtifactKind.INDEX.value,
-        ) in kinds
-        assert any(e.get("event") == "complete" for e in events)
+        kinds = [e.kind for e in events if isinstance(e, StageComplete)]
+        assert ArtifactKind.DATA in kinds
+        assert ArtifactKind.INDEX in kinds
+        assert any(isinstance(e, Complete) for e in events)
         assert shell_invocations == [], (
             "Stage-1 convert+sort pipeline must not run when the data "
             f"cache is warm; got invocations: {shell_invocations!r}"
@@ -277,11 +274,11 @@ class TestTabixIntervalProcessorDirectCall:
         events = [
             e
             async for e in TabixIntervalProcessor().run(
-                file_meta, workdir, cache_root
+                file_meta, workdir, LocalFsCache(cache_root)
             )
         ]
-        complete = next(e for e in reversed(events) if e.get("event") == "complete")
-        artifacts = complete["artifacts"]
+        complete = next(e for e in reversed(events) if isinstance(e, Complete))
+        artifacts = complete.artifacts
 
         # Assert
         cache = LocalFsCache(cache_root)
@@ -339,11 +336,11 @@ class TestTabixIntervalProcessorDirectCall:
         events = [
             e
             async for e in TabixIntervalProcessor().run(
-                file_meta, workdir, cache_root
+                file_meta, workdir, LocalFsCache(cache_root)
             )
         ]
-        complete = next(e for e in reversed(events) if e.get("event") == "complete")
-        artifacts = complete["artifacts"]
+        complete = next(e for e in reversed(events) if isinstance(e, Complete))
+        artifacts = complete.artifacts
 
         # Assert
         cache = LocalFsCache(cache_root)
@@ -416,16 +413,16 @@ class TestTabixIntervalProcessorDirectCall:
         events = [
             e
             async for e in TabixIntervalProcessor().run(
-                file_meta, workdir, cache_root
+                file_meta, workdir, LocalFsCache(cache_root)
             )
         ]
 
         # Assert
         complete = next(
-            (e for e in reversed(events) if e.get("event") == "complete"), None
+            (e for e in reversed(events) if isinstance(e, Complete)), None
         )
         assert complete is not None, "expected a terminal complete event"
-        artifacts = complete["artifacts"]
+        artifacts = complete.artifacts
         cache = LocalFsCache(cache_root)
 
         bgz_path = tmp_path / "out.bgz"

--- a/tests/integration/test_executor_boundary.py
+++ b/tests/integration/test_executor_boundary.py
@@ -40,20 +40,20 @@ def _make_executor(
     mock_db,
     tmp_path,
     processor: StubProcessor,
-    *,
-    workflow_duration_cap_seconds: int = 1200,
 ) -> WoolExecutor:
-    """Wire a WoolExecutor with a single StubProcessor registered."""
+    """Wire a WoolExecutor with a single StubProcessor registered.
+
+    The duration cap is module-level; tests that need to shrink it
+    monkeypatch ``executor._WORKFLOW_DURATION_CAP_SECONDS`` directly.
+    """
     cache = LocalFsCache(tmp_path / "cache")
     registry = ProcessorRegistry()
     registry.register(processor)
     return WoolExecutor(
         mock_db,
         cache,
-        cache.root,
         registry,
         workdir_root=tmp_path / "jobs",
-        workflow_duration_cap_seconds=workflow_duration_cap_seconds,
     )
 
 
@@ -140,7 +140,7 @@ class TestWoolExecutorPickleBoundary:
 
     @pytest.mark.asyncio
     async def test_ensure_workflow_should_record_failed_when_workflow_duration_cap_fires(
-        self, mock_db, tmp_path, wool_pool
+        self, mock_db, tmp_path, wool_pool, monkeypatch
     ):
         """Test that the runtime cap forces a clean FAILED termination.
 
@@ -165,9 +165,10 @@ class TestWoolExecutorPickleBoundary:
         # around the ``async for`` loop, so a pre-yield sleep does not
         # exercise the cap path. Between-yields blocking does.
         processor = StubProcessor(sleep_between_yields=5.0)
-        executor = _make_executor(
-            mock_db, tmp_path, processor, workflow_duration_cap_seconds=1
-        )
+        from cfdb.workflows import executor as executor_module
+
+        monkeypatch.setattr(executor_module, "_WORKFLOW_DURATION_CAP_SECONDS", 1)
+        executor = _make_executor(mock_db, tmp_path, processor)
 
         # Act
         try:

--- a/tests/integration/test_mongo_partial_unique.py
+++ b/tests/integration/test_mongo_partial_unique.py
@@ -63,7 +63,7 @@ _CLAIM_MD5: str = "d41d8cd98f00b204e9800998ecf8427e"
 
 
 def _claim_args(
-    workflow_key: str = f"encode/x/d41d8cd98f00b204e9800998ecf8427e/v1",
+    workflow_key: str = "encode/x/d41d8cd98f00b204e9800998ecf8427e/v1",
 ) -> dict:
     """Return the keyword arguments shared across claim_workflow calls."""
     return dict(

--- a/tests/integration/test_processor_e2e.py
+++ b/tests/integration/test_processor_e2e.py
@@ -168,7 +168,7 @@ class TestProcessorE2E:
             assert final.stages_done == ["index"]
             assert "data" not in final.artifact_cache_keys
 
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             cached_bai = cache_root / final.artifact_cache_keys["index"]
             assert cached_bai.stat().st_size > 0
 
@@ -222,7 +222,7 @@ class TestProcessorE2E:
             # Assert
             final = await get_job(install_jobs_index, record.job_id)
             assert final is not None and final.status == JobStatus.COMPLETED
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             cached_bam = cache_root / final.artifact_cache_keys["data"]
             subprocess.run(
                 ["samtools", "quickcheck", str(cached_bam)],
@@ -275,7 +275,7 @@ class TestProcessorE2E:
             final = await get_job(install_jobs_index, record.job_id)
             assert final is not None and final.status == JobStatus.COMPLETED
 
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             cached_bgz = cache_root / final.artifact_cache_keys["data"]
             cached_tbi = cache_root / final.artifact_cache_keys["index"]
             assert cached_bgz.stat().st_size > 0
@@ -357,7 +357,7 @@ class TestProcessorE2E:
             final = await get_job(install_jobs_index, record.job_id)
             assert final is not None and final.status == JobStatus.COMPLETED
 
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             cached_bgz = cache_root / final.artifact_cache_keys["data"]
             cached_tbi = cache_root / final.artifact_cache_keys["index"]
             assert cached_bgz.stat().st_size > 0
@@ -412,7 +412,7 @@ class TestProcessorE2E:
             # Assert
             final = await get_job(install_jobs_index, record.job_id)
             assert final is not None and final.status == JobStatus.COMPLETED
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             cached_bgz = cache_root / final.artifact_cache_keys["data"]
             decoded = gzip.decompress(cached_bgz.read_bytes()).decode()
             data_lines = [
@@ -459,7 +459,7 @@ class TestProcessorE2E:
             # Assert
             final = await get_job(install_jobs_index, record.job_id)
             assert final is not None and final.status == JobStatus.COMPLETED
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             cached_bgz = cache_root / final.artifact_cache_keys["data"]
             cached_tbi = cache_root / final.artifact_cache_keys["index"]
             assert cached_bgz.stat().st_size > 0
@@ -505,7 +505,7 @@ class TestProcessorE2E:
             # Assert
             final = await get_job(install_jobs_index, record.job_id)
             assert final is not None and final.status == JobStatus.COMPLETED
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             cached_bgz = cache_root / final.artifact_cache_keys["data"]
             cached_tbi = cache_root / final.artifact_cache_keys["index"]
             assert cached_bgz.stat().st_size > 0
@@ -556,7 +556,7 @@ class TestProcessorE2E:
             assert (
                 first_final is not None and first_final.status == JobStatus.COMPLETED
             )
-            cache_root = integration_executor._cache_root
+            cache_root = integration_executor._cache.root
             first_data = (
                 cache_root / first_final.artifact_cache_keys["data"]
             ).read_bytes()

--- a/tests/integration/test_router_e2e.py
+++ b/tests/integration/test_router_e2e.py
@@ -11,12 +11,10 @@ exercising the full workflow logic, cache lookup, and streaming path.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import re
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path
 
 import pytest
 from allpairspy import AllPairs
@@ -252,7 +250,7 @@ class TestRouterE2E:
             )
             final = await get_job(mock_db, job_id)
             assert final is not None
-            cache_root = wired_api._cache_root
+            cache_root = wired_api._cache.root
             cached_path = cache_root / final.artifact_cache_keys["index"]
             payload = cached_path.read_bytes()
             size = len(payload)
@@ -307,7 +305,7 @@ class TestRouterE2E:
             )
             final = await get_job(mock_db, job_id)
             assert final is not None
-            cache_root = wired_api._cache_root
+            cache_root = wired_api._cache.root
             cached_path = cache_root / final.artifact_cache_keys["index"]
             size = cached_path.stat().st_size
 
@@ -486,7 +484,6 @@ class TestRouterE2E:
         from cfdb.workflows.processors.passthrough import PassthroughProcessor
         from cfdb.workflows.processors.registry import ProcessorRegistry
 
-        registry: ProcessorRegistry = wired_api._registry
         # The wired registry only has BAM + tabix processors, not
         # passthrough. Build a fresh probe registry to confirm the
         # passthrough lookup behavior.
@@ -778,7 +775,7 @@ class TestRouterE2E:
 
             final = await get_job(mock_db, job_id)
             assert final is not None
-            cache_root = wired_api._cache_root
+            cache_root = wired_api._cache.root
             cached_path = cache_root / final.artifact_cache_keys["index"]
             cached_bytes = cached_path.read_bytes()
             size = len(cached_bytes)

--- a/tests/test_api/test_env_parsers.py
+++ b/tests/test_api/test_env_parsers.py
@@ -1,0 +1,75 @@
+"""Tests for the env-var parsers in :mod:`cfdb.api`."""
+
+from __future__ import annotations
+
+import pytest
+
+from cfdb.api import _parse_assign_public_ip
+
+
+class TestParseAssignPublicIp:
+    def test__parse_assign_public_ip_with_unset_var(self, monkeypatch):
+        """Test that an unset env var returns the supplied default.
+
+        Given:
+            No environment variable set for the given name.
+        When:
+            ``_parse_assign_public_ip`` is called with a default value.
+        Then:
+            It should return the default rather than raising so the PoC
+            profile (no ECS env) still imports cleanly.
+        """
+        # Arrange
+        monkeypatch.delenv("CFDB_TEST_ASSIGN_PUBLIC_IP", raising=False)
+
+        # Act
+        result = _parse_assign_public_ip(
+            "CFDB_TEST_ASSIGN_PUBLIC_IP", default="DISABLED"
+        )
+
+        # Assert
+        assert result == "DISABLED"
+
+    def test__parse_assign_public_ip_with_valid_value(self, monkeypatch):
+        """Test that an in-set value is returned as-is.
+
+        Given:
+            ``CFDB_TEST_ASSIGN_PUBLIC_IP=ENABLED``.
+        When:
+            ``_parse_assign_public_ip`` is called.
+        Then:
+            It should return ``"ENABLED"`` unchanged so the lifespan can
+            hand it to ``EcsProvisioner`` verbatim.
+        """
+        # Arrange
+        monkeypatch.setenv("CFDB_TEST_ASSIGN_PUBLIC_IP", "ENABLED")
+
+        # Act
+        result = _parse_assign_public_ip(
+            "CFDB_TEST_ASSIGN_PUBLIC_IP", default="DISABLED"
+        )
+
+        # Assert
+        assert result == "ENABLED"
+
+    def test__parse_assign_public_ip_with_invalid_value(self, monkeypatch):
+        """Test that an out-of-set value surfaces as an ImportError.
+
+        Given:
+            ``CFDB_TEST_ASSIGN_PUBLIC_IP`` set to an invalid value
+            (lowercase, typo, anything outside {ENABLED, DISABLED}).
+        When:
+            ``_parse_assign_public_ip`` is called.
+        Then:
+            It should raise ``ImportError`` so the misconfiguration
+            surfaces at module load rather than crashing the lifespan
+            mid-bootstrap.
+        """
+        # Arrange
+        monkeypatch.setenv("CFDB_TEST_ASSIGN_PUBLIC_IP", "enabled")
+
+        # Act & assert
+        with pytest.raises(ImportError, match="must be one of"):
+            _parse_assign_public_ip(
+                "CFDB_TEST_ASSIGN_PUBLIC_IP", default="DISABLED"
+            )

--- a/tests/test_api/test_provisioner_gate.py
+++ b/tests/test_api/test_provisioner_gate.py
@@ -1,0 +1,118 @@
+"""Tests for ``WorkflowProfile.from_env``'s partial-ECS gate.
+
+The Q24 refactor folded ``_maybe_build_provisioner`` into
+:meth:`cfdb.api.profile.WorkflowProfile.from_env` — the Q26 raise on
+partial ECS config now lives in the profile's ``_ecs_config_from_env``
+helper. These tests exercise that contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cfdb import api
+from cfdb.api.profile import WorkflowProfile
+
+
+class TestWorkflowProfileEcsGate:
+    def test_from_env_with_no_ecs_env_produces_local_or_s3_profile(
+        self, monkeypatch, tmp_path
+    ):
+        """Test that the PoC profile falls through to ``local`` without raising.
+
+        Given:
+            ``SYNC_DATA_DIR`` set so the workflow subsystem activates,
+            and no ECS env vars set.
+        When:
+            ``WorkflowProfile.from_env`` is invoked.
+        Then:
+            It should return a profile of kind ``"local"`` with no
+            ECS config attached, exercising the PoC path that the
+            laptop-dev profile depends on.
+        """
+        # Arrange
+        monkeypatch.setattr(api, "SYNC_DATA_DIR", str(tmp_path))
+        monkeypatch.setattr(api, "WORKFLOW_S3_BUCKET", None)
+        monkeypatch.setattr(api, "ECS_CLUSTER", None)
+        monkeypatch.setattr(api, "ECS_WORKER_TASK_DEFINITION", None)
+        monkeypatch.setattr(api, "ECS_WORKER_SUBNETS", [])
+
+        # Act
+        profile = WorkflowProfile.from_env()
+
+        # Assert
+        assert profile is not None
+        assert profile.kind == "local"
+        assert profile.ecs is None
+        assert profile.s3 is None
+
+    def test_from_env_with_cluster_but_missing_task_def_raises(
+        self, monkeypatch, tmp_path
+    ):
+        """Test that a partial config (cluster but no task-def) raises.
+
+        Given:
+            ``SYNC_DATA_DIR`` and ``ECS_CLUSTER`` set but
+            ``ECS_WORKER_TASK_DEFINITION`` unset.
+        When:
+            ``WorkflowProfile.from_env`` is invoked.
+        Then:
+            It should raise ``RuntimeError`` naming the missing knob
+            so operators see the misconfiguration at boot rather than
+            silently degrading to the PoC profile.
+        """
+        # Arrange
+        monkeypatch.setattr(api, "SYNC_DATA_DIR", str(tmp_path))
+        monkeypatch.setattr(api, "ECS_CLUSTER", "cfdb-prod")
+        monkeypatch.setattr(api, "ECS_WORKER_TASK_DEFINITION", None)
+        monkeypatch.setattr(api, "ECS_WORKER_SUBNETS", ["subnet-a"])
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="ECS_WORKER_TASK_DEFINITION"):
+            WorkflowProfile.from_env()
+
+    def test_from_env_with_cluster_but_empty_subnets_raises(
+        self, monkeypatch, tmp_path
+    ):
+        """Test that a partial config (cluster but no subnets) raises.
+
+        Given:
+            ``SYNC_DATA_DIR``, ``ECS_CLUSTER``, and
+            ``ECS_WORKER_TASK_DEFINITION`` set but
+            ``ECS_WORKER_SUBNETS`` empty.
+        When:
+            ``WorkflowProfile.from_env`` is invoked.
+        Then:
+            It should raise ``RuntimeError`` naming the missing knob so
+            an awsvpc-mode worker cannot be launched without subnets.
+        """
+        # Arrange
+        monkeypatch.setattr(api, "SYNC_DATA_DIR", str(tmp_path))
+        monkeypatch.setattr(api, "ECS_CLUSTER", "cfdb-prod")
+        monkeypatch.setattr(api, "ECS_WORKER_TASK_DEFINITION", "cfdb-worker")
+        monkeypatch.setattr(api, "ECS_WORKER_SUBNETS", [])
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="ECS_WORKER_SUBNETS"):
+            WorkflowProfile.from_env()
+
+    def test_from_env_with_sync_data_dir_unset_returns_none(self, monkeypatch):
+        """Test that the workflow subsystem stays disabled when SYNC_DATA_DIR is unset.
+
+        Given:
+            ``SYNC_DATA_DIR`` unset.
+        When:
+            ``WorkflowProfile.from_env`` is invoked.
+        Then:
+            It should return None so the lifespan skips workflow
+            initialization and routers fall back to their
+            direct-streaming paths.
+        """
+        # Arrange
+        monkeypatch.setattr(api, "SYNC_DATA_DIR", None)
+
+        # Act
+        profile = WorkflowProfile.from_env()
+
+        # Assert
+        assert profile is None

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -161,7 +161,6 @@ class TestStreamFileWorkflowPath:
             WoolExecutor(
                 mock_db,
                 api.cache,
-                "/tmp/cfdb/cache",
                 registry,
                 workdir_root="/tmp/cfdb/jobs",
             ),

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -416,7 +416,6 @@ class TestStreamIndexFileWorkflowPaths:
             WoolExecutor(
                 mock_db,
                 api.cache,
-                api.cache.root,
                 api.processor_registry,
                 workdir_root=tmp_path / "jobs",
             ),
@@ -663,7 +662,6 @@ class TestStreamIndexFileWorkflowPaths:
             WoolExecutor(
                 mock_db,
                 api.cache,
-                "/tmp/cfdb/cache",
                 registry,
                 workdir_root="/tmp/cfdb/jobs",
             ),

--- a/tests/test_workflows/test_cache_s3.py
+++ b/tests/test_workflows/test_cache_s3.py
@@ -1,0 +1,240 @@
+"""Tests for the moto-backed S3Cache implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from cfdb.workflows.cache import CacheEntry, S3Cache
+
+
+_BUCKET = "cfdb-test-cache"
+
+
+def _write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+async def _collect(stream) -> bytes:
+    chunks: list[bytes] = []
+    async for chunk in stream:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@pytest.fixture()
+def s3_client():
+    """Return a moto-backed boto3 S3 client with one created bucket."""
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=_BUCKET)
+        yield client
+
+
+@pytest.fixture()
+def cache(s3_client, tmp_path) -> S3Cache:
+    """Return an S3Cache wired up to the moto-backed client."""
+    return S3Cache(bucket=_BUCKET, client=s3_client)
+
+
+class TestS3Cache:
+    def test___init___with_empty_bucket_name(self, s3_client, tmp_path):
+        """Test that S3Cache rejects an empty bucket name.
+
+        Given:
+            A moto-backed S3 client and an empty bucket name.
+        When:
+            S3Cache is constructed.
+        Then:
+            It should raise ValueError so misconfigurations fail fast.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="bucket"):
+            S3Cache(bucket="", client=s3_client)
+
+    @pytest.mark.asyncio
+    async def test_head_with_absent_key(self, cache):
+        """Test that head reports a cache miss as None.
+
+        Given:
+            An empty S3Cache.
+        When:
+            head is awaited for an unknown key.
+        Then:
+            It should return None so the router can dispatch a workflow.
+        """
+        # Act
+        entry = await cache.head("encode/x/data/aa-v0")
+
+        # Assert
+        assert entry is None
+
+    @pytest.mark.asyncio
+    async def test_put_then_head_with_known_payload(self, cache, tmp_path):
+        """Test that put commits the artifact and head reports its size.
+
+        Given:
+            An S3Cache and a source file with known contents.
+        When:
+            put commits the artifact and head is then awaited.
+        Then:
+            head should return a CacheEntry carrying the exact byte size.
+        """
+        # Arrange
+        source = tmp_path / "src"
+        _write(source, b"hello world")
+
+        # Act
+        await cache.put("encode/x/data/aa-v0", source)
+        entry = await cache.head("encode/x/data/aa-v0")
+
+        # Assert
+        assert entry == CacheEntry(key="encode/x/data/aa-v0", size=11)
+
+    @pytest.mark.asyncio
+    async def test_get_with_full_object(self, cache, tmp_path):
+        """Test that get streams the full artifact without a byte range.
+
+        Given:
+            An S3Cache containing a multi-chunk artifact.
+        When:
+            get is iterated without a byte_range argument.
+        Then:
+            It should yield the complete bytes.
+        """
+        # Arrange
+        source = tmp_path / "src"
+        payload = b"0123456789" * 20_000
+        _write(source, payload)
+        await cache.put("encode/x/data/aa-v0", source)
+
+        # Act
+        collected = await _collect(cache.get("encode/x/data/aa-v0"))
+
+        # Assert
+        assert collected == payload
+
+    @pytest.mark.asyncio
+    async def test_get_with_inclusive_byte_range(self, cache, tmp_path):
+        """Test that get forwards an inclusive byte range to S3.
+
+        Given:
+            An S3Cache containing a known artifact.
+        When:
+            get is iterated with byte_range=(5, 9).
+        Then:
+            It should yield exactly bytes 5..9 inclusive (5 bytes total).
+        """
+        # Arrange
+        source = tmp_path / "src"
+        _write(source, b"0123456789ABCDEF")
+        await cache.put("encode/x/data/aa-v0", source)
+
+        # Act
+        collected = await _collect(cache.get("encode/x/data/aa-v0", (5, 9)))
+
+        # Assert
+        assert collected == b"56789"
+
+    @pytest.mark.asyncio
+    async def test_get_with_absent_key(self, cache):
+        """Test that get yields nothing for an absent key.
+
+        Given:
+            An empty S3Cache.
+        When:
+            get is iterated for a missing key.
+        Then:
+            It should yield no chunks rather than raise.
+        """
+        # Act
+        collected = await _collect(cache.get("encode/x/data/aa-v0"))
+
+        # Assert
+        assert collected == b""
+
+    @pytest.mark.asyncio
+    async def test_delete_with_present_key(self, cache, tmp_path):
+        """Test that delete reports True and removes the artifact.
+
+        Given:
+            An S3Cache containing one entry.
+        When:
+            delete is awaited for that key.
+        Then:
+            It should return True and a subsequent head should miss.
+        """
+        # Arrange
+        source = tmp_path / "src"
+        _write(source, b"x")
+        await cache.put("encode/x/data/aa-v0", source)
+
+        # Act
+        deleted = await cache.delete("encode/x/data/aa-v0")
+
+        # Assert
+        assert deleted is True
+        assert await cache.head("encode/x/data/aa-v0") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_with_absent_key(self, cache):
+        """Test that delete on a missing key is idempotent.
+
+        Given:
+            An empty S3Cache.
+        When:
+            delete is awaited for an unknown key.
+        Then:
+            It should return False rather than raise.
+        """
+        # Act & assert
+        assert await cache.delete("encode/x/data/aa-v0") is False
+
+    @pytest.mark.asyncio
+    async def test_put_with_traversal_segment_key(self, cache, tmp_path):
+        """Test that put refuses keys containing path-traversal segments.
+
+        Given:
+            An S3Cache and a key with a ``..`` segment.
+        When:
+            put is awaited with that key.
+        Then:
+            It should raise ValueError rather than write under a parent prefix.
+        """
+        # Arrange
+        source = tmp_path / "src"
+        _write(source, b"x")
+
+        # Act & assert
+        with pytest.raises(ValueError):
+            await cache.put("../oops", source)
+
+    @pytest.mark.asyncio
+    async def test_put_then_head_with_configured_prefix(self, s3_client, tmp_path):
+        """Test that the configured prefix is applied to every operation.
+
+        Given:
+            An S3Cache configured with a non-empty prefix.
+        When:
+            put writes a key and head reads it back.
+        Then:
+            The object should land under ``<prefix>/<key>`` and head should
+            report its size correctly.
+        """
+        # Arrange
+        cache = S3Cache(bucket=_BUCKET, prefix="env/dev", client=s3_client)
+        source = tmp_path / "src"
+        _write(source, b"abc")
+
+        # Act
+        await cache.put("encode/x/data/aa-v0", source)
+        entry = await cache.head("encode/x/data/aa-v0")
+
+        # Assert — moto stores under the prefixed key, not the raw key
+        assert entry == CacheEntry(key="encode/x/data/aa-v0", size=3)
+        listing = s3_client.list_objects_v2(Bucket=_BUCKET).get("Contents", [])
+        assert {item["Key"] for item in listing} == {"env/dev/encode/x/data/aa-v0"}

--- a/tests/test_workflows/test_discovery.py
+++ b/tests/test_workflows/test_discovery.py
@@ -1,0 +1,551 @@
+"""Tests for EcsDiscovery."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+import wool
+
+from cfdb.workflows.discovery import EcsDiscovery
+
+
+def _task_arn(task_id: str | None = None) -> str:
+    """Build a stable ECS task ARN for tests."""
+    return f"arn:aws:ecs:us-east-1:123:task/cluster/{task_id or uuid.uuid4().hex}"
+
+
+def _running_task(
+    task_id: str,
+    *,
+    ip: str = "10.0.0.5",
+    health: str = "HEALTHY",
+    status: str = "RUNNING",
+) -> dict[str, Any]:
+    """Construct a fake ECS DescribeTasks entry."""
+    return {
+        "taskArn": _task_arn(task_id),
+        "lastStatus": status,
+        "healthStatus": health,
+        "attachments": [
+            {
+                "type": "ElasticNetworkInterface",
+                "details": [
+                    {"name": "subnetId", "value": "subnet-1"},
+                    {"name": "privateIPv4Address", "value": ip},
+                ],
+            }
+        ],
+    }
+
+
+class _FakeEcsClient:
+    """Fake ECS client whose responses can be re-set per call."""
+
+    def __init__(self) -> None:
+        self.task_arns: list[str] = []
+        self.tasks: list[dict[str, Any]] = []
+
+    def list_tasks(self, **_kwargs):
+        return {"taskArns": list(self.task_arns)}
+
+    def describe_tasks(self, *, cluster: str, tasks: list[str]):
+        wanted = set(tasks)
+        return {
+            "tasks": [t for t in self.tasks if t["taskArn"] in wanted],
+        }
+
+
+class TestEcsDiscovery:
+    def test___init___without_cluster(self):
+        """Test that EcsDiscovery rejects an empty cluster argument.
+
+        Given:
+            An empty cluster name.
+        When:
+            EcsDiscovery is constructed.
+        Then:
+            It should raise ValueError so misconfigurations fail fast.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="cluster"):
+            EcsDiscovery(
+                cluster="",
+                task_definition_family="worker",
+                client=_FakeEcsClient(),
+            )
+
+    def test___init___without_task_definition_family(self):
+        """Test that EcsDiscovery rejects an empty task_definition_family.
+
+        Given:
+            A cluster but no task_definition_family.
+        When:
+            EcsDiscovery is constructed.
+        Then:
+            It should raise ValueError to surface the misconfiguration.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="task_definition_family"):
+            EcsDiscovery(
+                cluster="c",
+                task_definition_family="",
+                client=_FakeEcsClient(),
+            )
+
+    def test_publisher_conforms_to_discovery_publisher_like(self):
+        """Test that the publisher satisfies wool's DiscoveryPublisherLike.
+
+        Given:
+            An EcsDiscovery and the guard-rail publisher it returns.
+        When:
+            That publisher is checked against ``wool.DiscoveryPublisherLike``.
+        Then:
+            It should satisfy the protocol — including the ``bind_host``
+            attribute wool 0.9.2 made part of the contract — so wool keeps
+            accepting EcsDiscovery as a valid discovery backend.
+        """
+        # Arrange
+        discovery = EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=_FakeEcsClient(),
+        )
+
+        # Act
+        publisher = discovery.publisher
+
+        # Assert
+        assert isinstance(publisher, wool.DiscoveryPublisherLike)
+        assert isinstance(publisher.bind_host, str)
+
+    @pytest.mark.asyncio
+    async def test_poll_once_with_initial_healthy_workers(self):
+        """Test that the first poll emits worker-added events.
+
+        Given:
+            A fake ECS client returning one RUNNING + HEALTHY task.
+        When:
+            poll_once is awaited.
+        Then:
+            It should emit exactly one ``worker-added`` event whose metadata
+            carries the task's private IP and the configured worker port.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id)]
+        # The fake's task ARN must align with the seed.
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=client,
+            worker_port=4242,
+        )
+
+        # Act
+        events, resolved = await discovery.poll_once()
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata.address == "10.0.0.5:4242"
+        assert len(resolved) == 1
+
+    @pytest.mark.asyncio
+    async def test_poll_once_with_unhealthy_task_filtered(self):
+        """Test that UNHEALTHY tasks never surface as workers.
+
+        Given:
+            A fake ECS client whose task is RUNNING but UNHEALTHY.
+        When:
+            poll_once is awaited.
+        Then:
+            No events should be emitted and resolved should be empty.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id, health="UNHEALTHY")]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=client,
+        )
+
+        # Act
+        events, resolved = await discovery.poll_once()
+
+        # Assert
+        assert events == []
+        assert resolved == {}
+
+    @pytest.mark.asyncio
+    async def test_poll_once_with_dropped_task_after_initial_seen(self):
+        """Test that a vanished task surfaces as worker-dropped.
+
+        Given:
+            A fake ECS client that initially reports one task and then
+            reports an empty cluster on the next poll.
+        When:
+            poll_once is awaited twice.
+        Then:
+            The second poll should emit one worker-dropped event for the
+            previously-known task.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=client,
+        )
+        await discovery.poll_once()
+
+        # Act — second poll observes the cluster gone empty
+        client.task_arns = []
+        client.tasks = []
+        events, resolved = await discovery.poll_once()
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-dropped"
+        assert resolved == {}
+
+    @pytest.mark.asyncio
+    async def test_poll_once_with_idempotent_steady_state(self):
+        """Test that repeated polls of the same set emit no extra events.
+
+        Given:
+            A fake ECS client that consistently returns the same task.
+        When:
+            poll_once is awaited twice.
+        Then:
+            The second poll should emit no events because the diff is empty.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=client,
+        )
+        await discovery.poll_once()
+
+        # Act
+        events, _ = await discovery.poll_once()
+
+        # Assert
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_subscribe_with_filter_excluding_worker(self):
+        """Test that a subscriber's filter suppresses non-matching events.
+
+        Given:
+            A discovery instance with one healthy worker and a subscriber
+            whose filter rejects every metadata.
+        When:
+            poll_once is awaited.
+        Then:
+            The subscriber's queue should remain empty.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=client,
+        )
+        sub = discovery.subscribe(filter=lambda _meta: False)
+
+        async def _drain():
+            async for event in sub:  # pragma: no cover — should never iterate
+                return event
+            return None
+
+        # Act — start subscriber, then poll
+        consumer = asyncio.create_task(_drain())
+        await asyncio.sleep(0)  # let consumer register
+        await discovery.poll_once()
+        await asyncio.sleep(0.05)
+
+        # Assert
+        consumer.cancel()
+        try:
+            await consumer
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_subscribe_with_two_iter_calls_raises_on_second(self):
+        """Test that double-iteration of one subscriber is refused.
+
+        Given:
+            A subscriber whose async iterator has already been opened.
+        When:
+            A second async-for loop tries to drive the same subscriber.
+        Then:
+            It should raise RuntimeError on the second __anext__ rather
+            than silently double-register and duplicate event delivery.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        discovery = EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=client,
+        )
+        sub = discovery.subscribe()
+        iter_one = sub.__aiter__()
+        iter_two = sub.__aiter__()
+        # Start iter_one so it flips _exhausted before iter_two runs.
+        first_consumer = asyncio.create_task(iter_one.__anext__())
+        await asyncio.sleep(0)
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="already iterated"):
+            await iter_two.__anext__()
+
+        # Cleanup
+        first_consumer.cancel()
+        try:
+            await first_consumer
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_aexit_wakes_parked_consumer(self):
+        """Test that __aexit__ unblocks consumers parked on queue.get().
+
+        Given:
+            A discovery context with a subscriber consuming events.
+        When:
+            The discovery context exits while the consumer is parked.
+        Then:
+            The consumer's async-for loop ends cleanly within a short
+            timeout rather than blocking on a queue that nothing will
+            publish to again.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        events_seen: list[Any] = []
+
+        async def _consume(sub):
+            async for event in sub:
+                events_seen.append(event)
+
+        # Act
+        async with EcsDiscovery(
+            cluster="c",
+            task_definition_family="worker",
+            client=client,
+        ) as discovery:
+            consumer = asyncio.create_task(_consume(discovery.subscribe()))
+            # Let the consumer register and park on queue.get().
+            await asyncio.sleep(0.05)
+        # Exiting the context should push the sentinel; the consumer
+        # task ends shortly after.
+        await asyncio.wait_for(consumer, timeout=1.0)
+
+        # Assert — the consumer ended cleanly without exception.
+        assert consumer.done() and consumer.exception() is None
+
+
+# ---------------------------------------------------------------------------
+# Moto-backed wire-shape verification.
+#
+# Pure unit tests above use ``_FakeEcsClient`` to assert call shape and
+# branch coverage. The class below runs the same discovery client
+# against a real boto3 ``ecs`` client wired into ``moto``'s in-process
+# simulator — any drift between our kwarg shape and what ECS actually
+# accepts (or in the attachment payload shape ``_extract_eni_ip``
+# parses) surfaces here, catching a class of bug pure mocks cannot.
+#
+# moto does not transition ``healthStatus`` past ``None`` and ages
+# ``lastStatus`` to ``DEACTIVATING`` immediately, so full
+# ``poll_once`` cycles surface no metadata. These tests cover the
+# low-level methods (``_list_task_arns`` / ``_describe_tasks_batched``)
+# and the IP-extraction parser; ``_task_to_metadata``'s status filter
+# remains covered by the upstream class's synthetic fixtures.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def moto_ecs_env_for_discovery():
+    """Stand up a moto-backed ECS cluster + task def + VPC for discovery tests.
+
+    Pre-launches one Fargate task so the discovery client has
+    something to enumerate. Returns the boto3 ``ecs`` client, the
+    cluster, the family, and the launched ARN.
+    """
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        ec2 = boto3.client("ec2", region_name="us-east-1")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        ec2.modify_vpc_attribute(VpcId=vpc, EnableDnsHostnames={"Value": True})
+        subnet = ec2.create_subnet(
+            VpcId=vpc, CidrBlock="10.0.0.0/24", AvailabilityZone="us-east-1a"
+        )["Subnet"]["SubnetId"]
+        sg = ec2.create_security_group(
+            GroupName="cfdb-test-sg", Description="moto sg", VpcId=vpc
+        )["GroupId"]
+        ecs = boto3.client("ecs", region_name="us-east-1")
+        ecs.create_cluster(clusterName="cfdb-test")
+        ecs.register_task_definition(
+            family="cfdb-test-worker",
+            networkMode="awsvpc",
+            requiresCompatibilities=["FARGATE"],
+            cpu="256",
+            memory="512",
+            containerDefinitions=[
+                {
+                    "name": "worker",
+                    "image": "cfdb-worker:test",
+                    "essential": True,
+                    "memory": 512,
+                }
+            ],
+        )
+        arns: list[str] = []
+        for _ in range(3):
+            resp = ecs.run_task(
+                cluster="cfdb-test",
+                taskDefinition="cfdb-test-worker",
+                launchType="FARGATE",
+                count=1,
+                networkConfiguration={
+                    "awsvpcConfiguration": {
+                        "subnets": [subnet],
+                        "securityGroups": [sg],
+                        "assignPublicIp": "DISABLED",
+                    }
+                },
+            )
+            arns.append(resp["tasks"][0]["taskArn"])
+        yield {
+            "client": ecs,
+            "cluster": "cfdb-test",
+            "family": "cfdb-test-worker",
+            "task_arns": arns,
+        }
+
+
+class TestEcsDiscoveryAgainstMoto:
+    """Wire-shape verification against a real boto3 ``ecs`` client."""
+
+    def test_list_task_arns_should_enumerate_launched_tasks(
+        self, moto_ecs_env_for_discovery
+    ):
+        """Test that ``_list_task_arns`` surfaces every launched task.
+
+        Given:
+            A moto-backed cluster with three Fargate tasks launched
+            against the same family.
+        When:
+            ``_list_task_arns`` is invoked.
+        Then:
+            It should return all three ARNs, confirming the
+            ``cluster`` + ``family`` + ``desiredStatus`` kwargs are
+            accepted by the real ECS API shape.
+        """
+        # Arrange
+        discovery = EcsDiscovery(
+            cluster=moto_ecs_env_for_discovery["cluster"],
+            task_definition_family=moto_ecs_env_for_discovery["family"],
+            client=moto_ecs_env_for_discovery["client"],
+        )
+
+        # Act
+        arns = discovery._list_task_arns()
+
+        # Assert
+        assert set(arns) == set(moto_ecs_env_for_discovery["task_arns"])
+
+    def test_describe_tasks_batched_should_split_into_multiple_calls(
+        self, moto_ecs_env_for_discovery, monkeypatch
+    ):
+        """Test that ``_describe_tasks_batched`` chunks ARNs across batches.
+
+        Given:
+            A patched batch size of 2 and three launched tasks (so two
+            batches are required).
+        When:
+            ``_describe_tasks_batched`` is invoked on all three ARNs.
+        Then:
+            It should return three describe-task entries, proving both
+            batches were sent and concatenated correctly.
+        """
+        # Arrange
+        from cfdb.workflows import discovery as discovery_mod
+
+        monkeypatch.setattr(discovery_mod, "_DESCRIBE_BATCH_SIZE", 2)
+        discovery = EcsDiscovery(
+            cluster=moto_ecs_env_for_discovery["cluster"],
+            task_definition_family=moto_ecs_env_for_discovery["family"],
+            client=moto_ecs_env_for_discovery["client"],
+        )
+
+        # Act
+        tasks = discovery._describe_tasks_batched(
+            moto_ecs_env_for_discovery["task_arns"]
+        )
+
+        # Assert
+        assert {t["taskArn"] for t in tasks} == set(
+            moto_ecs_env_for_discovery["task_arns"]
+        )
+
+    def test_extract_eni_ip_should_parse_motos_attachment_payload(
+        self, moto_ecs_env_for_discovery
+    ):
+        """Test that ``_extract_eni_ip`` recovers the IP from moto's attachments.
+
+        Given:
+            A describe-tasks entry returned by moto for a Fargate task
+            with awsvpc networking.
+        When:
+            ``_extract_eni_ip`` runs against the task dict.
+        Then:
+            It should return the ``privateIPv4Address`` recorded in the
+            ``ElasticNetworkInterface`` attachment, proving our parser
+            agrees with the canonical ECS attachment shape.
+        """
+        # Arrange
+        from cfdb.workflows.discovery import _extract_eni_ip
+
+        described = moto_ecs_env_for_discovery["client"].describe_tasks(
+            cluster=moto_ecs_env_for_discovery["cluster"],
+            tasks=moto_ecs_env_for_discovery["task_arns"][:1],
+        )["tasks"][0]
+
+        # Act
+        ip = _extract_eni_ip(described)
+
+        # Assert — moto draws private IPs out of the subnet CIDR, which
+        # we set to 10.0.0.0/24; assert the parser recovered an IP in
+        # the IPv4 dotted-quad shape rather than pinning to a specific
+        # address (moto picks randomly within the subnet).
+        assert ip is not None
+        parts = ip.split(".")
+        assert len(parts) == 4 and all(p.isdigit() for p in parts)

--- a/tests/test_workflows/test_executor.py
+++ b/tests/test_workflows/test_executor.py
@@ -11,6 +11,13 @@ import pytest
 import wool
 
 from cfdb.workflows import executor as executor_module
+from cfdb.workflows import keys as key_utils
+from cfdb.workflows.events import (
+    Complete,
+    Heartbeat,
+    Progress,
+    StageComplete,
+)
 from cfdb.workflows.executor import (
     PIPELINE_VERSION,
     ExecutorDraining,
@@ -22,6 +29,7 @@ from cfdb.workflows.lock import get_job
 from cfdb.workflows.models import ACTIVE_STATUSES, ArtifactKind, JobStatus
 from cfdb.workflows.processors.base import Processor
 from cfdb.workflows.processors.registry import ProcessorRegistry
+from cfdb.workflows.provisioner import EcsProvisioner, RetryableProvisionerError
 from tests.test_workflows import FIXTURE_MD5
 
 #: Canonical artifact keys the stubs emit. Built from FIXTURE_MD5 so the
@@ -60,8 +68,8 @@ class _StubProcessor(Processor):
     ) -> AsyncIterator[dict[str, Any]]:
         self.run_calls += 1
         for kind, key in self.artifacts.items():
-            yield {"event": "stage_complete", "kind": kind, "key": key}
-        yield {"event": "complete", "artifacts": dict(self.artifacts)}
+            yield StageComplete(kind=ArtifactKind(kind), key=key)
+        yield Complete(artifacts=dict(self.artifacts))
 
 
 class _FailingProcessor(Processor):
@@ -243,7 +251,7 @@ class TestWoolExecutorEnsureWorkflow:
         _install_jobs_index(mock_db)
         registry = ProcessorRegistry()  # empty
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act & assert
@@ -275,7 +283,7 @@ class TestWoolExecutorEnsureWorkflow:
         registry = ProcessorRegistry()
         registry.register(processor)
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -319,14 +327,14 @@ class TestWoolExecutorEnsureWorkflow:
                 self.run_calls += 1
                 await release.wait()
                 for kind, key in self.artifacts.items():
-                    yield {"event": "stage_complete", "kind": kind, "key": key}
-                yield {"event": "complete", "artifacts": dict(self.artifacts)}
+                    yield StageComplete(kind=ArtifactKind(kind), key=key)
+                yield Complete(artifacts=dict(self.artifacts))
 
         processor = _BlockingProcessor()
         registry = ProcessorRegistry()
         registry.register(processor)
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -364,7 +372,7 @@ class TestWoolExecutorEnsureWorkflow:
         registry = ProcessorRegistry()
         registry.register(_FailingProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -402,15 +410,15 @@ class TestWoolExecutorEnsureWorkflow:
                 workdir.mkdir(parents=True, exist_ok=True)
                 (workdir / "scratch").write_bytes(b"tmp")
                 for kind, key in self.artifacts.items():
-                    yield {"event": "stage_complete", "kind": kind, "key": key}
-                yield {"event": "complete", "artifacts": dict(self.artifacts)}
+                    yield StageComplete(kind=ArtifactKind(kind), key=key)
+                yield Complete(artifacts=dict(self.artifacts))
 
         # Arrange
         _install_jobs_index(mock_db)
         registry = ProcessorRegistry()
         registry.register(_WorkdirTouchingProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -447,7 +455,7 @@ class TestWoolExecutorEnsureWorkflow:
         registry = ProcessorRegistry()
         registry.register(_StubProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         async def boom(*_a, **_kw):
@@ -473,6 +481,7 @@ class TestWoolExecutorEnsureWorkflow:
         tmp_cache,
         tmp_workdir,
         no_wool_dispatch,
+        mocker,
     ):
         """Test that jobs exceeding the runtime cap are marked FAILED.
 
@@ -491,27 +500,23 @@ class TestWoolExecutorEnsureWorkflow:
         class _HangingProcessor(_StubProcessor):
             async def run(self, file_meta, workdir, cache_root):
                 self.run_calls += 1
-                yield {
-                    "event": "stage_complete",
-                    "kind": ArtifactKind.DATA.value,
-                    "key": _DATA_KEY,
-                }
+                yield StageComplete(kind=ArtifactKind.DATA, key=_DATA_KEY)
                 await asyncio.sleep(10)
-                yield {"event": "complete", "artifacts": {}}
+                yield Complete(artifacts={})
 
         _install_jobs_index(mock_db)
         registry = ProcessorRegistry()
         registry.register(_HangingProcessor())
+        # Tiny but non-zero cap: zero risks event-loop edge cases on
+        # some asyncio versions; 0.05s is short enough to keep the
+        # test fast and long enough to be deterministic. Module-level
+        # so the timeout reads through monkeypatch.
+        mocker.patch.object(executor_module, "_WORKFLOW_DURATION_CAP_SECONDS", 0.05)
         executor = WoolExecutor(
             mock_db,
             tmp_cache,
-            tmp_cache.root,
             registry,
             workdir_root=tmp_workdir,
-            # Tiny but non-zero cap: zero risks event-loop edge cases on
-            # some asyncio versions; 0.05s is short enough to keep the
-            # test fast and long enough to be deterministic.
-            workflow_duration_cap_seconds=0.05,
         )
 
         # Act
@@ -572,39 +577,26 @@ class TestWoolExecutorPartialCommit:
                     src = workdir / "data"
                     src.write_bytes(b"data-bytes")
                     await cache.put(_DATA_KEY, src)
-                    yield {
-                        "event": "stage_complete",
-                        "kind": ArtifactKind.DATA.value,
-                        "key": _DATA_KEY,
-                    }
+                    yield StageComplete(kind=ArtifactKind.DATA, key=_DATA_KEY)
                     raise RuntimeError("stage-2 failure")
                 invocations.append(True)
-                yield {
-                    "event": "stage_complete",
-                    "kind": ArtifactKind.DATA.value,
-                    "key": _DATA_KEY,
-                }
+                yield StageComplete(kind=ArtifactKind.DATA, key=_DATA_KEY)
                 src = workdir / "index"
                 src.write_bytes(b"index-bytes")
                 await cache.put(_INDEX_KEY, src)
-                yield {
-                    "event": "stage_complete",
-                    "kind": ArtifactKind.INDEX.value,
-                    "key": _INDEX_KEY,
-                }
-                yield {
-                    "event": "complete",
-                    "artifacts": {
+                yield StageComplete(kind=ArtifactKind.INDEX, key=_INDEX_KEY)
+                yield Complete(
+                    artifacts={
                         ArtifactKind.DATA.value: _DATA_KEY,
                         ArtifactKind.INDEX.value: _INDEX_KEY,
-                    },
-                }
+                    }
+                )
 
         processor = _PartialCommitProcessor()
         registry = ProcessorRegistry()
         registry.register(processor)
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act — first run fails after committing stage 1.
@@ -644,33 +636,34 @@ class TestWoolExecutorArtifactKindCoercion:
         tmp_workdir,
         no_wool_dispatch,
     ):
-        """Test that processors emitting unknown artifact kinds fail loud.
+        """Test that an ill-typed StageComplete fails the job, not the routine.
 
         Given:
-            A processor whose ``run`` yields a ``stage_complete`` event
-            naming a kind not in ``ArtifactKind``.
+            A processor that violates the typed event contract by emitting
+            a StageComplete whose ``kind`` is a bare string rather than an
+            ArtifactKind.
         When:
             ensure_workflow is awaited and the background task completes.
         Then:
-            The job should land in FAILED with an error mentioning the
-            malformed event.
+            The job should land in FAILED rather than crashing the routine
+            — the executor records the failure and moves on.
         """
 
         # Arrange
         class _BogusKindProcessor(_StubProcessor):
             async def run(self, file_meta, workdir, cache_root):
                 self.run_calls += 1
-                yield {
-                    "event": "stage_complete",
-                    "kind": "weird_kind",
-                    "key": "encode/x/weird/aa-v0",
-                }
+                # Deliberately off-contract: kind must be an ArtifactKind.
+                yield StageComplete(
+                    kind="weird_kind",  # type: ignore[arg-type]
+                    key="encode/x/weird/aa-v0",
+                )
 
         _install_jobs_index(mock_db)
         registry = ProcessorRegistry()
         registry.register(_BogusKindProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -681,7 +674,7 @@ class TestWoolExecutorArtifactKindCoercion:
         final = await get_job(mock_db, record.job_id)
         assert final is not None
         assert final.status == JobStatus.FAILED
-        assert "stage_complete" in (final.error or "")
+        assert final.error
 
 
 class TestWoolExecutorDrain:
@@ -703,7 +696,7 @@ class TestWoolExecutorDrain:
         registry = ProcessorRegistry()
         registry.register(_StubProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -740,13 +733,13 @@ class TestWoolExecutorDrain:
                 self.run_calls += 1
                 await release.wait()
                 for kind, key in self.artifacts.items():
-                    yield {"event": "stage_complete", "kind": kind, "key": key}
-                yield {"event": "complete", "artifacts": dict(self.artifacts)}
+                    yield StageComplete(kind=ArtifactKind(kind), key=key)
+                yield Complete(artifacts=dict(self.artifacts))
 
         registry = ProcessorRegistry()
         registry.register(_BlockingProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         record, _ = await executor.ensure_workflow(_file_meta())
@@ -799,12 +792,12 @@ class TestWoolExecutorDrain:
             async def run(self, file_meta, workdir, cache_root):
                 self.run_calls += 1
                 await forever.wait()
-                yield {"event": "complete", "artifacts": {}}
+                yield Complete(artifacts={})
 
         registry = ProcessorRegistry()
         registry.register(_ForeverProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
         record, _ = await executor.ensure_workflow(_file_meta())
 
@@ -842,7 +835,7 @@ class TestWoolExecutorDrain:
         registry = ProcessorRegistry()
         registry.register(_StubProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
         await executor.drain(timeout=1.0)
 
@@ -892,7 +885,7 @@ class TestOpenStreamWithRetry:
         processor = _StubProcessor()
         registry.register(processor)
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Build two routines: one that immediately raises NoWorkersAvailable
@@ -906,8 +899,8 @@ class TestOpenStreamWithRetry:
 
         async def working_stream():
             attempts["count"] += 1
-            yield {"event": "stage_complete", "kind": "index", "key": _INDEX_KEY}
-            yield {"event": "complete", "artifacts": {}}
+            yield StageComplete(kind=ArtifactKind.INDEX, key=_INDEX_KEY)
+            yield Complete(artifacts={})
 
         streams = [failing_stream(), working_stream()]
 
@@ -929,7 +922,7 @@ class TestOpenStreamWithRetry:
 
         # Assert
         assert attempts["count"] == 2
-        assert any(e.get("event") == "complete" for e in events)
+        assert any(isinstance(e, Complete) for e in events)
 
     @pytest.mark.asyncio
     async def test_open_stream_with_retry_should_raise_when_deadline_expires(
@@ -953,7 +946,7 @@ class TestOpenStreamWithRetry:
         processor = _StubProcessor()
         registry.register(processor)
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         async def failing_stream():
@@ -1000,14 +993,14 @@ class TestStreamConsumerProgressEvents:
         class _ProgressProcessor(_StubProcessor):
             async def run(self, file_meta, workdir, cache_root):
                 self.run_calls += 1
-                yield {"event": "progress", "value": "merging"}
-                yield {"event": "complete", "artifacts": {}}
+                yield Progress(value="merging")
+                yield Complete(artifacts={})
 
         _install_jobs_index(mock_db)
         registry = ProcessorRegistry()
         registry.register(_ProgressProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -1018,47 +1011,6 @@ class TestStreamConsumerProgressEvents:
         final = await get_job(mock_db, record.job_id)
         assert final is not None
         assert final.progress == "merging"
-
-    @pytest.mark.asyncio
-    async def test_ensure_workflow_should_ignore_progress_event_with_non_string_value(
-        self, mock_db, tmp_cache, tmp_workdir, no_wool_dispatch
-    ):
-        """Test that non-string progress values are silently dropped.
-
-        Given:
-            A stub processor that yields ``{"event": "progress",
-            "value": 12345}`` (an int, not a string).
-        When:
-            ``ensure_workflow`` is awaited.
-        Then:
-            The job should reach COMPLETED and the persisted ``progress``
-            field should remain untouched (None) — the type guard skips
-            non-string values rather than crashing.
-        """
-
-        # Arrange
-        class _NumericProgressProcessor(_StubProcessor):
-            async def run(self, file_meta, workdir, cache_root):
-                self.run_calls += 1
-                yield {"event": "progress", "value": 12345}
-                yield {"event": "complete", "artifacts": {}}
-
-        _install_jobs_index(mock_db)
-        registry = ProcessorRegistry()
-        registry.register(_NumericProgressProcessor())
-        executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
-        )
-
-        # Act
-        record, _ = await executor.ensure_workflow(_file_meta())
-        await _wait_for_terminal(mock_db, record.job_id)
-
-        # Assert
-        final = await get_job(mock_db, record.job_id)
-        assert final is not None
-        assert final.status == JobStatus.COMPLETED
-        assert final.progress is None
 
 
 class TestStreamConsumerHeartbeatEvents:
@@ -1082,14 +1034,14 @@ class TestStreamConsumerHeartbeatEvents:
         class _HeartbeatProcessor(_StubProcessor):
             async def run(self, file_meta, workdir, cache_root):
                 self.run_calls += 1
-                yield {"event": "heartbeat"}
-                yield {"event": "complete", "artifacts": {}}
+                yield Heartbeat()
+                yield Complete(artifacts={})
 
         _install_jobs_index(mock_db)
         registry = ProcessorRegistry()
         registry.register(_HeartbeatProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
         spy = mocker.spy(executor_module, "heartbeat_workflow")
 
@@ -1126,13 +1078,13 @@ class TestStreamConsumerUnknownEvent:
             async def run(self, file_meta, workdir, cache_root):
                 self.run_calls += 1
                 yield {"event": "weird"}
-                yield {"event": "complete", "artifacts": {}}
+                yield Complete(artifacts={})
 
         _install_jobs_index(mock_db)
         registry = ProcessorRegistry()
         registry.register(_WeirdEventProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         # Act
@@ -1190,7 +1142,7 @@ class TestOpenStreamMalformedFirstEvent:
         processor = _StubProcessor()
         registry.register(processor)
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
 
         async def boom_stream():
@@ -1229,7 +1181,7 @@ class TestEnsureWorkflowSnapshotsFileMeta:
         registry = ProcessorRegistry()
         registry.register(_StubProcessor())
         executor = WoolExecutor(
-            mock_db, tmp_cache, tmp_cache.root, registry, workdir_root=tmp_workdir
+            mock_db, tmp_cache, registry, workdir_root=tmp_workdir
         )
         meta = _file_meta()
 
@@ -1241,3 +1193,253 @@ class TestEnsureWorkflowSnapshotsFileMeta:
         final = await get_job(mock_db, record.job_id)
         assert final is not None
         assert final.file_meta_snapshot == meta
+
+
+class TestWoolExecutorWithProvisioner:
+    @pytest.mark.asyncio
+    async def test_ensure_workflow_should_request_worker_when_provisioner_set(
+        self, mock_db, tmp_cache, tmp_workdir, no_wool_dispatch, mocker
+    ):
+        """Test that a fresh claim dispatches a provisioner request.
+
+        Given:
+            A WoolExecutor wired with a stub EcsProvisioner.
+        When:
+            ``ensure_workflow`` is awaited on a previously-unseen file.
+        Then:
+            The provisioner's ``request`` should be awaited exactly once
+            with ``dedup_key`` set to the workflow mutex key for the file.
+        """
+        # Arrange
+        _install_jobs_index(mock_db)
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor())
+        provisioner = mocker.AsyncMock(spec=EcsProvisioner)
+        provisioner.request.return_value = ["arn:fake:task/abc"]
+        executor = WoolExecutor(
+            mock_db,
+            tmp_cache,
+            registry,
+            workdir_root=tmp_workdir,
+            provisioner=provisioner,
+        )
+        meta = _file_meta()
+        dcc, local_id, md5 = extract_identity(meta)
+        expected_key = key_utils.workflow_key(
+            dcc=dcc, local_id=local_id, md5=md5, pipeline_version=PIPELINE_VERSION
+        )
+
+        # Act
+        record, _ = await executor.ensure_workflow(meta)
+        await _wait_for_terminal(mock_db, record.job_id)
+
+        # Assert
+        provisioner.request.assert_awaited_once_with(dedup_key=expected_key)
+
+    @pytest.mark.asyncio
+    async def test_ensure_workflow_should_skip_provisioner_when_attaching_to_existing_job(
+        self, mock_db, tmp_cache, tmp_workdir, no_wool_dispatch, mocker
+    ):
+        """Test that the provisioner is only invoked on fresh claims.
+
+        Given:
+            An executor with a stub provisioner and a blocking processor
+            so the first claim stays active when the second call arrives.
+        When:
+            ``ensure_workflow`` is awaited twice for the same file_meta.
+        Then:
+            ``provisioner.request`` should be awaited exactly once — the
+            attach path must not double-spend a Fargate worker against
+            an already-claimed workflow.
+        """
+        # Arrange
+        _install_jobs_index(mock_db)
+        release = asyncio.Event()
+
+        class _BlockingProcessor(_StubProcessor):
+            async def run(self, file_meta, workdir, cache_root):
+                self.run_calls += 1
+                await release.wait()
+                for kind, key in self.artifacts.items():
+                    yield StageComplete(kind=ArtifactKind(kind), key=key)
+                yield Complete(artifacts=dict(self.artifacts))
+
+        registry = ProcessorRegistry()
+        registry.register(_BlockingProcessor())
+        provisioner = mocker.AsyncMock(spec=EcsProvisioner)
+        provisioner.request.return_value = ["arn:fake:task/abc"]
+        executor = WoolExecutor(
+            mock_db,
+            tmp_cache,
+            registry,
+            workdir_root=tmp_workdir,
+            provisioner=provisioner,
+        )
+
+        # Act
+        record_a, fresh_a = await executor.ensure_workflow(_file_meta())
+        record_b, fresh_b = await executor.ensure_workflow(_file_meta())
+        release.set()
+        await _wait_for_terminal(mock_db, record_a.job_id)
+
+        # Assert
+        assert fresh_a is True
+        assert fresh_b is False
+        assert record_a.job_id == record_b.job_id
+        provisioner.request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ensure_workflow_should_fall_through_when_retryable_provisioner_raises(
+        self, mock_db, tmp_cache, tmp_workdir, no_wool_dispatch, mocker
+    ):
+        """Test that a retryable provisioner failure falls through to dispatch.
+
+        Given:
+            A provisioner whose ``request`` raises
+            ``RetryableProvisionerError`` (capacity / ENI exhaustion /
+            throttling) AND a wool pool that can still dispatch to an
+            existing worker (the no_wool_dispatch fixture runs the
+            routine in-process).
+        When:
+            ``ensure_workflow`` is awaited.
+        Then:
+            The retryable error should be logged but not fail the
+            workflow — the Wool pool routes to any available worker
+            via discovery, so an existing idle worker can service the
+            job even when ECS quota blocks a fresh launch. The
+            ``capacity:`` prefix is reserved for the case where
+            dispatch also exhausts its budget (see
+            ``test_ensure_workflow_should_record_capacity_failure_when_dispatch_also_fails``).
+        """
+        # Arrange
+        _install_jobs_index(mock_db)
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor())
+        provisioner = mocker.AsyncMock(spec=EcsProvisioner)
+        provisioner.request.side_effect = RetryableProvisionerError(
+            "ClientError: capacity-unavailable"
+        )
+        executor = WoolExecutor(
+            mock_db,
+            tmp_cache,
+            registry,
+            workdir_root=tmp_workdir,
+            provisioner=provisioner,
+        )
+
+        # Act
+        record, _ = await executor.ensure_workflow(_file_meta())
+        await _wait_for_terminal(mock_db, record.job_id)
+
+        # Assert
+        final = await get_job(mock_db, record.job_id)
+        assert final is not None
+        provisioner.request.assert_awaited_once()
+        # Provisioner failure was swallowed; in-process dispatch
+        # succeeded, so the workflow completes despite the
+        # retryable provisioner error.
+        assert final.status == JobStatus.COMPLETED
+        assert final.error is None
+
+    @pytest.mark.asyncio
+    async def test_ensure_workflow_should_record_capacity_failure_when_dispatch_also_fails(
+        self, mock_db, tmp_cache, tmp_workdir, no_wool_dispatch, mocker
+    ):
+        """Test that the capacity: prefix fires when dispatch also exhausts.
+
+        Given:
+            A provisioner whose ``request`` raises
+            ``RetryableProvisionerError`` AND a dispatch path that
+            exhausts its budget with ``wool.NoWorkersAvailable``.
+        When:
+            ``ensure_workflow`` is awaited.
+        Then:
+            The workflow should reach ``FAILED`` with the
+            ``capacity:`` prefix — the wire contract clients parse to
+            decide whether to resubmit. Per C26 the origin of the
+            prefix shifted from the provisioner-failure branch to the
+            dispatch-budget-exhausted branch, but the on-wire shape
+            is unchanged.
+        """
+        # Arrange
+        _install_jobs_index(mock_db)
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor())
+        provisioner = mocker.AsyncMock(spec=EcsProvisioner)
+        provisioner.request.side_effect = RetryableProvisionerError(
+            "ClientError: capacity-unavailable"
+        )
+        executor = WoolExecutor(
+            mock_db,
+            tmp_cache,
+            registry,
+            workdir_root=tmp_workdir,
+            provisioner=provisioner,
+        )
+        # Force the dispatch path to also fail with
+        # ``wool.NoWorkersAvailable``; the C26 stream-open branch
+        # translates that to the ``capacity:`` prefix.
+        mocker.patch.object(
+            executor,
+            "_open_stream_with_retry",
+            side_effect=wool.NoWorkersAvailable("pool empty after budget"),
+        )
+
+        # Act
+        record, _ = await executor.ensure_workflow(_file_meta())
+        await _wait_for_terminal(mock_db, record.job_id)
+
+        # Assert
+        final = await get_job(mock_db, record.job_id)
+        assert final is not None
+        assert final.status == JobStatus.FAILED
+        assert final.error is not None
+        assert final.error.startswith("capacity: "), (
+            f"expected 'capacity: ' prefix, got {final.error!r}"
+        )
+        assert "pool empty" in final.error
+
+    @pytest.mark.asyncio
+    async def test_ensure_workflow_should_record_provisioner_prefix_for_generic_exception(
+        self, mock_db, tmp_cache, tmp_workdir, no_wool_dispatch, mocker
+    ):
+        """Test that non-retryable provisioner failures use the 'provisioner: ' prefix.
+
+        Given:
+            A provisioner whose ``request`` raises a generic
+            ``RuntimeError`` (a misconfiguration or unexpected boto
+            failure, not a retryable transient).
+        When:
+            ``ensure_workflow`` is awaited.
+        Then:
+            The job should reach ``FAILED`` with an error string that
+            starts with ``"provisioner: "`` so clients can distinguish
+            "retry me later" from "the provisioner crashed".
+        """
+        # Arrange
+        _install_jobs_index(mock_db)
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor())
+        provisioner = mocker.AsyncMock(spec=EcsProvisioner)
+        provisioner.request.side_effect = RuntimeError("misconfigured cluster")
+        executor = WoolExecutor(
+            mock_db,
+            tmp_cache,
+            registry,
+            workdir_root=tmp_workdir,
+            provisioner=provisioner,
+        )
+
+        # Act
+        record, _ = await executor.ensure_workflow(_file_meta())
+        await _wait_for_terminal(mock_db, record.job_id)
+
+        # Assert
+        final = await get_job(mock_db, record.job_id)
+        assert final is not None
+        assert final.status == JobStatus.FAILED
+        assert final.error is not None
+        assert final.error.startswith("provisioner: "), (
+            f"expected 'provisioner: ' prefix, got {final.error!r}"
+        )
+        assert "misconfigured cluster" in final.error

--- a/tests/test_workflows/test_fetcher.py
+++ b/tests/test_workflows/test_fetcher.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import gzip
 
 import pytest
 
 from cfdb.services import drs
 from cfdb.workflows import fetcher
 from cfdb.workflows.urlsafe import UnsafeOutboundURL
+
+_HTTPS_URL = "https://encode-public.s3.amazonaws.com/x.sam.gz"
 
 
 class TestDownloadSource:
@@ -299,3 +301,114 @@ class TestDownloadSource:
         # Assert
         assert dest.exists()
         assert dest.read_bytes() == b"x"
+
+
+class TestPeekDecompressedPrefix:
+    @pytest.mark.asyncio
+    async def test_peek_should_gunzip_only_the_leading_bytes(self, mocker):
+        """Test that a gzip source is decompressed and Range-bounded.
+
+        Given:
+            A gzip-compressed SAM header streamed in two chunks and a
+            small ``max_compressed_bytes`` cap.
+        When:
+            peek_decompressed_prefix is awaited.
+        Then:
+            It should return the decompressed header bytes and pass a
+            ``bytes=0-`` Range header so only the file prefix is fetched.
+        """
+        # Arrange
+        header = b"@HD\tVN:1.0\n@SQ\tSN:chr1\tLN:1000\n" + b"r1\t0\tchr1\t1\n" * 50
+        gz = gzip.compress(header)
+        captured = {}
+
+        async def fake_stream(url, range_header=None):
+            captured["url"] = url
+            captured["range"] = range_header
+            yield gz[:8]
+            yield gz[8:]
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        # Act
+        out = await fetcher.peek_decompressed_prefix({"access_url": _HTTPS_URL})
+
+        # Assert
+        assert out.startswith(b"@HD\tVN:1.0\n@SQ\tSN:chr1\tLN:1000")
+        assert captured["url"] == _HTTPS_URL
+        assert captured["range"].startswith("bytes=0-")
+
+    @pytest.mark.asyncio
+    async def test_peek_should_pass_through_uncompressed_source(self, mocker):
+        """Test that a non-gzip source is returned verbatim.
+
+        Given:
+            A plain-text (non-gzip) source streamed as one chunk.
+        When:
+            peek_decompressed_prefix is awaited.
+        Then:
+            It should return the bytes unchanged rather than attempting
+            to gunzip them.
+        """
+        # Arrange
+        body = b"@HD\tVN:1.0\n@SQ\tSN:chr1\tLN:10\n"
+
+        async def fake_stream(url, range_header=None):
+            yield body
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        # Act
+        out = await fetcher.peek_decompressed_prefix({"access_url": _HTTPS_URL})
+
+        # Assert
+        assert out == body
+
+    @pytest.mark.asyncio
+    async def test_peek_should_stop_after_the_compressed_byte_cap(self, mocker):
+        """Test that streaming stops once the compressed cap is reached.
+
+        Given:
+            A stream that would yield far more than the cap and records
+            how many chunks were consumed.
+        When:
+            peek_decompressed_prefix is awaited with a tiny cap.
+        Then:
+            It should stop reading after the first over-cap chunk rather
+            than draining the whole (notional) file.
+        """
+        # Arrange
+        chunks_read = 0
+
+        async def fake_stream(url, range_header=None):
+            nonlocal chunks_read
+            for _ in range(1000):
+                chunks_read += 1
+                yield b"x" * 64
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        # Act
+        out = await fetcher.peek_decompressed_prefix(
+            {"access_url": _HTTPS_URL}, max_compressed_bytes=128
+        )
+
+        # Assert — stopped early, did not drain all 1000 chunks
+        assert chunks_read < 1000
+        assert len(out) <= 192
+
+    @pytest.mark.asyncio
+    async def test_peek_should_raise_when_access_url_missing(self):
+        """Test that peek rejects file_meta without an access_url.
+
+        Given:
+            A file_meta dict with no access_url.
+        When:
+            peek_decompressed_prefix is awaited.
+        Then:
+            It should raise ValueError rather than hit a later opaque
+            failure.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="access_url"):
+            await fetcher.peek_decompressed_prefix({})

--- a/tests/test_workflows/test_processors_bam.py
+++ b/tests/test_workflows/test_processors_bam.py
@@ -10,10 +10,91 @@ import pytest
 
 from cfdb.workflows import SAMTOOLS_MEMORY_CAP, keys as key_utils
 from cfdb.workflows.cache import LocalFsCache
+from cfdb.workflows.events import Complete
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.processors import bam as bam_module
-from cfdb.workflows.processors.bam import BamIndexProcessor, read_bam_header
+from cfdb.workflows.processors.bam import (
+    BamIndexProcessor,
+    read_bam_header,
+    validate_sam_header,
+)
 from tests.test_workflows import FIXTURE_MD5
+
+
+async def _fake_peek_valid_header(file_meta, **kwargs):
+    """Stub peek_decompressed_prefix with a well-formed tab-delimited header."""
+    return b"@HD\tVN:1.0\n@SQ\tSN:chr1\tLN:1000\n"
+
+
+class TestValidateSamHeader:
+    def test_should_raise_on_space_delimited_sq_line(self):
+        """Test that a space-delimited @SQ header is rejected.
+
+        Given:
+            A SAM header whose @SQ record uses spaces (the legacy
+            modENCODE shape) instead of tabs between fields.
+        When:
+            validate_sam_header is called.
+        Then:
+            It should raise RuntimeError naming the space-delimited
+            line, so the workflow fails fast with an actionable error
+            rather than samtools' opaque "fail to read the header".
+        """
+        # Arrange — spaces between fields, a legitimate space inside AS
+        header = "@HD VN:1.0\n@SQ SN:chr2L AS:FlyBase r5 LN:23011544\n"
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="space-delimited"):
+            validate_sam_header(header)
+
+    def test_should_pass_well_formed_tab_delimited_header(self):
+        """Test that a tab-delimited header is accepted.
+
+        Given:
+            A SAM header whose records are TAB-delimited, with a space
+            preserved inside a tag value.
+        When:
+            validate_sam_header is called.
+        Then:
+            It should return None without raising.
+        """
+        # Arrange
+        header = "@HD\tVN:1.0\n@SQ\tSN:chr2L\tAS:FlyBase r5\tLN:23011544\n"
+
+        # Act & assert — no exception
+        assert validate_sam_header(header) is None
+
+    def test_should_ignore_comment_records_without_tabs(self):
+        """Test that a tab-less @CO comment does not trip the check.
+
+        Given:
+            A header with a valid tab-delimited @SQ and an @CO comment
+            line carrying free text with no tab.
+        When:
+            validate_sam_header is called.
+        Then:
+            It should not raise, since @CO is free text and excluded
+            from the delimiter check.
+        """
+        # Arrange
+        header = "@SQ\tSN:chr1\tLN:1000\n@CO free text comment with no tab\n"
+
+        # Act & assert — no exception
+        assert validate_sam_header(header) is None
+
+    def test_should_be_noop_for_headerless_input(self):
+        """Test that input with no header records is left to samtools.
+
+        Given:
+            Header text containing no @-prefixed multi-field records.
+        When:
+            validate_sam_header is called.
+        Then:
+            It should return None — the truly-headerless case is a
+            different failure surfaced by samtools itself.
+        """
+        # Act & assert
+        assert validate_sam_header("") is None
 
 
 def _file_meta(fmt: str = "BAM") -> dict[str, Any]:
@@ -37,15 +118,18 @@ async def _drain_run(proc, file_meta, workdir, cache_root):
     and surfaces the final ``complete`` event's artifact mapping under
     the same dict key callers used to assert on.
     """
-    return [event async for event in proc.run(file_meta, workdir, cache_root)]
+    return [
+        event
+        async for event in proc.run(file_meta, workdir, LocalFsCache(cache_root))
+    ]
 
 
-def _final_artifacts(events: list[dict]) -> dict[str, str]:
-    """Return the artifact mapping carried by the terminal ``complete`` event."""
+def _final_artifacts(events: list) -> dict[str, str]:
+    """Return the artifact mapping carried by the terminal ``Complete`` event."""
     for event in reversed(events):
-        if event.get("event") == "complete":
-            return dict(event.get("artifacts") or {})
-    raise AssertionError("processor did not emit a `complete` event")
+        if isinstance(event, Complete):
+            return dict(event.artifacts)
+    raise AssertionError("processor did not emit a `Complete` event")
 
 
 async def _async_false() -> bool:
@@ -238,7 +322,7 @@ class TestBamIndexProcessor:
         # Act & assert
         with pytest.raises(RuntimeError, match="not coordinate-sorted"):
             async for _event in BamIndexProcessor().run(
-                _file_meta("BAM"), workdir, cache_root
+                _file_meta("BAM"), workdir, LocalFsCache(cache_root)
             ):
                 pass
 
@@ -334,6 +418,9 @@ class TestBamIndexProcessor:
                 target = Path(argv[-1])
                 (target.parent / (target.name + ".bai")).write_bytes(b"bai")
 
+        mocker.patch.object(
+            bam_module, "peek_decompressed_prefix", _fake_peek_valid_header
+        )
         mocker.patch.object(bam_module, "download_source", fake_download)
         mocker.patch.object(bam_module, "run_shell", fake_shell)
         mocker.patch.object(bam_module, "run_argv", fake_run)
@@ -469,6 +556,9 @@ class TestBamIndexProcessor:
                 target = Path(argv[-1])
                 (target.parent / (target.name + ".bai")).write_bytes(b"bai")
 
+        mocker.patch.object(
+            bam_module, "peek_decompressed_prefix", _fake_peek_valid_header
+        )
         mocker.patch.object(bam_module, "download_source", fake_download)
         mocker.patch.object(bam_module, "run_argv", fake_run)
         mocker.patch.object(bam_module, "run_shell", fake_shell)

--- a/tests/test_workflows/test_processors_base.py
+++ b/tests/test_workflows/test_processors_base.py
@@ -7,8 +7,11 @@ from typing import Any
 
 import pytest
 
+from cfdb.workflows import keys as key_utils
+from cfdb.workflows.events import Complete
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.processors.base import Processor
+from tests.test_workflows import FIXTURE_MD5
 
 
 class _ConcreteProcessor(Processor):
@@ -119,14 +122,62 @@ class TestProcessor:
             supported_formats = frozenset({"BAM"})
             artifact_kinds = (ArtifactKind.INDEX,)
 
-            async def run(self, file_meta, workdir, cache_root):
-                yield {"event": "complete", "artifacts": {}}
+            async def run(self, file_meta, workdir, cache):
+                yield Complete(artifacts={})
 
         # Act
         kinds = _IndexOnly().artifact_kinds_produced(None)
 
         # Assert
         assert kinds == (ArtifactKind.INDEX,)
+
+    def test_cache_key_for_should_match_keys_module_with_processor_version(self):
+        """Test that cache_key_for is the canonical key the router probes.
+
+        Given:
+            A processor with processor_version 1 and a complete file_meta.
+        When:
+            cache_key_for is called for the DATA artifact.
+        Then:
+            It should equal the key keys.cache_key derives with the same
+            identity and the processor's version — so the router probe,
+            the processor put, and the StageComplete event all agree.
+        """
+        # Arrange
+        meta = {
+            "dcc": {"dcc_abbreviation": "ENCODE"},
+            "local_id": "ENCFF1",
+            "md5": FIXTURE_MD5,
+        }
+
+        # Act
+        key = _ConcreteProcessor().cache_key_for(meta, ArtifactKind.DATA)
+
+        # Assert
+        assert key == key_utils.cache_key(
+            dcc="ENCODE",
+            local_id="ENCFF1",
+            artifact_kind=ArtifactKind.DATA,
+            md5=FIXTURE_MD5,
+            processor_version=1,
+        )
+
+    def test_cache_key_for_should_raise_when_file_meta_incomplete(self):
+        """Test that cache_key_for surfaces incomplete metadata loudly.
+
+        Given:
+            A file_meta missing local_id and md5.
+        When:
+            cache_key_for is called.
+        Then:
+            It should raise ValueError (via extract_identity) so the
+            router treats the file as workflow-not-applicable.
+        """
+        # Act & assert
+        with pytest.raises(ValueError):
+            _ConcreteProcessor().cache_key_for(
+                {"dcc": {"dcc_abbreviation": "ENCODE"}}, ArtifactKind.DATA
+            )
 
     def test_processor_should_be_abstract_and_reject_direct_instantiation(self):
         """Test that ``Processor`` cannot be instantiated directly.

--- a/tests/test_workflows/test_processors_tabix.py
+++ b/tests/test_workflows/test_processors_tabix.py
@@ -10,6 +10,7 @@ import pytest
 
 from cfdb.workflows import SORT_MEMORY_CAP, keys as key_utils
 from cfdb.workflows.cache import LocalFsCache
+from cfdb.workflows.events import Complete
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.processors import tabix as tabix_module
 from cfdb.workflows.processors.tabix import TabixIntervalProcessor
@@ -29,15 +30,18 @@ def _file_meta(fmt: str) -> dict[str, Any]:
 
 async def _drain_run(proc, file_meta, workdir, cache_root):
     """Drive the processor's async-generator ``run`` to completion."""
-    return [event async for event in proc.run(file_meta, workdir, cache_root)]
+    return [
+        event
+        async for event in proc.run(file_meta, workdir, LocalFsCache(cache_root))
+    ]
 
 
-def _final_artifacts(events: list[dict]) -> dict[str, str]:
-    """Return the artifact mapping from the terminal ``complete`` event."""
+def _final_artifacts(events: list) -> dict[str, str]:
+    """Return the artifact mapping from the terminal ``Complete`` event."""
     for event in reversed(events):
-        if event.get("event") == "complete":
-            return dict(event.get("artifacts") or {})
-    raise AssertionError("processor did not emit a `complete` event")
+        if isinstance(event, Complete):
+            return dict(event.artifacts)
+    raise AssertionError("processor did not emit a `Complete` event")
 
 
 class _PipelineHarness:
@@ -454,7 +458,7 @@ class TestTabixIntervalProcessorPipelines:
         # Act & assert
         with pytest.raises(RuntimeError, match="Refusing to commit empty"):
             async for _event in TabixIntervalProcessor().run(
-                _file_meta("BED"), workdir, cache_root
+                _file_meta("BED"), workdir, LocalFsCache(cache_root)
             ):
                 pass
         cache = LocalFsCache(cache_root)

--- a/tests/test_workflows/test_provisioner.py
+++ b/tests/test_workflows/test_provisioner.py
@@ -1,0 +1,595 @@
+"""Tests for EcsProvisioner."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cfdb.workflows.provisioner import RetryableProvisionerError, EcsProvisioner
+
+
+class _FakeEcsClient:
+    """In-memory ECS client recording RunTask calls for assertions."""
+
+    def __init__(self, *, response: dict | None = None, raise_on_call: Exception | None = None) -> None:
+        self.calls: list[dict] = []
+        self._response = response or {
+            "tasks": [{"taskArn": "arn:aws:ecs:::task/cluster/abc"}],
+            "failures": [],
+        }
+        self._raise = raise_on_call
+
+    def run_task(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raise is not None:
+            raise self._raise
+        return self._response
+
+
+class _SimpleGatedClient(_FakeEcsClient):
+    """run_task blocks on a threading.Event until released by the test."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        import threading
+
+        self._gate = threading.Event()
+        self._call_started = threading.Event()
+
+    def run_task(self, **kwargs):
+        self.calls.append(kwargs)
+        self._call_started.set()
+        # Block the worker thread until the test releases the gate.
+        self._gate.wait()
+        return self._response
+
+    def release(self) -> None:
+        self._gate.set()
+
+
+def _client_error(code: str) -> Exception:
+    """Construct a botocore ClientError with a structured response dict."""
+    from botocore.exceptions import ClientError
+
+    return ClientError(
+        {"Error": {"Code": code, "Message": "simulated"}, "ResponseMetadata": {"HTTPStatusCode": 500}},
+        "RunTask",
+    )
+
+
+class TestEcsProvisioner:
+    def test___init___without_cluster(self):
+        """Test that constructing EcsProvisioner without a cluster fails fast.
+
+        Given:
+            No cluster name.
+        When:
+            EcsProvisioner is constructed.
+        Then:
+            It should raise ValueError so misconfiguration is caught at boot.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="cluster"):
+            EcsProvisioner(
+                cluster="",
+                task_definition="worker",
+                subnets=["subnet-1"],
+                client=_FakeEcsClient(),
+            )
+
+    def test___init___without_task_definition(self):
+        """Test that omitting task_definition raises ValueError.
+
+        Given:
+            A cluster but no task definition.
+        When:
+            EcsProvisioner is constructed.
+        Then:
+            It should raise ValueError to surface the misconfiguration.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="task_definition"):
+            EcsProvisioner(
+                cluster="c",
+                task_definition="",
+                subnets=["subnet-1"],
+                client=_FakeEcsClient(),
+            )
+
+    def test___init___without_subnets(self):
+        """Test that constructing without subnets raises ValueError.
+
+        Given:
+            A cluster and task definition but no subnets.
+        When:
+            EcsProvisioner is constructed.
+        Then:
+            It should raise ValueError because awsvpc requires at least one.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="subnet"):
+            EcsProvisioner(
+                cluster="c",
+                task_definition="worker",
+                subnets=[],
+                client=_FakeEcsClient(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_request_with_single_caller(self):
+        """Test that request returns the launched task ARNs.
+
+        Given:
+            A provisioner backed by a fake client returning one task ARN.
+        When:
+            request is awaited once.
+        Then:
+            It should return the list of ARNs and have invoked RunTask once
+            with the configured cluster, family, and awsvpc network config.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            security_groups=["sg-1"],
+            client=client,
+        )
+
+        # Act
+        arns = await provisioner.request(dedup_key="wf-1")
+
+        # Assert
+        assert arns == ["arn:aws:ecs:::task/cluster/abc"]
+        assert len(client.calls) == 1
+        call = client.calls[0]
+        assert call["cluster"] == "c"
+        assert call["taskDefinition"] == "worker"
+        assert call["launchType"] == "FARGATE"
+        awsvpc = call["networkConfiguration"]["awsvpcConfiguration"]
+        assert awsvpc["subnets"] == ["subnet-1"]
+        assert awsvpc["securityGroups"] == ["sg-1"]
+
+    @pytest.mark.asyncio
+    async def test_request_with_concurrent_dedup_key_collisions(self):
+        """Test that concurrent calls with the same dedup_key share one RunTask.
+
+        Given:
+            A provisioner whose underlying RunTask call is gated on a
+            threading.Event so the first caller stays in-flight.
+        When:
+            Two coroutines call request concurrently with the same dedup_key.
+        Then:
+            Only one RunTask invocation should be issued, and both callers
+            should observe identical ARNs.
+        """
+        # Arrange
+        client = _SimpleGatedClient()
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            client=client,
+        )
+
+        # Act
+        first = asyncio.create_task(provisioner.request(dedup_key="wf-1"))
+        # Wait until the first call is mid-flight before starting the
+        # second so the dedup map is populated.
+        await asyncio.to_thread(client._call_started.wait)
+        second = asyncio.create_task(provisioner.request(dedup_key="wf-1"))
+        # Release the gated client so both callers can return.
+        client.release()
+        first_arns, second_arns = await asyncio.gather(first, second)
+
+        # Assert
+        assert first_arns == second_arns == ["arn:aws:ecs:::task/cluster/abc"]
+        assert len(client.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_request_with_distinct_dedup_keys(self):
+        """Test that distinct dedup keys produce independent RunTask calls.
+
+        Given:
+            A provisioner backed by a fake client.
+        When:
+            request is awaited twice with different dedup_keys.
+        Then:
+            Two RunTask invocations should be issued.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            client=client,
+        )
+
+        # Act
+        await provisioner.request(dedup_key="wf-a")
+        await provisioner.request(dedup_key="wf-b")
+
+        # Assert
+        assert len(client.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_request_with_capacity_client_error(self):
+        """Test that capacity ClientErrors map to RetryableProvisionerError.
+
+        Given:
+            A provisioner whose underlying client raises a Capacity error.
+        When:
+            request is awaited.
+        Then:
+            It should raise RetryableProvisionerError so callers can surface it as a
+            retryable terminal failure.
+        """
+        # Arrange
+        client = _FakeEcsClient(raise_on_call=_client_error("CapacityProviderException"))
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            client=client,
+        )
+
+        # Act & assert
+        with pytest.raises(RetryableProvisionerError):
+            await provisioner.request(dedup_key="wf-1")
+
+    @pytest.mark.asyncio
+    async def test_request_with_capacity_failure_in_response(self):
+        """Test that capacity failures inside the RunTask response also raise.
+
+        Given:
+            A provisioner whose RunTask response carries a failures entry
+            whose reason includes RESOURCE: tokens.
+        When:
+            request is awaited.
+        Then:
+            It should raise RetryableProvisionerError rather than treating the call
+            as a success with zero ARNs.
+        """
+        # Arrange
+        client = _FakeEcsClient(
+            response={
+                "tasks": [],
+                "failures": [{"reason": "RESOURCE:CPU"}],
+            }
+        )
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            client=client,
+        )
+
+        # Act & assert
+        with pytest.raises(RetryableProvisionerError):
+            await provisioner.request(dedup_key="wf-1")
+
+    @pytest.mark.asyncio
+    async def test_request_with_partial_failure_preserves_arn(self):
+        """Test that a launched ARN is preserved even when failures[] is non-empty.
+
+        Given:
+            A provisioner whose RunTask response carries both a launched
+            taskArn and a non-retryable failures entry.
+        When:
+            request is awaited.
+        Then:
+            It should return the launched ARN and log the failure rather
+            than discarding the worker that is already running.
+        """
+        # Arrange
+        client = _FakeEcsClient(
+            response={
+                "tasks": [{"taskArn": "arn:aws:ecs:::task/cluster/abc"}],
+                "failures": [{"reason": "secondary placement warning"}],
+            }
+        )
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            client=client,
+        )
+
+        # Act
+        arns = await provisioner.request(dedup_key="wf-1")
+
+        # Assert
+        assert arns == ["arn:aws:ecs:::task/cluster/abc"]
+
+    @pytest.mark.asyncio
+    async def test_request_with_done_cached_task_launches_fresh_run(self):
+        """Test that a stale completed in-flight entry is replaced on next request.
+
+        Given:
+            A provisioner where the first request completed and the dedup
+            slot still holds the done task (simulating a release-slot race
+            where the post-completion pop was skipped).
+        When:
+            A second request with the same dedup_key is awaited.
+        Then:
+            A fresh RunTask is issued rather than the second caller
+            attaching to the already-finished task.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            client=client,
+        )
+        first = await provisioner.request(dedup_key="wf-shared")
+        # Simulate the post-completion pop having been skipped (e.g. by a
+        # CancelledError that re-raised out of the shielded release): put
+        # the done task back into the dedup map.
+        done_task = asyncio.create_task(_resolved(first))
+        await done_task
+        provisioner._in_flight["wf-shared"] = done_task
+
+        # Act
+        second = await provisioner.request(dedup_key="wf-shared")
+
+        # Assert
+        assert second == first
+        assert len(client.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_aclose_cancels_in_flight_and_clears_map(self):
+        """Test that aclose cancels in-flight tasks and clears the dedup map.
+
+        Given:
+            A provisioner with one in-flight RunTask whose underlying
+            boto3 call is mid-flight on the ``asyncio.to_thread`` worker.
+        When:
+            aclose is awaited.
+        Then:
+            The asyncio task is cancelled, the dedup map is empty, and
+            the original caller observes CancelledError rather than a hang.
+        """
+        # Arrange — use a client that simulates a slow round-trip via a
+        # short ``time.sleep`` in the worker thread. ``asyncio.to_thread``
+        # cannot cancel the running thread, but the wrapping task can be
+        # cancelled — which is what ``aclose`` does. The short sleep
+        # makes the thread exit promptly so pytest's executor join at
+        # session teardown does not hit a 300 s timeout.
+        import time
+
+        class _SlowClient(_FakeEcsClient):
+            def run_task(self, **kwargs):
+                self.calls.append(kwargs)
+                time.sleep(0.5)
+                return self._response
+
+        client = _SlowClient()
+        provisioner = EcsProvisioner(
+            cluster="c",
+            task_definition="worker",
+            subnets=["subnet-1"],
+            client=client,
+        )
+        caller = asyncio.create_task(provisioner.request(dedup_key="wf-1"))
+        # Yield so the dedup-registration task is scheduled and the
+        # boto thread call has begun.
+        await asyncio.sleep(0.05)
+
+        # Act
+        await provisioner.aclose()
+
+        # Assert
+        assert provisioner._in_flight == {}
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+
+
+async def _resolved(value):
+    """Helper coroutine that immediately returns ``value``.
+
+    Used by the dedup-self-heal test to construct a real done task that
+    holds the same return value as the first request.
+    """
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Moto-backed wire-shape verification.
+#
+# Pure unit tests above use ``_FakeEcsClient`` to assert call shape and
+# branch coverage. The class below runs the same provisioner against a
+# real boto3 ``ecs`` client wired into ``moto``'s in-process AWS
+# simulator — any drift between our kwarg shape and what ECS actually
+# accepts surfaces as a moto rejection, catching the class of bug
+# pure mocks cannot (e.g. a misspelled ``networkConfiguration`` key,
+# an unsupported ``launchType`` value, an unregistered cluster).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def moto_ecs_env():
+    """Stand up a moto-backed ECS cluster + task definition + VPC.
+
+    Returns a ``(client, cluster, task_definition, subnet, security_group)``
+    bundle for the provisioner to target. The VPC has
+    ``EnableDnsHostnames`` enabled because moto's ECS ``RunTask`` model
+    unconditionally reads ``eni.private_dns_name`` and crashes when the
+    attribute is unset.
+    """
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        ec2 = boto3.client("ec2", region_name="us-east-1")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        ec2.modify_vpc_attribute(VpcId=vpc, EnableDnsHostnames={"Value": True})
+        subnet = ec2.create_subnet(
+            VpcId=vpc, CidrBlock="10.0.0.0/24", AvailabilityZone="us-east-1a"
+        )["Subnet"]["SubnetId"]
+        sg = ec2.create_security_group(
+            GroupName="cfdb-test-sg", Description="moto sg", VpcId=vpc
+        )["GroupId"]
+
+        ecs = boto3.client("ecs", region_name="us-east-1")
+        ecs.create_cluster(clusterName="cfdb-test")
+        ecs.register_task_definition(
+            family="cfdb-test-worker",
+            networkMode="awsvpc",
+            requiresCompatibilities=["FARGATE"],
+            cpu="256",
+            memory="512",
+            containerDefinitions=[
+                {
+                    "name": "worker",
+                    "image": "cfdb-worker:test",
+                    "essential": True,
+                    "memory": 512,
+                }
+            ],
+        )
+        yield {
+            "client": ecs,
+            "cluster": "cfdb-test",
+            "task_definition": "cfdb-test-worker",
+            "subnet": subnet,
+            "security_group": sg,
+        }
+
+
+class TestEcsProvisionerAgainstMoto:
+    """Wire-shape verification against a real boto3 ``ecs`` client.
+
+    These tests are slower than the ``_FakeEcsClient`` ones (a few
+    hundred milliseconds for VPC + cluster + task-def setup) so they
+    live in a separate class. They guard against accidental drift in
+    the ``RunTask`` kwarg names / enum values that pure mocks cannot
+    detect.
+    """
+
+    @pytest.mark.asyncio
+    async def test_request_should_launch_a_task_when_moto_accepts_the_kwargs(
+        self, moto_ecs_env
+    ):
+        """Test that RunTask is accepted by moto and returns a task ARN.
+
+        Given:
+            A provisioner targeting a moto-backed cluster with a
+            registered Fargate task definition and a valid awsvpc
+            subnet + security group.
+        When:
+            request is awaited with a fresh dedup_key.
+        Then:
+            It should return one task ARN matching the ARN ECS recorded,
+            with no failure entries, proving the kwarg shape is accepted.
+        """
+        # Arrange
+        provisioner = EcsProvisioner(
+            cluster=moto_ecs_env["cluster"],
+            task_definition=moto_ecs_env["task_definition"],
+            subnets=[moto_ecs_env["subnet"]],
+            security_groups=[moto_ecs_env["security_group"]],
+            client=moto_ecs_env["client"],
+        )
+        try:
+            # Act
+            arns = await provisioner.request(dedup_key="wf-moto-1")
+
+            # Assert
+            assert len(arns) == 1
+            assert arns[0].startswith(
+                "arn:aws:ecs:us-east-1:123456789012:task/cfdb-test/"
+            )
+            recorded = moto_ecs_env["client"].list_tasks(
+                cluster=moto_ecs_env["cluster"],
+                family=moto_ecs_env["task_definition"],
+                desiredStatus="RUNNING",
+            )["taskArns"]
+            assert arns[0] in recorded
+        finally:
+            await provisioner.aclose()
+
+    @pytest.mark.asyncio
+    async def test_request_should_send_fargate_awsvpc_configuration(
+        self, moto_ecs_env
+    ):
+        """Test that the awsvpc network configuration round-trips through ECS.
+
+        Given:
+            A provisioner with explicit subnet, security group, and
+            assignPublicIp=DISABLED.
+        When:
+            request launches a task and DescribeTasks queries it back.
+        Then:
+            The launched task should carry a FARGATE launchType and an
+            ElasticNetworkInterface attachment, confirming the awsvpc
+            configuration reached the ECS backend intact.
+        """
+        # Arrange
+        provisioner = EcsProvisioner(
+            cluster=moto_ecs_env["cluster"],
+            task_definition=moto_ecs_env["task_definition"],
+            subnets=[moto_ecs_env["subnet"]],
+            security_groups=[moto_ecs_env["security_group"]],
+            assign_public_ip="DISABLED",
+            client=moto_ecs_env["client"],
+        )
+        try:
+            # Act
+            arns = await provisioner.request(dedup_key="wf-moto-net")
+            described = moto_ecs_env["client"].describe_tasks(
+                cluster=moto_ecs_env["cluster"], tasks=arns
+            )["tasks"]
+
+            # Assert
+            assert len(described) == 1
+            task = described[0]
+            assert task.get("launchType") == "FARGATE"
+            eni_attachments = [
+                a
+                for a in task.get("attachments", [])
+                if a.get("type") == "ElasticNetworkInterface"
+            ]
+            assert eni_attachments, (
+                "moto did not produce an ENI attachment — awsvpc kwargs "
+                "may not have reached the backend correctly"
+            )
+        finally:
+            await provisioner.aclose()
+
+    @pytest.mark.asyncio
+    async def test_request_should_classify_throttling_as_retryable_against_moto(
+        self, moto_ecs_env, mocker
+    ):
+        """Test that ThrottlingException from RunTask becomes RetryableProvisionerError.
+
+        Given:
+            A provisioner whose underlying boto3 RunTask is monkey-
+            patched to raise the canonical ClientError moto would
+            emit if ECS were throttling.
+        When:
+            request is awaited.
+        Then:
+            It should raise RetryableProvisionerError so the executor
+            surfaces the workflow failure with a retryable contract.
+        """
+        # Arrange
+        provisioner = EcsProvisioner(
+            cluster=moto_ecs_env["cluster"],
+            task_definition=moto_ecs_env["task_definition"],
+            subnets=[moto_ecs_env["subnet"]],
+            client=moto_ecs_env["client"],
+        )
+        mocker.patch.object(
+            moto_ecs_env["client"], "run_task", side_effect=_client_error("ThrottlingException")
+        )
+        try:
+            # Act & assert
+            with pytest.raises(RetryableProvisionerError):
+                await provisioner.request(dedup_key="wf-moto-throttle")
+        finally:
+            await provisioner.aclose()

--- a/tests/test_workflows/test_s3_contract.py
+++ b/tests/test_workflows/test_s3_contract.py
@@ -1,0 +1,209 @@
+"""End-to-end contract test: workflows must persist artifacts to S3.
+
+This is the test that would have caught the bug where processors hardcoded
+``LocalFsCache`` and ignored the injected backend, so the S3/ECS profile
+never actually persisted artifacts to the store the API reads from.
+
+It runs the executor with in-process dispatch (``no_wool_dispatch``) so
+moto's in-process S3 mock stays active — moto cannot patch boto3 inside a
+spawned worker subprocess. The cloudpickle boundary itself is exercised
+separately by ``tests/integration/test_executor_boundary.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from cfdb import api
+from cfdb.api.routers.cache_stream import serve_workflow_artifact_or_dispatch
+from cfdb.workflows.cache import S3Cache
+from cfdb.workflows.events import Complete, StageComplete, WorkflowEvent
+from cfdb.workflows.executor import WoolExecutor
+from cfdb.workflows.lock import get_job
+from cfdb.workflows.models import ACTIVE_STATUSES, ArtifactKind, JobStatus
+from cfdb.workflows.processors.base import Processor
+from cfdb.workflows.processors.registry import ProcessorRegistry
+from tests.test_workflows import FIXTURE_MD5
+from tests.test_workflows.test_executor import _wait_for_terminal
+
+_BUCKET = "cfdb-contract-cache"
+
+
+@pytest.fixture()
+def s3_client():
+    """Yield a moto-backed boto3 S3 client with the cache bucket created."""
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=_BUCKET)
+        yield client
+
+
+class _S3StubProcessor(Processor):
+    """Materialise two artifacts to ``workdir`` and ``put`` them via the cache.
+
+    Tool-free so the test stays a unit test, but exercises the real
+    producer path: derive keys via :meth:`cache_key_for`, write local
+    files, and persist through the injected backend.
+    """
+
+    processor_version = 0
+    supported_formats = frozenset({"BED"})
+    artifact_kinds = (ArtifactKind.DATA, ArtifactKind.INDEX)
+
+    _PAYLOADS = {
+        ArtifactKind.DATA: b"data-bytes",
+        ArtifactKind.INDEX: b"index-bytes",
+    }
+
+    async def run(self, file_meta, workdir, cache) -> AsyncIterator[WorkflowEvent]:
+        workdir.mkdir(parents=True, exist_ok=True)
+        artifacts: dict[str, str] = {}
+        for kind, payload in self._PAYLOADS.items():
+            key = self.cache_key_for(file_meta, kind)
+            src = workdir / kind.value
+            src.write_bytes(payload)
+            await cache.put(key, src)
+            artifacts[kind.value] = key
+            yield StageComplete(kind=kind, key=key)
+        yield Complete(artifacts=artifacts)
+
+
+def _install_jobs_index(mock_db) -> None:
+    mock_db.jobs.create_index(
+        {"workflow_key": 1},
+        unique=True,
+        partialFilterExpression={
+            "status": {"$in": [s.value for s in ACTIVE_STATUSES]}
+        },
+    )
+
+
+def _file_meta() -> dict[str, Any]:
+    return {
+        "dcc": {"dcc_abbreviation": "ENCODE"},
+        "local_id": "ENCFF1",
+        "md5": FIXTURE_MD5,
+        "file_format": {"name": "BED"},
+        "access_url": "https://example.org/x.bed",
+    }
+
+
+class _Request:
+    def __init__(self, method: str = "GET") -> None:
+        self.method = method
+
+
+@pytest.mark.asyncio
+async def test_workflow_should_persist_artifacts_to_s3_and_serve_cache_hit(
+    mock_db, s3_client, tmp_path: Path, no_wool_dispatch, mocker
+):
+    """Test that a workflow's artifacts reach S3 and the API then serves them.
+
+    Given:
+        An executor wired to an S3Cache (moto-backed) and a processor that
+        commits its artifacts through the injected backend.
+    When:
+        A workflow is dispatched in-process and runs to completion.
+    Then:
+        Each artifact exists as an object in the S3 bucket, cache.get
+        streams the bytes back, and serve_workflow_artifact_or_dispatch
+        returns a cache hit (not a 202) on a subsequent GET — proving the
+        producer -> S3 -> consumer round-trip the S3 profile depends on.
+    """
+    # Arrange
+    cache = S3Cache(bucket=_BUCKET, client=s3_client)
+    processor = _S3StubProcessor()
+    registry = ProcessorRegistry()
+    registry.register(processor)
+    executor = WoolExecutor(
+        mock_db, cache, registry, workdir_root=tmp_path / "jobs"
+    )
+    _install_jobs_index(mock_db)
+    file_meta = _file_meta()
+
+    # Act
+    record, _ = await executor.ensure_workflow(file_meta)
+    await _wait_for_terminal(mock_db, record.job_id)
+
+    # Assert — the workflow completed...
+    final = await get_job(mock_db, record.job_id)
+    assert final is not None
+    assert final.status == JobStatus.COMPLETED
+
+    data_key = processor.cache_key_for(file_meta, ArtifactKind.DATA)
+    index_key = processor.cache_key_for(file_meta, ArtifactKind.INDEX)
+
+    # ...the artifacts are real objects in the bucket (the bug: empty)...
+    s3_client.head_object(Bucket=_BUCKET, Key=data_key)
+    s3_client.head_object(Bucket=_BUCKET, Key=index_key)
+
+    # ...the cache reads them back...
+    assert await cache.head(data_key) is not None
+    chunks = [chunk async for chunk in cache.get(data_key)]
+    assert b"".join(chunks) == b"data-bytes"
+
+    # ...and the router serves a cache hit rather than re-dispatching.
+    mocker.patch.object(api, "cache", cache)
+    mocker.patch.object(api, "executor", executor)
+    mocker.patch.object(api, "processor_registry", registry)
+    resp = await serve_workflow_artifact_or_dispatch(
+        file_meta,
+        ArtifactKind.DATA,
+        _Request("GET"),
+        None,
+        head_404_detail="n/a",
+    )
+    assert resp is not None
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_serve_should_dispatch_when_s3_artifact_absent(
+    mock_db, s3_client, tmp_path: Path, mocker
+):
+    """Test that an empty S3 cache yields a 202 dispatch, not a false hit.
+
+    Given:
+        An S3Cache with no objects and the workflow subsystem wired.
+    When:
+        serve_workflow_artifact_or_dispatch is awaited for a GET.
+    Then:
+        It returns a 202 (cache miss -> dispatch), confirming the cache
+        probe genuinely consults S3.
+    """
+    # Arrange
+    cache = S3Cache(bucket=_BUCKET, client=s3_client)
+    registry = ProcessorRegistry()
+    registry.register(_S3StubProcessor())
+    executor = WoolExecutor(
+        mock_db, cache, registry, workdir_root=tmp_path / "jobs"
+    )
+    _install_jobs_index(mock_db)
+    mocker.patch.object(api, "cache", cache)
+    mocker.patch.object(api, "executor", executor)
+    mocker.patch.object(api, "processor_registry", registry)
+
+    # Assert the bucket really is empty for this identity.
+    miss_key = _S3StubProcessor().cache_key_for(_file_meta(), ArtifactKind.DATA)
+    with pytest.raises(ClientError):
+        s3_client.head_object(Bucket=_BUCKET, Key=miss_key)
+
+    # Act
+    resp = await serve_workflow_artifact_or_dispatch(
+        _file_meta(),
+        ArtifactKind.DATA,
+        _Request("GET"),
+        None,
+        head_404_detail="n/a",
+    )
+
+    # Assert — dispatched (202), proving the probe consulted S3.
+    assert resp is not None
+    assert resp.status_code == 202

--- a/tests/test_workflows/test_worker_lan.py
+++ b/tests/test_workflows/test_worker_lan.py
@@ -1,0 +1,120 @@
+"""Tests for the local-dev LAN worker entrypoint argument parsing."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from cfdb.workflows import worker_lan
+
+
+def _invoke(args: list[str]) -> tuple[int, dict[str, object]]:
+    """Run ``worker_lan.main`` with ``args``, capturing the ``serve`` kwargs.
+
+    Returns ``(exit_code, captured_kwargs)``. The real ``serve`` is patched
+    out so the test never actually spawns a worker pool.
+    """
+    captured: dict[str, object] = {}
+
+    async def _fake_serve(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    runner = CliRunner()
+    with patch.object(worker_lan, "serve", _fake_serve):
+        result = runner.invoke(worker_lan.main, args, standalone_mode=True)
+    return result.exit_code, captured
+
+
+class TestMainCli:
+    def test_main_uses_documented_defaults_when_no_args_or_env(self, monkeypatch):
+        """Test that bare invocation surfaces the documented defaults.
+
+        Given:
+            No CLI arguments and no overriding environment variables.
+        When:
+            ``worker_lan.main`` is invoked.
+        Then:
+            ``serve`` should be called with the documented namespace and
+            worker-count defaults so a bare ``python -m`` launch pairs
+            with a bare API.
+        """
+        # Arrange — clear any env overrides so defaults apply
+        for var in ("WORKFLOW_POOL_NAMESPACE", "WORKFLOW_WORKER_COUNT"):
+            monkeypatch.delenv(var, raising=False)
+
+        # Act
+        exit_code, captured = _invoke([])
+
+        # Assert
+        assert exit_code == 0
+        assert captured["namespace"] == worker_lan.DEFAULT_NAMESPACE
+        assert captured["workers"] == worker_lan.DEFAULT_WORKER_COUNT
+
+    def test_main_with_env_overrides(self, monkeypatch):
+        """Test that environment variables override the defaults.
+
+        Given:
+            ``WORKFLOW_POOL_NAMESPACE`` and ``WORKFLOW_WORKER_COUNT`` set
+            to non-default values.
+        When:
+            ``worker_lan.main`` is invoked with no CLI flags.
+        Then:
+            ``serve`` should receive the env-driven values so the same
+            env vars size both the API and the publisher.
+        """
+        # Arrange
+        monkeypatch.setenv("WORKFLOW_POOL_NAMESPACE", "cfdb-dev")
+        monkeypatch.setenv("WORKFLOW_WORKER_COUNT", "4")
+
+        # Act
+        exit_code, captured = _invoke([])
+
+        # Assert
+        assert exit_code == 0
+        assert captured["namespace"] == "cfdb-dev"
+        assert captured["workers"] == 4
+
+    def test_main_cli_flags_override_env_vars(self, monkeypatch):
+        """Test that CLI flags win over environment variables.
+
+        Given:
+            ``WORKFLOW_POOL_NAMESPACE`` set in the environment.
+        When:
+            ``worker_lan.main`` is invoked with an explicit
+            ``--namespace`` CLI flag.
+        Then:
+            ``serve`` should receive the CLI-supplied value.
+        """
+        # Arrange
+        monkeypatch.setenv("WORKFLOW_POOL_NAMESPACE", "cfdb-dev")
+
+        # Act
+        exit_code, captured = _invoke(["--namespace", "cfdb-cli"])
+
+        # Assert
+        assert exit_code == 0
+        assert captured["namespace"] == "cfdb-cli"
+
+    def test_main_rejects_non_positive_worker_count(self, monkeypatch):
+        """Test that a worker count below 1 is rejected at parse time.
+
+        Given:
+            A ``--workers`` value of 0.
+        When:
+            ``worker_lan.main`` is invoked.
+        Then:
+            Click should exit non-zero before reaching ``serve`` so the
+            misconfiguration surfaces clearly rather than spawning an
+            empty pool the API blocks against.
+        """
+        # Arrange
+        monkeypatch.delenv("WORKFLOW_WORKER_COUNT", raising=False)
+
+        # Act
+        exit_code, captured = _invoke(["--workers", "0"])
+
+        # Assert
+        assert exit_code != 0
+        assert "workers" not in captured

--- a/tests/test_workflows/test_worker_main.py
+++ b/tests/test_workflows/test_worker_main.py
@@ -1,0 +1,132 @@
+"""Tests for the ECS worker entrypoint argument parsing."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from cfdb.workflows import worker_main
+
+
+def _invoke(args: list[str]) -> tuple[int, dict[str, object]]:
+    """Run ``worker_main.main`` with ``args``, capturing the ``serve`` kwargs.
+
+    Returns ``(exit_code, captured_kwargs)``. The real ``serve`` is patched
+    out — the entrypoint always calls ``raise SystemExit(asyncio.run(serve(...)))``,
+    so swapping ``asyncio.run`` for ``lambda coro: coro.close() or 0`` plus
+    stubbing ``serve`` keeps the test from actually booting a worker.
+    """
+    captured: dict[str, object] = {}
+
+    async def _fake_serve(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    runner = CliRunner()
+    with patch.object(worker_main, "serve", _fake_serve):
+        result = runner.invoke(worker_main.main, args, standalone_mode=True)
+    return result.exit_code, captured
+
+
+class TestMainCli:
+    def test_main_uses_documented_defaults_when_no_args_or_env(self, monkeypatch):
+        """Test that bare invocation surfaces the documented defaults.
+
+        Given:
+            No CLI arguments and no overriding environment variables.
+        When:
+            ``worker_main.main`` is invoked.
+        Then:
+            ``serve`` should be called with the documented worker port,
+            health port, max lifetime, and drain-grace defaults so a
+            bare container ``CMD`` works.
+        """
+        # Arrange — clear any env overrides so defaults apply
+        for var in (
+            "CFDB_WORKER_GRPC_PORT",
+            "CFDB_WORKER_HEALTH_PORT",
+            "CFDB_WORKER_MAX_LIFETIME_SECONDS",
+            "CFDB_WORKER_DRAIN_GRACE_SECONDS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        # Act
+        exit_code, captured = _invoke([])
+
+        # Assert
+        assert exit_code == 0
+        assert captured["worker_port"] == worker_main.DEFAULT_WORKER_PORT
+        assert captured["health_port"] == worker_main.DEFAULT_HEALTH_PORT
+        assert captured["max_lifetime_seconds"] == worker_main.DEFAULT_MAX_LIFETIME_SECONDS
+        assert captured["drain_grace_seconds"] == worker_main.DEFAULT_DRAIN_GRACE_SECONDS
+
+    def test_main_with_env_overrides(self, monkeypatch):
+        """Test that environment variables override the defaults.
+
+        Given:
+            ``CFDB_WORKER_GRPC_PORT`` and friends set to non-default values.
+        When:
+            ``worker_main.main`` is invoked with no CLI flags.
+        Then:
+            ``serve`` should receive the env-driven values.
+        """
+        # Arrange
+        monkeypatch.setenv("CFDB_WORKER_GRPC_PORT", "60001")
+        monkeypatch.setenv("CFDB_WORKER_HEALTH_PORT", "9001")
+        monkeypatch.setenv("CFDB_WORKER_MAX_LIFETIME_SECONDS", "1800")
+        monkeypatch.setenv("CFDB_WORKER_DRAIN_GRACE_SECONDS", "10")
+
+        # Act
+        exit_code, captured = _invoke([])
+
+        # Assert
+        assert exit_code == 0
+        assert captured["worker_port"] == 60001
+        assert captured["health_port"] == 9001
+        assert captured["max_lifetime_seconds"] == 1800.0
+        assert captured["drain_grace_seconds"] == 10.0
+
+    def test_main_cli_flags_override_env_vars(self, monkeypatch):
+        """Test that CLI flags win over environment variables.
+
+        Given:
+            ``CFDB_WORKER_GRPC_PORT`` set in the environment.
+        When:
+            ``worker_main.main`` is invoked with an explicit
+            ``--worker-port`` CLI flag.
+        Then:
+            ``serve`` should receive the CLI-supplied value.
+        """
+        # Arrange
+        monkeypatch.setenv("CFDB_WORKER_GRPC_PORT", "60001")
+
+        # Act
+        exit_code, captured = _invoke(["--worker-port", "55555"])
+
+        # Assert
+        assert exit_code == 0
+        assert captured["worker_port"] == 55555
+
+    def test_main_rejects_out_of_range_worker_port(self, monkeypatch):
+        """Test that a port outside [1, 65535] is rejected at parse time.
+
+        Given:
+            A ``--worker-port`` value above 65535.
+        When:
+            ``worker_main.main`` is invoked.
+        Then:
+            Click should exit non-zero before reaching ``serve``, so the
+            failure surfaces clearly rather than as an opaque bind error
+            later.
+        """
+        # Arrange
+        for var in ("CFDB_WORKER_GRPC_PORT",):
+            monkeypatch.delenv(var, raising=False)
+
+        # Act
+        exit_code, captured = _invoke(["--worker-port", "99999"])
+
+        # Assert
+        assert exit_code != 0
+        assert "worker_port" not in captured


### PR DESCRIPTION
## Summary

Add the runtime application substrate the workflow subsystem needs to run on the ECS Fargate fleet outlined in #32: an `EcsProvisioner` that launches ephemeral worker containers per workflow via `RunTask`, an `EcsDiscovery` poll-and-diff loop over `ListTasks` + `DescribeTasks` that surfaces healthy tasks to Wool's worker pool, an `S3Cache` backend that mirrors `LocalFsCache` semantics over boto3, a worker-container entrypoint, and a workflow heartbeat that lets multi-hour preprocessing runs survive the stale-reclaim predicate. The same boto3-backed code targets real AWS in production and LocalStack in dev — only `AWS_ENDPOINT_URL` differs.

Two `WoolExecutor` defaults move with the multi-hour profile: `DEFAULT_WORKFLOW_DURATION_CAP_SECONDS` rises from 20 min to 4 h (env-driven), and `_NO_WORKERS_RETRY_ATTEMPTS` widens from 5 to 60 to cover the Fargate cold-start budget. `STALE_WORKFLOW_THRESHOLD` drops from 1 h to 15 min — paired with a 5-min heartbeat sidecar in the executor, that catches actually-dead workers fast without false-positive reclaiming legitimate long sorts.

Scope intentionally narrows to the runtime application code so it lands self-contained with full unit coverage. Defer for follow-up PRs once the runtime classes have integration coverage and a deploy pipeline exists: LocalStack `docker-compose.yml`, CloudFormation worker task-def updates, multi-stage worker Dockerfile + SOCI index, README documentation, and LocalStack-backed integration tests.

Closes #33

## Proposed changes

### S3 cache backend

Add `S3Cache` (`src/cfdb/workflows/cache.py`) as a `CacheBackend` over boto3 with `head_object` / `get_object` (with `Range`) / `upload_file` / `delete_object`. Support an optional key prefix for sharing a single bucket across environments, reject path-traversal segments, and yield an empty iterator on missing objects to match `LocalFsCache` semantics. Centralize client construction in `build_s3_client` so production, LocalStack-backed dev, and unit tests all produce the same shape of client — only the endpoint differs.

### ECS provisioner and worker discovery

Add `EcsProvisioner` (`src/cfdb/workflows/provisioner.py`) wrapping `RunTask` with awsvpc network configuration. Dedupe concurrent calls keyed on the workflow mutex key so a burst of `ensure_workflow` calls on the same source does not fan out into multiple tasks, and guard the ~20 req/s `RunTask` rate limit with a semaphore. `CapacityException` covers both `ClientError`- and `failures[].reason`-shaped capacity / ENI errors so the executor can surface them as retryable rather than hanging.

Add `EcsDiscovery` (`src/cfdb/workflows/discovery.py`) implementing Wool's `DiscoveryLike` protocol with a poll-and-diff loop over `list_tasks` + `describe_tasks`. Filter on `healthStatus: HEALTHY`, extract the awsvpc IP, and emit `worker-added` / `worker-dropped` events to non-blocking subscribers via per-subscriber `asyncio.Queue`. Replay state on subscribe so subscribers attached after startup observe the existing healthy fleet.

### Worker container entrypoint

Add `worker_main.py` (`src/cfdb/workflows/worker_main.py`) starting `wool.LocalWorker`, exposing a tiny aiohttp `/health` endpoint that returns 503 during drain so ECS marks the task unhealthy before `stop_task` kills gRPC, installing SIGTERM/SIGINT handlers, and self-terminating after a configurable idle timeout. Deliberately omit discovery registration — `EcsDiscovery` polls ECS directly, so the worker only needs to bind its gRPC port and stay HEALTHY.

### Workflow heartbeat

Add `heartbeat_workflow` (`src/cfdb/workflows/lock.py`) bumping `updated_at` on an active job record so a multi-hour run does not trip `claim_workflow`'s stale-reclaim predicate. Fence the update on an active status so a heartbeat against a terminal or stale-reclaimed record is a silent no-op — the executor uses the `False` return as a stop signal. Shorten `STALE_WORKFLOW_THRESHOLD` from 1 h to 15 min and expose `DEFAULT_HEARTBEAT_INTERVAL_SECONDS` as the cadence shared between executor and tests.

### Executor integration

Extend `WoolExecutor` with `provisioner` and `heartbeat_interval_seconds` ctor args. Invoke the provisioner from `ensure_workflow` on a fresh claim and surface `CapacityException` as a terminal `FAILED` job with a retryable error string. Spawn a heartbeat sidecar task that bumps `updated_at` while the workflow body runs and cancel it in `finally` before the terminal release so the next tick cannot observe an active record while status is flipping. Raise `DEFAULT_WORKFLOW_DURATION_CAP_SECONDS` from 1200 to 4 h and widen `_NO_WORKERS_RETRY_ATTEMPTS` from 5 to 60 (~60 s window) for Fargate cold-start. Drop the `LambdaExecutor` mention from the `JobExecutor` ABC docstring.

### API lifespan wiring

Add env vars to `src/cfdb/api/__init__.py`: `AWS_ENDPOINT_URL`, `AWS_REGION`, `WORKFLOW_S3_BUCKET` / `PREFIX`, `ECS_CLUSTER`, `ECS_WORKER_TASK_DEFINITION`, `ECS_WORKER_SUBNETS`, `ECS_WORKER_SECURITY_GROUPS`, `ECS_WORKER_ASSIGN_PUBLIC_IP`, `WORKFLOW_DURATION_CAP_SECONDS`. Have the lifespan pick `S3Cache` over `LocalFsCache` when `WORKFLOW_S3_BUCKET` is set and build an `EcsProvisioner` when ECS env config is present (helper `_maybe_build_provisioner`). Leave the bare PoC profile unchanged: with none of the new env set, the API continues to use the local filesystem cache plus the in-process `WorkerPool`.

### Build dependencies

Add `boto3` to runtime deps and `moto[ecs,s3]` to dev deps so the unit tests can exercise boto3 paths without LocalStack or real AWS.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestS3Cache` | An `S3Cache` constructed with empty bucket | The constructor runs | `ValueError` is raised | Constructor input validation |
| 2 | `TestS3Cache` | A bucket containing no object for the key | `head` is awaited | `None` is returned | Cache-miss head |
| 3 | `TestS3Cache` | A small payload uploaded via `put` | `head` is awaited for the same key | The reported size matches the payload | Round-trip put/head |
| 4 | `TestS3Cache` | A cached object | `get` is iterated without a byte range | The full payload is yielded | Full-object streaming |
| 5 | `TestS3Cache` | A cached object | `get` is iterated with an inclusive byte range | Only the slice is yielded | Range-aware streaming |
| 6 | `TestS3Cache` | A bucket with no object for the key | `get` is iterated | An empty stream is produced | Cache-miss get |
| 7 | `TestS3Cache` | A cached object | `delete` is awaited | `True` is returned and the object is gone | Existing-key deletion |
| 8 | `TestS3Cache` | A bucket with no object for the key | `delete` is awaited | `False` is returned | Absent-key deletion |
| 9 | `TestS3Cache` | A key containing a `..` segment | `put` is awaited | `ValueError` is raised | Path-traversal rejection |
| 10 | `TestS3Cache` | An `S3Cache` constructed with a key prefix | Round-trip put/head is awaited | Object lands under the prefix | Prefix application |
| 11 | `TestEcsProvisioner` | A provisioner constructed without a cluster | The constructor runs | `ValueError` is raised | Constructor input validation |
| 12 | `TestEcsProvisioner` | A provisioner constructed without a task definition | The constructor runs | `ValueError` is raised | Constructor input validation |
| 13 | `TestEcsProvisioner` | A provisioner constructed without subnets | The constructor runs | `ValueError` is raised | Constructor input validation |
| 14 | `TestEcsProvisioner` | A configured provisioner | `request` is awaited once | `RunTask` is called once with the expected payload | Single-caller dispatch |
| 15 | `TestEcsProvisioner` | A provisioner with concurrent calls sharing a dedup key | Many `request` calls await in parallel | `RunTask` is invoked once and all callers receive the same ARN | In-flight dedup |
| 16 | `TestEcsProvisioner` | A provisioner with concurrent calls under distinct dedup keys | Many `request` calls await in parallel | `RunTask` is invoked once per key | Dedup boundary |
| 17 | `TestEcsProvisioner` | A boto3 client raising `ClientError` for capacity | `request` is awaited | `CapacityException` is raised | Capacity error path |
| 18 | `TestEcsProvisioner` | A `RunTask` response with capacity in `failures[]` | `request` is awaited | `CapacityException` is raised | Failure-payload capacity path |
| 19 | `TestEcsDiscovery` | A discovery constructed without a cluster | The constructor runs | `ValueError` is raised | Constructor input validation |
| 20 | `TestEcsDiscovery` | A discovery constructed without a task family | The constructor runs | `ValueError` is raised | Constructor input validation |
| 21 | `TestEcsDiscovery` | An ECS client returning healthy tasks | `_poll_once` is awaited | `worker-added` events are emitted with the expected addresses | Initial healthy fleet |
| 22 | `TestEcsDiscovery` | An ECS client returning a non-healthy task | `_poll_once` is awaited | The unhealthy task is filtered out | Health filter |
| 23 | `TestEcsDiscovery` | A previously seen worker absent on a later poll | `_poll_once` is awaited again | `worker-dropped` is emitted for the gone worker | Drop diff |
| 24 | `TestEcsDiscovery` | A steady-state ECS client | `_poll_once` is awaited twice | No duplicate events are emitted | Idempotent steady state |
| 25 | `TestEcsDiscovery` | A subscriber with a filter rejecting a worker | The discovery emits an `add` event | The filtered subscriber receives nothing | Subscriber filter |
| 26 | `TestParseArgs` | A clean environment | `_parse_args` runs without args | Documented defaults are returned | Default arg parsing |
| 27 | `TestParseArgs` | Worker env vars set | `_parse_args` runs without args | Env values override defaults | Env override |
| 28 | `TestParseArgs` | Worker env vars set and CLI flags passed | `_parse_args` runs with the flags | CLI values override env | CLI precedence |
| 29 | `TestHeartbeatWorkflow` | An active job whose `updated_at` has been backdated | `heartbeat_workflow` is awaited | `True` is returned and `updated_at` advances | Heartbeat happy path |
| 30 | `TestHeartbeatWorkflow` | A job already released to `COMPLETED` | `heartbeat_workflow` is awaited | `False` is returned | Heartbeat stop signal |
| 31 | `TestStaleWorkflowThreshold` | The current `STALE_WORKFLOW_THRESHOLD` constant | Its value is read | It equals 15 minutes | Threshold guard |
| 32 | `TestWoolExecutorWithProvisioner` | An executor with a recording provisioner | `ensure_workflow` is awaited for a fresh key | The provisioner observes one request keyed by the workflow mutex key | Provisioner dispatch |
| 33 | `TestWoolExecutorWithProvisioner` | A provisioner that always raises `CapacityException` | `ensure_workflow` is awaited | The job is `FAILED` with a "capacity"-prefixed error | Capacity-failure handling |
| 34 | `TestWoolExecutorHeartbeat` | An executor with a sub-second heartbeat cadence and a blocking processor | `ensure_workflow` is awaited and the test polls during the run | `updated_at` advances past the original claim timestamp | In-flight heartbeat |