### PR TITLE
Add readiness-probe endpoints for `/data` and `/index` — Closes #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,40 @@ Stream index files (e.g., `.px2`, `.bai`) associated with DCC data files.
 curl -O http://localhost:8000/index/4dn/4DNFIG5NX1EC
 ```
 
+### Readiness Probes
+
+**URL:** `GET /data/{dcc}/{local_id}/status` | `GET /index/{dcc}/{local_id}/status`
+
+Side-effect-free probes that report whether a streaming `GET` to the corresponding endpoint would return bytes immediately or first require preprocessing. They reuse the same lookup, DCC normalization, and access-control logic as `/data` and `/index` and mirror their error codes, but on success return a small JSON body `{ "ready": bool }` instead of streaming. They **never dispatch a workflow** and make no upstream network calls — they read only database and cache metadata, so they are cheap control-plane queries safe to call before committing to a fetch.
+
+**Path Parameters:**
+- `dcc` - DCC abbreviation (e.g., `4dn`, `hubmap`, `encode`) - case insensitive
+- `local_id` - The file's unique ID within the DCC
+
+- `ready: true` — a `GET` would not require preprocessing: the processed artifact is already cached, an upstream sidecar exists (`/index`), or the format is served directly (passthrough such as CSV/TSV/bigWig, or a format with no processed `/data` artifact).
+- `ready: false` — the file is accessible, but a `GET` would trigger preprocessing (a processable format whose artifact is not yet cached, i.e. `GET` would return `202`).
+
+`ready` reflects only the default (preprocessed) path. It indicates that **no preprocessing is required**, not that a `GET` is guaranteed to return `200`: the subsequent `GET` may still resolve an access URL upstream and return `403`/`404`/`501`/`502`/`504`, and when the workflow subsystem is disabled a `ready: true` processable file is served as raw upstream bytes rather than a preprocessed artifact. The probes take no `raw`, `Range`, or `HEAD` semantics — they always describe the default path.
+
+| Code | Description |
+|------|-------------|
+| 200 | Readiness reported as `{ "ready": bool }` |
+| 400 | Invalid DCC or path-param shape |
+| 403 | File requires consortium/protected access (HuBMAP) |
+| 404 | File not found, or (on `/index`) the format has no index (CSV/TSV/bigWig) |
+| 501 | (`/data` only) File has no access URL |
+| 502 | (`/index` only) Malformed upstream sidecar |
+| 503 | (`/index` only) Workflow subsystem disabled (set `SYNC_DATA_DIR`) for a processable format |
+
+```bash
+# Will a GET stream immediately, or trigger preprocessing?
+curl http://localhost:8000/data/4dn/4DNFIG5NX1EC/status
+# {"ready": true}
+
+curl http://localhost:8000/index/encode/ENCFF123ABC/status
+# {"ready": false}
+```
+
 ### Preprocessing & indexing workflow
 
 Many upstream files are not directly consumable by Gosling Designer without preprocessing (e.g., sort+index for BAM, bgzip+tabix for VCF/GFF/BED). When `/data` or `/index` is called for a format that needs preprocessing and the processed artifact is not yet in cache, the API dispatches a workflow and returns `202 Accepted` with a `Location` header pointing to a job status endpoint. A subsequent call, after the workflow completes, streams the processed artifact from cache (with `Range` support). Both endpoints share a single workflow per source file via a Mongo-backed mutex.

--- a/src/cfdb/api/routers/cache_stream.py
+++ b/src/cfdb/api/routers/cache_stream.py
@@ -288,3 +288,57 @@ async def serve_workflow_artifact_or_dispatch(
             "Retry-After": "5",
         },
     )
+
+
+async def probe_workflow_readiness(
+    file_doc: dict[str, Any],
+    artifact_kind: ArtifactKind,
+) -> Optional[bool]:
+    """Report whether a GET would stream a workflow artifact immediately.
+
+    Mirrors the applicability checks in
+    ``serve_workflow_artifact_or_dispatch`` exactly — workflow-subsystem
+    wired → processor lookup → ``needs_processing`` →
+    ``artifact_kinds_produced`` → cache-key derivation — but **never
+    dispatches**: it only reads cache state. This is the side-effect-free
+    counterpart used by the ``/status`` probes.
+
+    Args:
+        file_doc: Source file metadata document.
+        artifact_kind: Which artifact kind to probe for.
+
+    Returns:
+        - ``True`` — the artifact is cached; a GET would stream it now.
+        - ``False`` — the file is workflow-applicable for ``artifact_kind``
+          but the artifact is not cached; a GET would dispatch (202).
+        - ``None`` — the workflow subsystem is unwired, the file isn't
+          workflow-applicable, the processor doesn't produce
+          ``artifact_kind``, or ``file_doc`` is incomplete. The caller
+          decides what "ready" means for its own non-workflow path.
+    """
+    if api.processor_registry is None or api.cache is None or api.executor is None:
+        return None
+
+    processor = api.processor_registry.lookup_for(file_doc)
+    if processor is None or not processor.needs_processing(file_doc):
+        return None
+
+    if artifact_kind not in processor.artifact_kinds_produced(file_doc):
+        return None
+
+    try:
+        # Single cache-key authority: the processor derives the key it
+        # writes under; the probe reads the same key here, exactly as
+        # ``serve_workflow_artifact_or_dispatch`` does.
+        cache_key = processor.cache_key_for(file_doc, artifact_kind)
+    except ValueError as exc:
+        # Mirror the dispatch helper: treat an incomplete file_meta as
+        # "workflow not applicable" so the caller falls through to its own
+        # path rather than 500ing on a stale/hand-edited document.
+        logger.warning(
+            f"Cannot probe workflow readiness — file_meta incomplete: {exc}"
+        )
+        return None
+
+    entry = await api.cache.head(cache_key)
+    return entry is not None

--- a/src/cfdb/api/routers/data.py
+++ b/src/cfdb/api/routers/data.py
@@ -311,6 +311,14 @@ async def stream_file_status(
     (passthrough, or a format with no DATA artifact); ``false`` when the
     file is processable but the artifact is not yet cached (a ``GET``
     would return ``202``).
+
+    ``ready: true`` means *no preprocessing is required*, not that a
+    ``GET`` is guaranteed to return ``200``. Because the probe makes no
+    upstream calls, a subsequent ``GET`` may still fail when it resolves
+    the access URL (``403``/``404``/``501``/``502``/``504`` from the DRS
+    or HTTPS path), and when the workflow subsystem is disabled a
+    ``ready: true`` processable file is served as raw upstream bytes
+    rather than a preprocessed artifact.
     """
     await locks.wait_for_cutover()
 

--- a/src/cfdb/api/routers/data.py
+++ b/src/cfdb/api/routers/data.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Header, HTTPException, Path, Request, status
 from cfdb import api
 from cfdb.api.routers._helpers import enforce_hubmap_access, lookup_file_doc
 from cfdb.api.routers.cache_stream import (
+    probe_workflow_readiness,
     serve_workflow_artifact_or_dispatch,
     stream_upstream_url,
 )
@@ -282,6 +283,85 @@ async def stream_file(
         raise
     except Exception:
         logger.exception("Unexpected error in stream_file")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        )
+
+
+@router.get("/{dcc}/{local_id}/status")
+async def stream_file_status(
+    dcc: str = Path(
+        ..., max_length=_PATH_PARAM_MAX_LEN, pattern=_PATH_PARAM_PATTERN
+    ),
+    local_id: str = Path(
+        ..., max_length=_PATH_PARAM_MAX_LEN, pattern=_PATH_PARAM_PATTERN
+    ),
+):
+    """Report whether a ``GET /data`` would stream immediately.
+
+    A side-effect-free readiness probe: it reuses the same lookup, DCC
+    normalization, and access-control logic as ``stream_file`` and returns
+    the same error codes for files that can't be served, but on success
+    returns ``{"ready": bool}`` instead of streaming and **never
+    dispatches a workflow**.
+
+    ``ready`` reflects the default (preprocessed) path: ``true`` when the
+    processed artifact is already cached or the format is served directly
+    (passthrough, or a format with no DATA artifact); ``false`` when the
+    file is processable but the artifact is not yet cached (a ``GET``
+    would return ``202``).
+    """
+    await locks.wait_for_cutover()
+
+    try:
+        from cfdb.dcc_registry import get_all_dcc_names, normalize_dcc_name
+
+        normalized_dcc = normalize_dcc_name(dcc)
+        valid_dccs = get_all_dcc_names()
+
+        if normalized_dcc not in valid_dccs:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown DCC '{dcc}'. Valid DCCs: {', '.join(valid_dccs)}",
+            )
+
+        if api.db is None:
+            logger.error("Database not initialized")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Database not available",
+            )
+
+        file_doc = await lookup_file_doc(api.db, normalized_dcc, local_id)
+        if not file_doc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            )
+
+        # Mirror ``stream_file``'s ordering: the no-access-method 501 is
+        # checked before the HuBMAP access guard.
+        if not file_doc.get("access_url"):
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                detail="File has no access URL",
+            )
+
+        enforce_hubmap_access(normalized_dcc, file_doc)
+
+        # Workflow cache state — never dispatches. ``None`` means the file
+        # is served directly from upstream (passthrough format, a format
+        # with no DATA artifact, or the subsystem is disabled), all of
+        # which stream immediately → ready.
+        readiness = await probe_workflow_readiness(file_doc, ArtifactKind.DATA)
+        if readiness is None:
+            return {"ready": True}
+        return {"ready": readiness}
+
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unexpected error in stream_file_status")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error",

--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, Header, HTTPException, Path, Request, status
 from cfdb import api
 from cfdb.api.routers._helpers import enforce_hubmap_access, lookup_file_doc
 from cfdb.api.routers.cache_stream import (
+    probe_workflow_readiness,
     serve_workflow_artifact_or_dispatch,
     stream_upstream_url,
 )
@@ -189,20 +190,133 @@ async def stream_index_file(
         )
 
 
-async def _try_serve_fourdn_sidecar(
-    file_doc: dict,
-    normalized_dcc: str,
-    request: Request,
-    range_header: Optional[str],
+@router.get("/{dcc}/{local_id}/status")
+async def stream_index_file_status(
+    dcc: str = Path(
+        ..., max_length=_PATH_PARAM_MAX_LEN, pattern=_PATH_PARAM_PATTERN
+    ),
+    local_id: str = Path(
+        ..., max_length=_PATH_PARAM_MAX_LEN, pattern=_PATH_PARAM_PATTERN
+    ),
 ):
-    """Return a streaming response if the file carries a legacy sidecar.
+    """Report whether a ``GET /index`` would stream immediately.
 
-    Looks first at ``extra.extra_files`` (the path used by pre-materialized
-    documents) and then at ``extra.fourdn.extra_files`` (the DCC-specific
+    A side-effect-free readiness probe: it reuses the same lookup, DCC
+    normalization, and access-control logic as ``stream_index_file`` and
+    returns the same error codes for files that can't be served, but on
+    success returns ``{"ready": bool}`` instead of streaming and **never
+    dispatches a workflow**.
+
+    ``ready`` reflects the default (preprocessed) path:
+    ``true`` when an upstream sidecar exists or the processed index is
+    already cached; ``false`` when the index is processable but not yet
+    cached (a ``GET`` would return ``202``).
+    """
+    await locks.wait_for_cutover()
+
+    try:
+        normalized_dcc = normalize_dcc_name(dcc)
+        valid_dccs = get_all_dcc_names()
+
+        if normalized_dcc not in valid_dccs:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown DCC '{dcc}'. Valid DCCs: {', '.join(valid_dccs)}",
+            )
+
+        if api.db is None:
+            logger.error("Database not initialized")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Database not available",
+            )
+
+        file_doc = await lookup_file_doc(api.db, normalized_dcc, local_id)
+        if not file_doc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            )
+
+        enforce_hubmap_access(normalized_dcc, file_doc)
+
+        # 1. Upstream sidecar present → a GET streams it immediately.
+        #    A malformed sidecar raises 502, mirroring the stream path.
+        if _resolve_fourdn_sidecar(file_doc, normalized_dcc) is not None:
+            return {"ready": True}
+
+        # 2. Workflow cache state — never dispatches.
+        readiness = await probe_workflow_readiness(file_doc, ArtifactKind.INDEX)
+        if readiness is not None:
+            return {"ready": readiness}
+
+        # 3. Terminal cases mirror ``stream_index_file`` exactly: a
+        #    no-index format (the matched processor declares no artifacts)
+        #    has no index in any state of the world (404); a processable
+        #    format with the subsystem disabled is degraded mode (503);
+        #    otherwise no processor produces an index for this format
+        #    (404). Asking the registry's processor keeps the "is this a
+        #    no-index format?" decision out of a hard-coded format set.
+        processor = (
+            api.processor_registry.lookup_for(file_doc)
+            if api.processor_registry is not None
+            else None
+        )
+        if processor is not None and not processor.artifact_kinds_produced(file_doc):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No index file available for this file format",
+            )
+        if api.processor_registry is None or api.cache is None or api.executor is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Workflow subsystem disabled — set SYNC_DATA_DIR and "
+                    "start a wool worker pool to serve preprocessed "
+                    "indexes."
+                ),
+                headers={"Retry-After": "30"},
+            )
+
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No index file available for this file",
+        )
+
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unexpected error in stream_index_file_status")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        )
+
+
+def _resolve_fourdn_sidecar(
+    file_doc: dict, normalized_dcc: str
+) -> Optional[tuple[str, dict]]:
+    """Resolve and validate a 4DN index sidecar, if the file carries one.
+
+    Pure (no I/O): the detection-and-validation half shared by the
+    sidecar streaming path and the ``/status`` probe. Looks first at
+    ``extra.extra_files`` (the path used by pre-materialized documents)
+    and then at ``extra.fourdn.extra_files`` (the DCC-specific
     subdocument). Each entry's ``file_format`` is normalized from either a
     ``{display_title: ...}`` CV object (the shape 4DN materializes) or a
     bare string before matching ``_SIDECAR_INDEX_FORMATS``; an entry whose
     token is unrecognized falls through to the first-entry fallback.
+
+    Returns:
+        ``(download_url, index_entry)`` when a valid sidecar is present,
+        or ``None`` when no sidecar exists or the DCC config is
+        unavailable (caller falls through to the workflow path).
+
+    Raises:
+        HTTPException(502): The sidecar is present but malformed — a
+            non-object entry, a missing ``href``, or a URL that fails the
+            outbound allowlist. Surfaced rather than silently falling
+            through because a workflow artifact (md5-cached) would not
+            match the bytes a client expected from the upstream sidecar.
     """
     extra = file_doc.get("extra") or {}
     extra_files = extra.get("extra_files") or []
@@ -246,10 +360,6 @@ async def _try_serve_fourdn_sidecar(
 
     href = index_entry.get("href")
     if not href:
-        # Sidecar entry is malformed — surface a clear 502 rather than
-        # silently falling through to the workflow path. A workflow
-        # artifact (md5-cached) would not match the bytes a client
-        # expected from the upstream sidecar.
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Upstream sidecar entry is missing required `href` field",
@@ -273,6 +383,27 @@ async def _try_serve_fourdn_sidecar(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Upstream sidecar URL failed allowlist validation",
         )
+
+    return download_url, index_entry
+
+
+async def _try_serve_fourdn_sidecar(
+    file_doc: dict,
+    normalized_dcc: str,
+    request: Request,
+    range_header: Optional[str],
+):
+    """Return a streaming response if the file carries a legacy sidecar.
+
+    Thin wrapper over ``_resolve_fourdn_sidecar`` that adds the
+    streaming/Range/HEAD handling; returns ``None`` when no sidecar is
+    present so the caller falls through to the workflow path.
+    """
+    resolved = _resolve_fourdn_sidecar(file_doc, normalized_dcc)
+    if resolved is None:
+        return None
+    download_url, index_entry = resolved
+    href = index_entry["href"]
 
     filename = href.rsplit("/", 1)[-1] if "/" in href else href
     file_size = index_entry.get("file_size")

--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -211,6 +211,12 @@ async def stream_index_file_status(
     ``true`` when an upstream sidecar exists or the processed index is
     already cached; ``false`` when the index is processable but not yet
     cached (a ``GET`` would return ``202``).
+
+    ``ready: true`` means *no preprocessing is required*, not that a
+    ``GET`` is guaranteed to return ``200``. The probe describes only the
+    default path: it takes no ``raw`` parameter, so for a file whose only
+    index is a cached workflow artifact (no upstream sidecar) it reports
+    ``ready: true`` even though ``GET ...?raw=true`` would ``404``.
     """
     await locks.wait_for_cutover()
 

--- a/tests/integration/test_direct_processors.py
+++ b/tests/integration/test_direct_processors.py
@@ -465,11 +465,18 @@ class TestTabixIntervalProcessorDirectCall:
             if shutil.which(tool) is None:
                 pytest.skip(f"{tool} not on PATH")
 
+        from cfdb.workflows.models import ArtifactKind
+
         # Arrange
         workdir = tmp_path / "work"
         cache_root = tmp_path / "cache"
         workdir.mkdir()
         cache_root.mkdir()
+        # Production hands the processor a real CacheBackend, not a bare
+        # path — drive it the same way so the cache-state assertions below
+        # exercise the genuine commit/head contract.
+        cache = LocalFsCache(cache_root)
+        processor = TabixIntervalProcessor()
 
         empty_vcf = tmp_path / "empty.vcf"
         empty_vcf.write_text(
@@ -495,29 +502,15 @@ class TestTabixIntervalProcessorDirectCall:
 
         # Act & assert
         with pytest.raises(RuntimeError, match="Refusing to commit empty"):
-            async for _ in TabixIntervalProcessor().run(
-                file_meta, workdir, cache_root
-            ):
+            async for _ in processor.run(file_meta, workdir, cache):
                 pass
 
-        # Cache MUST stay empty so a fixed-source retry can run cleanly.
-        cache = LocalFsCache(cache_root)
-        from cfdb.workflows import keys as key_utils
-        from cfdb.workflows.models import ArtifactKind
-
-        data_key = key_utils.cache_key(
-            dcc="encode",
-            local_id="int-vcf-empty",
-            artifact_kind=ArtifactKind.DATA,
-            md5="c4ca4238a0b923820dcc509a6f75849b",
-            processor_version=TabixIntervalProcessor.processor_version,
-        )
-        index_key = key_utils.cache_key(
-            dcc="encode",
-            local_id="int-vcf-empty",
-            artifact_kind=ArtifactKind.INDEX,
-            md5="c4ca4238a0b923820dcc509a6f75849b",
-            processor_version=TabixIntervalProcessor.processor_version,
-        )
+        # The rejection MUST leave the cache pristine so a later retry
+        # against a fixed source can populate it cleanly. Resolve the keys
+        # through the processor's own ``cache_key_for`` — the single
+        # cache-key authority production consumers use — rather than
+        # re-deriving the formula here.
+        data_key = processor.cache_key_for(file_meta, ArtifactKind.DATA)
+        index_key = processor.cache_key_for(file_meta, ArtifactKind.INDEX)
         assert await cache.head(data_key) is None
         assert await cache.head(index_key) is None

--- a/tests/integration/test_router_e2e.py
+++ b/tests/integration/test_router_e2e.py
@@ -630,10 +630,10 @@ class TestRouterE2E:
         async def fake_stream(*_args, **_kwargs):
             yield sidecar_bytes
 
-        # Patch on the module where the index router imported it from.
-        from cfdb.api.routers import index as index_module
-
-        mocker.patch.object(index_module.drs, "stream_from_url", fake_stream)
+        # The sidecar path now streams via ``cache_stream.stream_upstream_url``,
+        # which calls ``drs.stream_from_url`` on the shared ``cfdb.services.drs``
+        # module — patch it there.
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
 
         # Act
         resp = await stream_index_file(

--- a/tests/test_cache_stream.py
+++ b/tests/test_cache_stream.py
@@ -12,6 +12,7 @@ from starlette.responses import StreamingResponse
 
 from cfdb import api
 from cfdb.api.routers.cache_stream import (
+    probe_workflow_readiness,
     serve_workflow_artifact_or_dispatch,
     stream_cache_entry,
 )
@@ -569,3 +570,189 @@ class TestServeWorkflowArtifactOrDispatch:
         assert resp.status_code == 202
         assert resp.headers["location"] == f"/jobs/{record.job_id}"
         assert resp.headers["retry-after"] == "5"
+
+
+class TestProbeWorkflowReadiness:
+    @pytest.mark.asyncio
+    async def test_probe_workflow_readiness_should_return_none_when_subsystem_unwired(
+        self, mocker
+    ):
+        """Test that the probe bails when subsystem fields are None.
+
+        Given:
+            ``api.processor_registry``, ``api.cache``, and ``api.executor``
+            are all None.
+        When:
+            ``probe_workflow_readiness`` is awaited.
+        Then:
+            It should return None so the caller decides readiness for its
+            own non-workflow path.
+        """
+        # Arrange
+        mocker.patch.object(api, "processor_registry", None)
+        mocker.patch.object(api, "cache", None)
+        mocker.patch.object(api, "executor", None)
+
+        # Act
+        result = await probe_workflow_readiness(_file_doc(), ArtifactKind.DATA)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_probe_workflow_readiness_should_return_none_when_processor_does_not_need_processing(
+        self, mocker, tmp_path
+    ):
+        """Test that a no-work processor yields None.
+
+        Given:
+            Subsystem wired; registry returns a processor whose
+            ``needs_processing`` is False (a passthrough format).
+        When:
+            The probe is awaited.
+        Then:
+            It should return None.
+        """
+        # Arrange
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor(needs=False))
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "cache", LocalFsCache(tmp_path / "cache"))
+        mocker.patch.object(api, "executor", _RecordingExecutor())
+
+        # Act
+        result = await probe_workflow_readiness(_file_doc(), ArtifactKind.DATA)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_probe_workflow_readiness_should_return_none_when_artifact_kind_not_produced(
+        self, mocker, tmp_path
+    ):
+        """Test that an unproduced artifact kind yields None.
+
+        Given:
+            A processor whose ``artifact_kinds_produced`` returns
+            ``(INDEX,)`` only, probed with ``artifact_kind=DATA``.
+        When:
+            The probe is awaited.
+        Then:
+            It should return None.
+        """
+        # Arrange
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor(produced=(ArtifactKind.INDEX,)))
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "cache", LocalFsCache(tmp_path / "cache"))
+        mocker.patch.object(api, "executor", _RecordingExecutor())
+
+        # Act
+        result = await probe_workflow_readiness(_file_doc(), ArtifactKind.DATA)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_probe_workflow_readiness_should_return_none_when_extract_identity_raises(
+        self, mocker, tmp_path
+    ):
+        """Test that an incomplete file_doc yields None.
+
+        Given:
+            A processor that applies and a file_doc missing ``md5`` so
+            ``extract_identity`` raises ``ValueError``.
+        When:
+            The probe is awaited.
+        Then:
+            It should return None — the missing-field error is treated as
+            "workflow not applicable".
+        """
+        # Arrange
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor())
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "cache", LocalFsCache(tmp_path / "cache"))
+        mocker.patch.object(api, "executor", _RecordingExecutor())
+        broken = _file_doc()
+        del broken["md5"]
+
+        # Act
+        result = await probe_workflow_readiness(broken, ArtifactKind.DATA)
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_probe_workflow_readiness_should_return_true_on_cache_hit(
+        self, mocker, tmp_path
+    ):
+        """Test that a cached artifact reports ready without dispatching.
+
+        Given:
+            The cache pre-populated with the derived key and an executor
+            that fails if dispatched.
+        When:
+            The probe is awaited.
+        Then:
+            It should return True and ``ensure_workflow`` MUST NOT be
+            called.
+        """
+        # Arrange
+        from cfdb.workflows import keys as key_utils
+
+        processor = _StubProcessor()
+        registry = ProcessorRegistry()
+        registry.register(processor)
+        cache = LocalFsCache(tmp_path / "cache")
+        src = tmp_path / "src"
+        src.write_bytes(b"cached-data")
+        key = key_utils.cache_key(
+            dcc="encode",
+            local_id="ENCFF123",
+            artifact_kind=ArtifactKind.DATA,
+            md5=FIXTURE_MD5,
+            processor_version=processor.processor_version,
+        )
+        await cache.put(key, src)
+        executor = _RecordingExecutor()
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "cache", cache)
+        mocker.patch.object(api, "executor", executor)
+
+        # Act
+        result = await probe_workflow_readiness(_file_doc(), ArtifactKind.DATA)
+
+        # Assert
+        assert result is True
+        assert executor.calls == []
+
+    @pytest.mark.asyncio
+    async def test_probe_workflow_readiness_should_return_false_on_cache_miss(
+        self, mocker, tmp_path
+    ):
+        """Test that a workflow-applicable cache miss reports not-ready.
+
+        Given:
+            A processor that applies, an empty cache, and an executor that
+            fails if dispatched.
+        When:
+            The probe is awaited.
+        Then:
+            It should return False (a GET would dispatch) and
+            ``ensure_workflow`` MUST NOT be called.
+        """
+        # Arrange
+        registry = ProcessorRegistry()
+        registry.register(_StubProcessor())
+        executor = _RecordingExecutor()
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "cache", LocalFsCache(tmp_path / "cache"))
+        mocker.patch.object(api, "executor", executor)
+
+        # Act
+        result = await probe_workflow_readiness(_file_doc(), ArtifactKind.DATA)
+
+        # Assert
+        assert result is False
+        assert executor.calls == []

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from wool.runtime.routine.task import do_dispatch
 
 from cfdb import api
-from cfdb.api.routers.data import stream_file
+from cfdb.api.routers.data import stream_file, stream_file_status
 from cfdb.services import drs, locks
 from cfdb.workflows.executor import WoolExecutor
 from cfdb.workflows.models import ACTIVE_STATUSES
@@ -591,3 +591,362 @@ class TestStreamFileWorkflowPath:
             "passthrough must reach the direct DRS streaming path, "
             "not the workflow dispatch path"
         )
+
+
+class TestStreamFileStatus:
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_raise_400_when_dcc_invalid(
+        self, mock_db, mocker
+    ):
+        """Test that an unknown DCC is rejected the same as /data.
+
+        Given:
+            A status probe for a DCC name not in the registry.
+        When:
+            stream_file_status is called.
+        Then:
+            It should raise HTTPException(400).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_file_status("nope", "file-1")
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_raise_404_when_file_missing(
+        self, mock_db, mocker
+    ):
+        """Test that a missing file mirrors /data's 404.
+
+        Given:
+            A valid DCC but no matching file document.
+        When:
+            stream_file_status is called.
+        Then:
+            It should raise HTTPException(404).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mock_db.files.docs = []
+        mock_db.file.docs = []
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_file_status("4dn", "missing")
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_raise_403_when_hubmap_not_public(
+        self, mock_db, mocker
+    ):
+        """Test that a protected HuBMAP file mirrors /data's 403.
+
+        Given:
+            A HuBMAP file with ``data_access_level="consortium"`` and an
+            access_url.
+        When:
+            stream_file_status is called.
+        Then:
+            It should raise HTTPException(403).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mock_db.dcc.docs = [_make_dcc_doc()]
+        mock_db.file.docs = [_make_file_doc(access_level="consortium")]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_file_status("hubmap", "file-1")
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_raise_501_when_no_access_url(
+        self, mock_db, mocker
+    ):
+        """Test that a file with no access method mirrors /data's 501.
+
+        Given:
+            A 4DN file document with no ``access_url``.
+        When:
+            stream_file_status is called.
+        Then:
+            It should raise HTTPException(501).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            {
+                "submission": "4dn",
+                "id_namespace": "tag:4dn.org,2015:",
+                "local_id": "4DNFINOURL",
+                "filename": "x.csv",
+                "file_format": {"name": "CSV"},
+            }
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_file_status("4dn", "4DNFINOURL")
+        assert exc_info.value.status_code == 501
+
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_report_ready_on_cache_hit_for_sam(
+        self, mock_db, mocker, tmp_path
+    ):
+        """Test that a cached DATA artifact reports ready without dispatch.
+
+        Given:
+            A SAM file with the DATA cache pre-populated and a wired
+            workflow subsystem whose executor fails if dispatched.
+        When:
+            stream_file_status is called.
+        Then:
+            It should return ``{"ready": True}`` and ``ensure_workflow``
+            MUST NOT be called.
+        """
+        # Arrange
+        from cfdb.workflows import keys as key_utils
+        from cfdb.workflows.cache import LocalFsCache
+        from cfdb.workflows.models import ArtifactKind
+
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        cache = LocalFsCache(tmp_path / "cache")
+        src = tmp_path / "src"
+        src.write_bytes(b"sam-cached-bytes")
+        processor = BamIndexProcessor()
+        data_key = key_utils.cache_key(
+            dcc="4dn_dcic",
+            local_id="4DNFISAM01",
+            artifact_kind=ArtifactKind.DATA,
+            md5=FIXTURE_MD5,
+            processor_version=processor.processor_version,
+        )
+        await cache.put(data_key, src)
+
+        class _FailIfDispatched:
+            async def ensure_workflow(self, _file_doc):
+                raise AssertionError("status probe must NOT dispatch a workflow")
+
+        registry = ProcessorRegistry()
+        registry.register(processor)
+        mocker.patch.object(api, "cache", cache)
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "executor", _FailIfDispatched())
+
+        mock_db.dcc.docs = [
+            {
+                "dcc_abbreviation": "4DN_DCIC",
+                "project_id_namespace": "tag:4dn.org,2015:",
+            }
+        ]
+        mock_db.file.docs = [
+            {
+                "submission": "4dn",
+                "id_namespace": "tag:4dn.org,2015:",
+                "local_id": "4DNFISAM01",
+                "filename": "x.sam",
+                "md5": FIXTURE_MD5,
+                "access_url": "https://example.com/x.sam",
+                "dcc": {"dcc_abbreviation": "4DN_DCIC"},
+                "file_format": {"name": "SAM"},
+            }
+        ]
+
+        # Act
+        result = await stream_file_status("4dn", "4DNFISAM01")
+
+        # Assert
+        assert result == {"ready": True}
+
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_report_not_ready_on_cache_miss_for_sam(
+        self, mock_db, mocker
+    ):
+        """Test that a processable-but-uncached file reports not-ready.
+
+        Given:
+            A SAM file with an empty cache, a registered BAM/SAM
+            processor, and an executor that fails if dispatched.
+        When:
+            stream_file_status is called.
+        Then:
+            It should return ``{"ready": False}`` and ``ensure_workflow``
+            MUST NOT be called — the probe never dispatches.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        class _MissCache:
+            async def head(self, _k):
+                return None
+
+            def get(self, _k, _r=None):
+                raise AssertionError
+
+            async def put(self, *_a, **_kw):
+                raise AssertionError
+
+            async def delete(self, _k):
+                return False
+
+        class _FailIfDispatched:
+            async def ensure_workflow(self, _file_doc):
+                raise AssertionError("status probe must NOT dispatch a workflow")
+
+        registry = ProcessorRegistry()
+        registry.register(BamIndexProcessor())
+        mocker.patch.object(api, "cache", _MissCache())
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "executor", _FailIfDispatched())
+
+        mock_db.dcc.docs = [
+            {
+                "dcc_abbreviation": "4DN_DCIC",
+                "project_id_namespace": "tag:4dn.org,2015:",
+            }
+        ]
+        mock_db.file.docs = [
+            {
+                "submission": "4dn",
+                "id_namespace": "tag:4dn.org,2015:",
+                "local_id": "4DNFISAM01",
+                "filename": "x.sam",
+                "md5": FIXTURE_MD5,
+                "access_url": "https://example.com/x.sam",
+                "dcc": {"dcc_abbreviation": "4DN_DCIC"},
+                "file_format": {"name": "SAM"},
+            }
+        ]
+
+        # Act
+        result = await stream_file_status("4dn", "4DNFISAM01")
+
+        # Assert
+        assert result == {"ready": False}
+
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_report_ready_for_passthrough_format(
+        self, mock_db, mocker
+    ):
+        """Test that a passthrough format reports ready immediately.
+
+        Given:
+            A CSV file (a PassthroughProcessor format) with a wired
+            workflow subsystem whose cache and executor fail if consulted.
+        When:
+            stream_file_status is called.
+        Then:
+            It should return ``{"ready": True}`` — passthrough files
+            stream directly, so the probe never consults the cache.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mocker.patch.object(api, "processor_registry", default_registry())
+
+        class _FailIfConsulted:
+            async def head(self, _k):
+                raise AssertionError("passthrough must not consult cache")
+
+            def get(self, *_a, **_kw):
+                raise AssertionError
+
+            async def put(self, *_a, **_kw):
+                raise AssertionError
+
+            async def delete(self, _k):
+                return False
+
+        mocker.patch.object(api, "cache", _FailIfConsulted())
+        mocker.patch.object(api, "executor", object())
+
+        mock_db.dcc.docs = [
+            {
+                "dcc_abbreviation": "4DN_DCIC",
+                "project_id_namespace": "tag:4dn.org,2015:",
+            }
+        ]
+        mock_db.file.docs = [
+            {
+                "submission": "4dn",
+                "id_namespace": "tag:4dn.org,2015:",
+                "local_id": "4DNFICSV01",
+                "filename": "x.csv",
+                "md5": FIXTURE_MD5,
+                "access_url": "drs://4dn/abc",
+                "file_format": {"name": "CSV"},
+            }
+        ]
+
+        # Act
+        result = await stream_file_status("4dn", "4DNFICSV01")
+
+        # Assert
+        assert result == {"ready": True}
+
+    @pytest.mark.asyncio
+    async def test_stream_file_status_should_report_ready_for_bam_without_data_artifact(
+        self, mock_db, mocker
+    ):
+        """Test that a BAM (no DATA artifact) reports ready for /data.
+
+        Given:
+            A 4DN BAM file with a registered ``BamIndexProcessor``. BAM
+            advertises only an INDEX artifact (the source is already
+            coordinate-sorted upstream), so /data falls through to direct
+            streaming.
+        When:
+            stream_file_status is called.
+        Then:
+            It should return ``{"ready": True}`` without consulting the
+            cache — the DATA path is a direct upstream stream.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        class _FailIfConsulted:
+            async def head(self, _k):
+                raise AssertionError("BAM /data must not consult the cache")
+
+            def get(self, *_a, **_k):
+                raise AssertionError
+
+            async def put(self, *_a, **_k):
+                raise AssertionError
+
+            async def delete(self, _k):
+                return False
+
+        registry = ProcessorRegistry()
+        registry.register(BamIndexProcessor())
+        mocker.patch.object(api, "cache", _FailIfConsulted())
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "executor", object())
+
+        mock_db.dcc.docs = [
+            {
+                "dcc_abbreviation": "4DN_DCIC",
+                "project_id_namespace": "tag:4dn.org,2015:",
+            }
+        ]
+        mock_db.file.docs = [
+            {
+                "submission": "4dn",
+                "id_namespace": "tag:4dn.org,2015:",
+                "local_id": "4DNFIBAM01",
+                "filename": "x.bam",
+                "md5": FIXTURE_MD5,
+                "access_url": "drs://4dn/abc",
+                "dcc": {"dcc_abbreviation": "4DN_DCIC"},
+                "file_format": {"name": "BAM"},
+            }
+        ]
+
+        # Act
+        result = await stream_file_status("4dn", "4DNFIBAM01")
+
+        # Assert
+        assert result == {"ready": True}

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from wool.runtime.routine.task import do_dispatch
 
 from cfdb import api
-from cfdb.api.routers.index import stream_index_file
+from cfdb.api.routers.index import stream_index_file, stream_index_file_status
 from cfdb.services import drs, locks
 from cfdb.workflows.executor import WoolExecutor
 from cfdb.workflows.models import ACTIVE_STATUSES, ArtifactKind
@@ -1103,3 +1103,298 @@ class TestStreamIndexFileWorkflowPaths:
         assert isinstance(resp, JSONResponse)
         assert resp.status_code == 202
         assert resp.headers["location"].startswith("/jobs/")
+
+
+class TestStreamIndexFileStatus:
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_raise_400_when_dcc_invalid(
+        self, mock_db, mocker
+    ):
+        """Test that an unknown DCC is rejected the same as /index.
+
+        Given:
+            A status probe for a DCC name not in the registry.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should raise HTTPException(400).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file_status("nope", "file-1")
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_raise_404_when_file_missing(
+        self, mock_db, mocker
+    ):
+        """Test that a missing file mirrors /index's 404.
+
+        Given:
+            A valid DCC but no matching file document.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should raise HTTPException(404).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mock_db.files.docs = []
+        mock_db.file.docs = []
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file_status("4dn", "missing")
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_report_ready_when_sidecar_present(
+        self, mock_db, mocker
+    ):
+        """Test that an upstream sidecar reports ready immediately.
+
+        Given:
+            A 4DN BED with an ``extra.extra_files`` sidecar entry.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should return ``{"ready": True}`` without opening any
+            upstream stream.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        stream_calls: list = []
+
+        async def fake_stream(url, _range):
+            stream_calls.append(url)
+            yield b"should-not-stream"
+
+        mocker.patch.object(drs, "stream_from_url", fake_stream)
+
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(
+                extra={"extra_files": [{"href": "/x/abc.tbi", "file_size": 100}]}
+            )
+        ]
+
+        # Act
+        result = await stream_index_file_status("4dn", "4DNFIBED01")
+
+        # Assert
+        assert result == {"ready": True}
+        assert stream_calls == []
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_502_when_sidecar_href_missing(
+        self, mock_db, mocker
+    ):
+        """Test that a malformed sidecar mirrors /index's 502.
+
+        Given:
+            A 4DN sidecar entry with no ``href`` key.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should raise HTTPException(502).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            _make_file_doc(extra={"extra_files": [{"file_format": "tbi"}]})
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file_status("4dn", "4DNFIBED01")
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_report_ready_on_cache_hit(
+        self, mock_db, mocker, tmp_path
+    ):
+        """Test that a cached INDEX artifact reports ready without dispatch.
+
+        Given:
+            A BAM file with no sidecar, a registered ``BamIndexProcessor``,
+            and the INDEX cache pre-populated with the BAI bytes.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should return ``{"ready": True}`` and ``ensure_workflow``
+            MUST NOT be called.
+        """
+        # Arrange
+        from cfdb.workflows import keys as key_utils
+        from cfdb.workflows.cache import LocalFsCache
+
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        cache = LocalFsCache(tmp_path / "cache")
+        src = tmp_path / "src"
+        src.write_bytes(b"bai-cached")
+        processor = BamIndexProcessor()
+        index_key = key_utils.cache_key(
+            dcc="4dn_dcic",
+            local_id="4DNFIBAM01",
+            artifact_kind=ArtifactKind.INDEX,
+            md5=FIXTURE_MD5,
+            processor_version=processor.processor_version,
+        )
+        await cache.put(index_key, src)
+
+        class _FailIfDispatched:
+            async def ensure_workflow(self, _file_doc):
+                raise AssertionError("status probe must NOT dispatch a workflow")
+
+        registry = ProcessorRegistry()
+        registry.register(processor)
+        mocker.patch.object(api, "cache", cache)
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "executor", _FailIfDispatched())
+
+        bam_doc = _make_file_doc(
+            file_format={"name": "BAM"},
+            filename="x.bam",
+            local_id="4DNFIBAM01",
+        )
+        bam_doc.pop("extra", None)
+        mock_db.files.docs = []
+        mock_db.file.docs = [bam_doc]
+
+        # Act
+        result = await stream_index_file_status("4dn", "4DNFIBAM01")
+
+        # Assert
+        assert result == {"ready": True}
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_report_not_ready_on_cache_miss(
+        self, mock_db, mocker
+    ):
+        """Test that a processable-but-uncached index reports not-ready.
+
+        Given:
+            A BAM file with no sidecar, a registered processor emitting an
+            INDEX artifact, an empty cache, and an executor that fails if
+            dispatched.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should return ``{"ready": False}`` and ``ensure_workflow``
+            MUST NOT be called — the probe never dispatches.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+        class _MissCache:
+            async def head(self, _k):
+                return None
+
+            def get(self, _k, _r=None):
+                raise AssertionError
+
+            async def put(self, *_a, **_kw):
+                raise AssertionError
+
+            async def delete(self, _k):
+                return False
+
+        class _FailIfDispatched:
+            async def ensure_workflow(self, _file_doc):
+                raise AssertionError("status probe must NOT dispatch a workflow")
+
+        registry = ProcessorRegistry()
+        registry.register(BamIndexProcessor())
+        mocker.patch.object(api, "cache", _MissCache())
+        mocker.patch.object(api, "processor_registry", registry)
+        mocker.patch.object(api, "executor", _FailIfDispatched())
+
+        bam_doc = _make_file_doc(
+            file_format={"name": "BAM"},
+            filename="x.bam",
+            local_id="4DNFIBAM01",
+        )
+        bam_doc.pop("extra", None)
+        mock_db.files.docs = []
+        mock_db.file.docs = [bam_doc]
+
+        # Act
+        result = await stream_index_file_status("4dn", "4DNFIBAM01")
+
+        # Assert
+        assert result == {"ready": False}
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_raise_404_for_passthrough_format(
+        self, mock_db, mocker, tmp_path
+    ):
+        """Test that a passthrough format mirrors /index's no-index 404.
+
+        Given:
+            A CSV file with no sidecar and the workflow subsystem wired
+            with an empty registry.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should raise HTTPException(404) — CSV has no index in any
+            state of the world.
+        """
+        # Arrange
+        from cfdb.workflows.cache import LocalFsCache
+
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        doc = _make_file_doc(file_format={"name": "CSV"})
+        doc.pop("extra", None)
+        mock_db.files.docs = []
+        mock_db.file.docs = [doc]
+        mocker.patch.object(api, "cache", LocalFsCache(tmp_path / "cache"))
+        mocker.patch.object(api, "processor_registry", ProcessorRegistry())
+        mocker.patch.object(
+            api,
+            "executor",
+            WoolExecutor(
+                mock_db,
+                api.cache,
+                api.processor_registry,
+                workdir_root=tmp_path / "jobs",
+            ),
+        )
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file_status("4dn", "4DNFIBED01")
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_raise_503_when_subsystem_disabled(
+        self, mock_db, mocker
+    ):
+        """Test that a processable format with the subsystem off mirrors 503.
+
+        Given:
+            A BAM file with no sidecar and the workflow subsystem unwired
+            (``api.executor is None``).
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should raise HTTPException(503).
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mocker.patch.object(api, "executor", None)
+        mocker.patch.object(api, "cache", None)
+        mocker.patch.object(api, "processor_registry", None)
+        doc = _make_file_doc(file_format={"name": "BAM"})
+        doc.pop("extra", None)
+        mock_db.files.docs = []
+        mock_db.file.docs = [doc]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file_status("4dn", "4DNFIBED01")
+        assert exc_info.value.status_code == 503

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -13,7 +13,7 @@ from cfdb.services import drs, locks
 from cfdb.workflows.executor import WoolExecutor
 from cfdb.workflows.models import ACTIVE_STATUSES, ArtifactKind
 from cfdb.workflows.processors.bam import BamIndexProcessor
-from cfdb.workflows.processors.registry import ProcessorRegistry
+from cfdb.workflows.processors.registry import ProcessorRegistry, default_registry
 from tests.test_workflows import FIXTURE_MD5
 
 
@@ -1151,6 +1151,39 @@ class TestStreamIndexFileStatus:
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_stream_index_file_status_should_raise_403_when_hubmap_not_public(
+        self, mock_db, mocker
+    ):
+        """Test that a protected HuBMAP file mirrors /index's 403.
+
+        Given:
+            A HuBMAP file with ``data_access_level="consortium"``.
+        When:
+            stream_index_file_status is called.
+        Then:
+            It should raise HTTPException(403) before any sidecar or
+            workflow lookup.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mock_db.files.docs = []
+        mock_db.file.docs = [
+            {
+                "submission": "hubmap",
+                "id_namespace": "tag:hubmapconsortium.org,2023:",
+                "local_id": "HBM-1",
+                "filename": "x.bed",
+                "data_access_level": "consortium",
+                "file_format": {"name": "BED"},
+            }
+        ]
+
+        # Act & assert
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_index_file_status("hubmap", "HBM-1")
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
     async def test_stream_index_file_status_should_report_ready_when_sidecar_present(
         self, mock_db, mocker
     ):
@@ -1336,8 +1369,8 @@ class TestStreamIndexFileStatus:
         """Test that a passthrough format mirrors /index's no-index 404.
 
         Given:
-            A CSV file with no sidecar and the workflow subsystem wired
-            with an empty registry.
+            A CSV file with no sidecar and the default registry wired, so
+            the matched PassthroughProcessor declares no index artifact.
         When:
             stream_index_file_status is called.
         Then:
@@ -1352,8 +1385,12 @@ class TestStreamIndexFileStatus:
         doc.pop("extra", None)
         mock_db.files.docs = []
         mock_db.file.docs = [doc]
+        # Wire the DEFAULT registry (which includes PassthroughProcessor)
+        # so CSV resolves to a processor that produces no artifacts —
+        # exercising the no-index-format branch rather than the generic
+        # "no processor matched" fall-through.
         mocker.patch.object(api, "cache", LocalFsCache(tmp_path / "cache"))
-        mocker.patch.object(api, "processor_registry", ProcessorRegistry())
+        mocker.patch.object(api, "processor_registry", default_registry())
         mocker.patch.object(
             api,
             "executor",


### PR DESCRIPTION
## Summary

Add two side-effect-free readiness probes — `GET /data/{dcc}/{local_id}/status` and `GET /index/{dcc}/{local_id}/status` — that report whether a streaming `GET` would return bytes immediately or first require preprocessing, without ever dispatching a workflow.

Each probe reuses the same cutover wait, DCC normalization, file lookup, and access-control logic as its streaming sibling and mirrors its error codes (400 bad DCC/param, 403 protected/consortium, 404 not found / format-has-no-index, 501 no access method on `/data`, 502 malformed sidecar on `/index`, 503 subsystem disabled on `/index`). On success it returns `{"ready": bool}` instead of streaming. `ready` reflects the default preprocessed path: `true` when the processed artifact is already cached, the format is served directly (passthrough or a format with no DATA artifact), or an upstream sidecar exists; `false` when the file is processable but the artifact is not yet cached, i.e. a `GET` would return `202`.

The probes deliberately make no upstream network calls — they read only Mongo and cache metadata — so they are cheap control-plane queries. `ready: true` means no preprocessing is required, not that a `GET` is guaranteed to return `200` (a later `GET` may still fail resolving the access URL, and a subsystem-disabled processable file is served raw); the handler docstrings and README document this caveat. This lets a client (e.g. Gosling Designer) warn the user that a dataset will require processing before committing to a fetch, which neither `GET` (dispatches work on cache miss) nor `HEAD` (ambiguous 404 on cache miss) can express today.

Closes #39

## Proposed changes

- **Shared probe helper** (`cache_stream.py`) — add `probe_workflow_readiness(file_doc, artifact_kind)`, the non-dispatching counterpart of `serve_workflow_artifact_or_dispatch`. It runs the identical applicability chain (subsystem wired → processor lookup → `needs_processing` → `artifact_kinds_produced` → `cache_key_for`) and returns `True` (cached), `False` (applicable but cache miss), or `None` (not workflow-applicable — caller decides). It resolves the cache key through the processor's `cache_key_for` single authority rather than re-deriving the formula.
- **`/data` probe** (`data.py`) — add `stream_file_status`, mirroring `stream_file`'s deterministic prefix (400/404/501/403). A `None` readiness means the file streams directly from upstream → `ready: true`.
- **`/index` probe** (`index.py`) — add `stream_index_file_status`, mirroring `stream_index_file`'s sidecar-first ordering and terminal logic (no-index format → 404, subsystem disabled → 503). Extract the 4DN sidecar detection-and-validation into a pure `_resolve_fourdn_sidecar` helper so the probe can reuse it and surface the same 502 for malformed sidecars; `_try_serve_fourdn_sidecar` becomes a thin streaming wrapper over it.
- **Documentation** (`README.md`, handler docstrings) — add a REST API "Readiness Probes" section (URLs, path params, `{"ready": bool}` contract, mirrored status-code table, never-dispatches guarantee) and clarify in both docstrings that `ready: true` means "no preprocessing required", not "GET guaranteed 200".
- **Stale-test repairs** (`test_router_e2e.py`, `test_direct_processors.py`) — fix two tests left red by master's pipeline-hardening refactor: patch `drs.stream_from_url` on `cfdb.services.drs` (the index router no longer imports `drs`), and pass a real `LocalFsCache` to `TabixIntervalProcessor.run` (now takes a `CacheBackend`, not a path), resolving keys via `cache_key_for`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestProbeWorkflowReadiness` | The workflow subsystem is unwired | The probe is awaited | Returns `None` | Fall-through signal |
| 2 | `TestProbeWorkflowReadiness` | A processor with no work or no matching artifact kind | The probe is awaited | Returns `None` | Non-applicable cases |
| 3 | `TestProbeWorkflowReadiness` | A file doc missing `md5` | The probe is awaited | Returns `None` | Incomplete-doc tolerance |
| 4 | `TestProbeWorkflowReadiness` | A cached artifact and a no-dispatch executor | The probe is awaited | Returns `True`, no dispatch | Cache-hit readiness |
| 5 | `TestProbeWorkflowReadiness` | An empty cache and a no-dispatch executor | The probe is awaited | Returns `False`, no dispatch | Cache-miss readiness |
| 6 | `TestStreamFileStatus` | An unknown DCC, missing file, protected HuBMAP, or no access_url | `stream_file_status` is called | Raises 400 / 404 / 403 / 501 | `/data` error mirrors |
| 7 | `TestStreamFileStatus` | A SAM with the DATA artifact cached | `stream_file_status` is called | Returns `{"ready": true}`, no dispatch | `/data` cached path |
| 8 | `TestStreamFileStatus` | A SAM with an empty cache | `stream_file_status` is called | Returns `{"ready": false}`, no dispatch | `/data` uncached path |
| 9 | `TestStreamFileStatus` | A passthrough CSV or a BAM with no DATA artifact | `stream_file_status` is called | Returns `{"ready": true}`, cache untouched | `/data` direct-stream path |
| 10 | `TestStreamIndexFileStatus` | An unknown DCC, missing file, or protected HuBMAP | `stream_index_file_status` is called | Raises 400 / 404 / 403 | `/index` error mirrors |
| 11 | `TestStreamIndexFileStatus` | A 4DN file with an upstream sidecar | `stream_index_file_status` is called | Returns `{"ready": true}`, no upstream stream | Sidecar readiness |
| 12 | `TestStreamIndexFileStatus` | A sidecar entry missing `href` | `stream_index_file_status` is called | Raises 502 | Malformed-sidecar mirror |
| 13 | `TestStreamIndexFileStatus` | A BAM with the INDEX artifact cached or absent | `stream_index_file_status` is called | Returns `{"ready": true/false}`, no dispatch | `/index` cache states |
| 14 | `TestStreamIndexFileStatus` | A passthrough CSV via the default registry, or a BAM with the subsystem disabled | `stream_index_file_status` is called | Raises 404 (no-index-format branch) / 503 | `/index` terminal mirrors |
| 15 | `TestTabixIntervalProcessorDirectCall` | A header-only VCF and a real `LocalFsCache` | `run` is awaited | Raises "Refusing to commit empty" and leaves the cache pristine | Empty-artifact guard repair |
| 16 | `TestRouterE2E` | A 4DN file with a sidecar and `drs.stream_from_url` patched | `stream_index_file` is called | Streams the sidecar bytes over the workflow path | Sidecar-precedence repair |