### PR TITLE
Add CloudFormation for the wool worker fleet and S3 artifact cache — Closes #40

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Keep the Docker build context (COPY . /app in Dockerfile.api and
+# Dockerfile.wool) free of VCS history, virtualenvs, build/test caches,
+# and large local data files so images stay small and don't leak history.
+
+# Version control
+.git
+.github
+.gitignore
+
+# Python virtualenv and caches
+.venv
+**/__pycache__
+*.py[cod]
+.pytest_cache
+.ruff_cache
+.mypy_cache
+.hypothesis
+
+# Rust materializer build artifacts
+materialize/target
+
+# Local data, scratch, and tooling
+.data
+.sandbox
+.understand-anything
+.claude
+build
+.encode_metadata.tsv
+
+# Tests are not needed in the runtime image
+tests
+
+# Editor / OS cruft
+.DS_Store
+*.swp

--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -38,6 +38,24 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:latest
           docker push $REGISTRY/$REPOSITORY:$SHA_TAG
 
+      # Build the wool worker image (Dockerfile.wool) and push to a
+      # separate ECR repository. Pinned to linux/amd64 because the image
+      # bundles UCSC's x86_64-only bigBedToBed. Workers are launched on
+      # demand via RunTask against the task definition's :latest image, so
+      # no service update is needed here. The cfdb-wool repository must
+      # exist in ECR (created out of band, like the cfdb repository).
+      - name: Build and push wool worker to ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: cfdb-wool
+        run: |
+          SHA_TAG=${GITHUB_SHA::8}
+          docker build --platform linux/amd64 --file Dockerfile.wool \
+            -t $REGISTRY/$REPOSITORY:latest \
+            -t $REGISTRY/$REPOSITORY:$SHA_TAG .
+          docker push $REGISTRY/$REPOSITORY:latest
+          docker push $REGISTRY/$REPOSITORY:$SHA_TAG
+
       - name: Deploy to ECS
         env:
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}

--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -33,26 +33,53 @@ jobs:
         run: |
           SHA_TAG=${GITHUB_SHA::8}
           docker build --file Dockerfile.api \
+            --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+$SHA_TAG \
             -t $REGISTRY/$REPOSITORY:latest \
             -t $REGISTRY/$REPOSITORY:$SHA_TAG .
           docker push $REGISTRY/$REPOSITORY:latest
           docker push $REGISTRY/$REPOSITORY:$SHA_TAG
 
-      # Build the wool worker image (Dockerfile.wool) and push to a
-      # separate ECR repository. Pinned to linux/amd64 because the image
-      # bundles UCSC's x86_64-only bigBedToBed. Workers are launched on
-      # demand via RunTask against the task definition's :latest image, so
-      # no service update is needed here. The cfdb-wool repository must
+      # Build the wool worker image (Dockerfile.wool), scan it, then push to
+      # a separate ECR repository. Pinned to linux/amd64 because the image
+      # bundles UCSC's x86_64-only bigBedToBed. The cfdb-wool repository must
       # exist in ECR (created out of band, like the cfdb repository).
-      - name: Build and push wool worker to ECR
+      #
+      # This publishes the image only — it does NOT roll the worker fleet.
+      # The worker task definition pins `Image: !Ref WorkerImageURI`, so
+      # rolling workers is a deliberate `aws cloudformation deploy` of the
+      # workers stack with WorkerImageURI set to the :$SHA_TAG URI pushed
+      # here (see README "Deploying the CloudFormation stacks"). :latest is
+      # pushed only as a convenience pointer.
+      - name: Build wool worker image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: cfdb-wool
         run: |
           SHA_TAG=${GITHUB_SHA::8}
+          echo "WOOL_IMAGE=$REGISTRY/$REPOSITORY:$SHA_TAG" >> "$GITHUB_ENV"
           docker build --platform linux/amd64 --file Dockerfile.wool \
+            --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+$SHA_TAG \
             -t $REGISTRY/$REPOSITORY:latest \
             -t $REGISTRY/$REPOSITORY:$SHA_TAG .
+
+      # Fail the build on HIGH/CRITICAL OS/library vulnerabilities before the
+      # image can reach ECR — the worker shells out to samtools/tabix/
+      # bigBedToBed over untrusted upstream bytes.
+      - name: Scan wool worker image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.WOOL_IMAGE }}
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Push wool worker image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: cfdb-wool
+        run: |
+          SHA_TAG=${GITHUB_SHA::8}
           docker push $REGISTRY/$REPOSITORY:latest
           docker push $REGISTRY/$REPOSITORY:$SHA_TAG
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 !.gitignore
 !.github/
+!.dockerignore
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ Run `./certs/generate-certs.sh --help` for full usage information.
 | `make mongodb-prod` | Start MongoDB with TLS/X.509 authentication |
 | `make api-prod` | Start API with X.509 client certificate |
 
+### Deploying the CloudFormation stacks
+
+Production runs on four CloudFormation stacks under `cloudformation/`. Deploy them in dependency order (each imports exports from the earlier ones):
+
+1. `network.yml` — VPC, subnets, security groups (including the worker SG), S3 gateway endpoint.
+2. `database.yml` — DocumentDB cluster and connection-URL secret.
+3. `workers.yml` — wool worker task definition, S3 artifact cache, worker IAM roles.
+4. `backend.yml` — API service, ALB, and the IAM/env wiring that dispatches to the worker fleet.
+
+Tear down in the reverse order (`backend` → `workers` → `database` → `network`); `backend` imports the worker exports, so it must be deleted first. The `cfdb-wool` ECR repository is a prerequisite created out of band (like the `cfdb` repository); consider giving it an `IMMUTABLE` tag policy and a lifecycle policy to prune untagged images.
+
+**Rolling the worker fleet.** The CI pipeline builds, scans, and pushes the worker image to `cfdb-wool:<sha>` on every merge to `master`, but it does not roll workers — the worker task definition pins `Image: !Ref WorkerImageURI`. To deploy a new worker image, redeploy the workers stack with the SHA-tagged URI:
+
+```bash
+aws cloudformation deploy \
+  --stack-name <workers-stack> \
+  --template-file cloudformation/workers.yml \
+  --parameter-overrides WorkerImageURI=<account>.dkr.ecr.<region>.amazonaws.com/cfdb-wool:<sha> \
+  --capabilities CAPABILITY_IAM
+```
+
+This registers a new task-definition revision that `EcsProvisioner` launches on the next workflow dispatch. Pin to an immutable `:<sha>` (not `:latest`) so the running fleet is traceable to a commit and rollback is a redeploy with the prior SHA.
+
+**Tearing down the cache.** CloudFormation cannot delete a non-empty S3 bucket, so empty the `CacheBucket` before deleting the workers stack or the delete will fail and roll back.
+
 ## GraphQL API
 
 **URL:** `POST /metadata`

--- a/cloudformation/backend.yml
+++ b/cloudformation/backend.yml
@@ -10,9 +10,18 @@ Parameters:
   DatabaseStackName:
     Type: String
     Description: Name of the database stack
+  WorkersStackName:
+    Type: String
+    Description: Name of the workers stack (worker task def + S3 cache)
   ImageURI:
     Type: String
     Description: ECR image URI for the CFDB API
+  WorkflowS3Prefix:
+    Type: String
+    Default: ""
+    Description: >
+      Optional key prefix the S3 cache prepends to every artifact key,
+      letting one bucket host multiple environments (WORKFLOW_S3_PREFIX).
   DesiredCount:
     Type: Number
     Default: 1
@@ -167,6 +176,30 @@ Resources:
               Value: "false"
             - Name: SYNC_DATA_DIR
               Value: /tmp/sync-data
+            # Selects the "ecs" workflow profile (S3Cache + EcsDiscovery +
+            # EcsProvisioner). ECS_CLUSTER reuses this stack's own cluster.
+            - Name: ECS_CLUSTER
+              Value: !Ref ECSCluster
+            - Name: ECS_WORKER_TASK_DEFINITION
+              Value:
+                Fn::ImportValue: !Sub "${WorkersStackName}-WorkerTaskFamily"
+            - Name: ECS_WORKER_SUBNETS
+              Value:
+                Fn::ImportValue: !Sub "${NetworkStackName}-PublicSubnetIds"
+            - Name: ECS_WORKER_SECURITY_GROUPS
+              Value:
+                Fn::ImportValue: !Sub "${NetworkStackName}-WorkerSecurityGroupId"
+            # Workers fetch upstream files over HTTPS; private subnets have
+            # no NAT, so workers run in public subnets with a public IP.
+            - Name: ECS_WORKER_ASSIGN_PUBLIC_IP
+              Value: ENABLED
+            - Name: WORKFLOW_S3_BUCKET
+              Value:
+                Fn::ImportValue: !Sub "${WorkersStackName}-CacheBucketName"
+            - Name: WORKFLOW_S3_PREFIX
+              Value: !Ref WorkflowS3Prefix
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
           Secrets:
             - Name: DATABASE_URL
               ValueFrom:
@@ -258,6 +291,9 @@ Resources:
           Value: !Sub "${AWS::StackName}-execution-role"
 
   # ---------- IAM: task role ----------
+  # The API dispatches workflows to the worker fleet (EcsProvisioner
+  # RunTask, EcsDiscovery ListTasks/DescribeTasks), passes the worker
+  # roles to those tasks, and reads cached artifacts back from S3.
   TaskRole:
     Type: AWS::IAM::Role
     Properties:
@@ -268,6 +304,54 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
+      Policies:
+        - PolicyName: workflow-dispatch
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: ecs:RunTask
+                Resource: !Sub
+                  - "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/${Family}:*"
+                  - Family:
+                      Fn::ImportValue: !Sub "${WorkersStackName}-WorkerTaskFamily"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster: !GetAtt ECSCluster.Arn
+              # ListTasks does not support resource-level scoping; it is
+              # granted on "*" and naturally bounded by the cluster the
+              # API passes at call time.
+              - Effect: Allow
+                Action: ecs:ListTasks
+                Resource: "*"
+              - Effect: Allow
+                Action: ecs:DescribeTasks
+                Resource: !Sub "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:task/${ECSCluster}/*"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster: !GetAtt ECSCluster.Arn
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource:
+                  - Fn::ImportValue: !Sub "${WorkersStackName}-WorkerExecutionRoleArn"
+                  - Fn::ImportValue: !Sub "${WorkersStackName}-WorkerTaskRoleArn"
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: ecs-tasks.amazonaws.com
+        - PolicyName: cache-read
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub
+                  - "${BucketArn}/*"
+                  - BucketArn:
+                      Fn::ImportValue: !Sub "${WorkersStackName}-CacheBucketArn"
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource:
+                  Fn::ImportValue: !Sub "${WorkersStackName}-CacheBucketArn"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-task-role"

--- a/cloudformation/backend.yml
+++ b/cloudformation/backend.yml
@@ -191,6 +191,8 @@ Resources:
                 Fn::ImportValue: !Sub "${NetworkStackName}-WorkerSecurityGroupId"
             # Workers fetch upstream files over HTTPS; private subnets have
             # no NAT, so workers run in public subnets with a public IP.
+            # Safe because the worker SG closes all inbound except 50051
+            # from the API SG — the public IP is egress-only in practice.
             - Name: ECS_WORKER_ASSIGN_PUBLIC_IP
               Value: ENABLED
             - Name: WORKFLOW_S3_BUCKET
@@ -318,12 +320,15 @@ Resources:
                 Condition:
                   ArnEquals:
                     ecs:cluster: !GetAtt ECSCluster.Arn
-              # ListTasks does not support resource-level scoping; it is
-              # granted on "*" and naturally bounded by the cluster the
-              # API passes at call time.
+              # ListTasks doesn't support resource-level ARNs, but it does
+              # honor the ecs:cluster condition key — scope it to this
+              # cluster so the role can't enumerate tasks account-wide.
               - Effect: Allow
                 Action: ecs:ListTasks
                 Resource: "*"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster: !GetAtt ECSCluster.Arn
               - Effect: Allow
                 Action: ecs:DescribeTasks
                 Resource: !Sub "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:task/${ECSCluster}/*"

--- a/cloudformation/network.yml
+++ b/cloudformation/network.yml
@@ -399,11 +399,14 @@ Resources:
           Value: !Sub "${AWS::StackName}-docdb-sg"
 
   # Workers accept gRPC 50051 from the API tasks (dispatched to a worker's
-  # awsvpc IP) and need all egress for upstream file fetches + S3 writes.
+  # awsvpc IP). Egress is restricted to HTTPS (upstream file fetches and
+  # the S3 gateway endpoint) and DNS: workers only ever fetch https:// URLs
+  # (DRS resolves to HTTPS), so arbitrary-port egress is unnecessary.
+  # Responses to the inbound gRPC connection are allowed statefully.
   WorkerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Wool workers - allow 50051 from ECS, all egress
+      GroupDescription: Wool workers - allow 50051 from ECS; egress HTTPS + DNS
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
@@ -412,7 +415,17 @@ Resources:
           SourceSecurityGroupId: !Ref ECSSecurityGroup
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
-          IpProtocol: "-1"
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: tcp
+          FromPort: 53
+          ToPort: 53
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: udp
+          FromPort: 53
+          ToPort: 53
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-worker-sg"

--- a/cloudformation/network.yml
+++ b/cloudformation/network.yml
@@ -398,6 +398,25 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-docdb-sg"
 
+  # Workers accept gRPC 50051 from the API tasks (dispatched to a worker's
+  # awsvpc IP) and need all egress for upstream file fetches + S3 writes.
+  WorkerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Wool workers - allow 50051 from ECS, all egress
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 50051
+          ToPort: 50051
+          SourceSecurityGroupId: !Ref ECSSecurityGroup
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          IpProtocol: "-1"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-worker-sg"
+
   # ---------- DocumentDB subnet group ----------
   DocumentDBSubnetGroup:
     Type: AWS::DocDB::DBSubnetGroup
@@ -447,6 +466,10 @@ Outputs:
     Value: !GetAtt DocumentDBSecurityGroup.GroupId
     Export:
       Name: !Sub "${AWS::StackName}-DocumentDBSecurityGroupId"
+  WorkerSecurityGroupId:
+    Value: !GetAtt WorkerSecurityGroup.GroupId
+    Export:
+      Name: !Sub "${AWS::StackName}-WorkerSecurityGroupId"
   DocumentDBSubnetGroupName:
     Value: !Ref DocumentDBSubnetGroup
     Export:

--- a/cloudformation/workers.yml
+++ b/cloudformation/workers.yml
@@ -4,7 +4,10 @@ Description: >
   (run on demand by EcsProvisioner) and the S3 artifact cache the
   preprocessing/indexing pipeline writes to. Deploy after the network
   stack and before the backend stack: backend.yml imports the worker
-  task family, worker role ARNs, and cache bucket from here.
+  task family, worker role ARNs, and cache bucket from here. Tear down
+  in reverse — delete the backend stack before this one, since those
+  imports lock these exports — and empty the cache bucket first (see the
+  CacheBucket DeletionPolicy note).
 
 Parameters:
   WorkerImageURI:
@@ -53,9 +56,19 @@ Parameters:
 
 Resources:
   # ---------- S3 artifact cache ----------
+  # DeletionPolicy/UpdateReplacePolicy are explicit Delete: the cache is
+  # disposable (content-addressed by upstream md5, re-materialized on a
+  # miss). NOTE: CloudFormation cannot delete a non-empty bucket, so a
+  # stack delete (or a replacement-triggering update) fails until the
+  # bucket is emptied — empty it before tearing down the stack.
   CacheBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
+      # SSE-S3 (AES256) is a deliberate choice over SSE-KMS: no per-request
+      # KMS cost or key management. Revisit if the cached artifacts ever
+      # need key-policy access control or CloudTrail data events.
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -75,6 +88,26 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-cache"
+
+  # Deny any non-TLS access to the cache at the bucket-policy layer so
+  # artifact reads/writes are HTTPS-only regardless of caller IAM.
+  CacheBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref CacheBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !GetAtt CacheBucket.Arn
+              - !Sub "${CacheBucket.Arn}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
 
   # ---------- CloudWatch log group ----------
   WorkerLogGroup:
@@ -205,6 +238,13 @@ Resources:
             Interval: 30
             Timeout: 5
             Retries: 3
+            # Grace window so boot-time probes don't transiently mark the
+            # task UNHEALTHY (EcsDiscovery only advertises HEALTHY tasks);
+            # mirrors the image HEALTHCHECK's --start-period.
+            StartPeriod: 60
+          # Match WorkerDrainGraceSeconds (default 120) so ECS does not
+          # SIGKILL at the 30s Fargate default and cut the drain short.
+          StopTimeout: 120
 
 Outputs:
   WorkerTaskFamily:

--- a/cloudformation/workers.yml
+++ b/cloudformation/workers.yml
@@ -1,0 +1,233 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CFDB workflow workers — the ephemeral wool worker ECS task definition
+  (run on demand by EcsProvisioner) and the S3 artifact cache the
+  preprocessing/indexing pipeline writes to. Deploy after the network
+  stack and before the backend stack: backend.yml imports the worker
+  task family, worker role ARNs, and cache bucket from here.
+
+Parameters:
+  WorkerImageURI:
+    Type: String
+    Description: ECR image URI for the cfdb wool worker (Dockerfile.wool)
+  WorkerCpu:
+    Type: String
+    Default: "2048"
+    Description: Fargate task CPU units for a worker (1024 = 1 vCPU)
+  WorkerMemory:
+    Type: String
+    Default: "4096"
+    Description: Fargate task memory (MiB) for a worker
+  WorkerEphemeralStorageGiB:
+    Type: Number
+    Default: 50
+    MinValue: 21
+    MaxValue: 200
+    Description: >
+      Fargate ephemeral storage (GiB) backing the per-job /tmp scratch
+      workdir. Sized above the 20 GiB default for multi-hour sorts of
+      large genomic files.
+  CacheArtifactExpirationDays:
+    Type: Number
+    Default: 30
+    MinValue: 1
+    Description: >
+      Days after which cached artifacts expire. Cache keys are
+      content-addressed by upstream md5, so expiry is safe — a missing
+      artifact is simply re-materialized on the next request.
+  WorkerMaxLifetimeSeconds:
+    Type: String
+    Default: "18000"
+    AllowedPattern: "^[0-9]+$"
+    Description: >
+      Hard ceiling on worker uptime (CFDB_WORKER_MAX_LIFETIME_SECONDS);
+      one hour above the 4 h workflow duration cap so a worker started
+      shortly before a long sort can still outlive the job.
+  WorkerDrainGraceSeconds:
+    Type: String
+    Default: "120"
+    AllowedPattern: "^[0-9]+$"
+    Description: >
+      Seconds /health returns 503 after SIGTERM before the gRPC port is
+      torn down (CFDB_WORKER_DRAIN_GRACE_SECONDS).
+
+Resources:
+  # ---------- S3 artifact cache ----------
+  CacheBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-cached-artifacts
+            Status: Enabled
+            ExpirationInDays: !Ref CacheArtifactExpirationDays
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-cache"
+
+  # ---------- CloudWatch log group ----------
+  WorkerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${AWS::StackName}-worker"
+      RetentionInDays: 30
+
+  # ---------- IAM: worker execution role ----------
+  # Pulls the image from ECR and writes container logs. The API task
+  # role passes this role to the worker task via iam:PassRole at RunTask.
+  WorkerExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: execution
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !GetAtt WorkerLogGroup.Arn
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-worker-execution-role"
+
+  # ---------- IAM: worker task role ----------
+  # The processing routine runs in the worker and writes processed
+  # artifacts to the cache (cache.head + cache.put), so the task role
+  # needs read+write on the bucket. No delete: nothing in the request
+  # path calls cache.delete.
+  WorkerTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: cache-access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub "${CacheBucket.Arn}/*"
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !GetAtt CacheBucket.Arn
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-worker-task-role"
+
+  # ---------- Worker task definition ----------
+  WorkerTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${AWS::StackName}-worker"
+      Cpu: !Ref WorkerCpu
+      Memory: !Ref WorkerMemory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      # The worker image is pinned to linux/amd64 (Dockerfile.wool) because
+      # UCSC publishes bigBedToBed only as a linux.x86_64 binary. Pin the
+      # task to X86_64 Fargate capacity so samtools/bgzip/tabix and the
+      # interpreter run native rather than emulated on arm64 hosts.
+      RuntimePlatform:
+        CpuArchitecture: X86_64
+        OperatingSystemFamily: LINUX
+      EphemeralStorage:
+        SizeInGiB: !Ref WorkerEphemeralStorageGiB
+      ExecutionRoleArn: !GetAtt WorkerExecutionRole.Arn
+      TaskRoleArn: !GetAtt WorkerTaskRole.Arn
+      ContainerDefinitions:
+        - Name: cfdb-worker
+          Image: !Ref WorkerImageURI
+          Essential: true
+          PortMappings:
+            - ContainerPort: 50051
+              Protocol: tcp
+            - ContainerPort: 8080
+              Protocol: tcp
+          Environment:
+            - Name: CFDB_WORKER_GRPC_PORT
+              Value: "50051"
+            - Name: CFDB_WORKER_HEALTH_PORT
+              Value: "8080"
+            - Name: CFDB_WORKER_MAX_LIFETIME_SECONDS
+              Value: !Ref WorkerMaxLifetimeSeconds
+            - Name: CFDB_WORKER_DRAIN_GRACE_SECONDS
+              Value: !Ref WorkerDrainGraceSeconds
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref WorkerLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+          # Probes the aiohttp /health endpoint worker_main serves on the
+          # health port. ECS must see HEALTHY before EcsDiscovery advertises
+          # the task; without a healthCheck healthStatus stays UNKNOWN.
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - curl -f http://127.0.0.1:8080/health || exit 1
+            Interval: 30
+            Timeout: 5
+            Retries: 3
+
+Outputs:
+  WorkerTaskFamily:
+    Value: !Sub "${AWS::StackName}-worker"
+    Export:
+      Name: !Sub "${AWS::StackName}-WorkerTaskFamily"
+  WorkerTaskDefinitionArn:
+    Value: !Ref WorkerTaskDefinition
+    Export:
+      Name: !Sub "${AWS::StackName}-WorkerTaskDefinitionArn"
+  WorkerExecutionRoleArn:
+    Value: !GetAtt WorkerExecutionRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-WorkerExecutionRoleArn"
+  WorkerTaskRoleArn:
+    Value: !GetAtt WorkerTaskRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-WorkerTaskRoleArn"
+  CacheBucketName:
+    Value: !Ref CacheBucket
+    Export:
+      Name: !Sub "${AWS::StackName}-CacheBucketName"
+  CacheBucketArn:
+    Value: !GetAtt CacheBucket.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-CacheBucketArn"


### PR DESCRIPTION
## Summary

Provision the deploy infrastructure for the ECS Fargate workflow profile that the worker-runtime work (#34) deferred. The runtime classes (EcsProvisioner, EcsDiscovery, S3Cache, worker_main) shipped without any CloudFormation to stand up the fleet they target, so with no ECS/S3 environment set the API silently runs the local PoC profile. This adds a new workers.yml stack for the on-demand wool worker task definition and the S3 artifact cache, a worker security group in network.yml, the IAM and environment wiring in backend.yml that flips the API into the ecs profile, and a CI step that builds and pushes the worker image.

Deploy order is network → database → workers → backend. The worker task definition does not reference the ECS cluster (only the API's RunTask does), so workers depends only on network while backend imports the worker family, role ARNs, and cache bucket from workers — no cross-stack cycle.

LocalStack-backed local testing remains a separate follow-up: ECS RunTask is a LocalStack Pro feature, and the runtime classes already have moto-based unit coverage.

Closes #40

## Proposed changes

### cloudformation/workers.yml (new stack)

- Add the S3 artifact cache bucket — SSE-S3 encryption, full public-access block, and a lifecycle rule expiring objects after a configurable retention (default 30 days) plus aborting incomplete multipart uploads after 7 days. Expiry is safe because cache keys are content-addressed by upstream md5.
- Add the worker ECS task definition — FARGATE/awsvpc for the Dockerfile.wool image. Pin RuntimePlatform to X86_64 so the amd64-only image (it bundles UCSC's x86_64 bigBedToBed) runs native rather than emulated, keeping samtools/bgzip/tabix off the emulation path. Declare a /health (port 8080) health check so ECS marks the task HEALTHY and EcsDiscovery advertises it, size ephemeral storage above the 20 GiB default for large genomic sorts, and set the worker runtime knobs.
- Add worker IAM roles — an execution role for ECR pull and log writes, and a task role with s3:GetObject/s3:PutObject/s3:ListBucket on the cache bucket. The processing routine runs on the worker and calls cache.put, so the worker writes artifacts; no s3:DeleteObject since nothing in the request path deletes.
- Export the worker task family, execution/task role ARNs, and cache bucket name/ARN for the backend stack.

### cloudformation/network.yml

- Add a worker security group allowing gRPC ingress on 50051 from the API ECS security group (the API dispatches to a worker's awsvpc IP) with all egress for upstream fetches and S3 writes, placed alongside the existing ALB/ECS/DocumentDB groups.

### cloudformation/backend.yml

- Grant the API task role ecs:RunTask (scoped to the worker task family and cluster), ecs:ListTasks, ecs:DescribeTasks (scoped to the cluster's tasks), iam:PassRole on the worker roles (conditioned on ecs-tasks.amazonaws.com), and s3:GetObject/s3:ListBucket on the cache bucket for serving cached artifacts.
- Inject the environment that selects the ecs profile: ECS_CLUSTER, ECS_WORKER_TASK_DEFINITION, ECS_WORKER_SUBNETS (the public subnets — workers need outbound HTTPS and the private subnets have no NAT), ECS_WORKER_SECURITY_GROUPS, ECS_WORKER_ASSIGN_PUBLIC_IP, WORKFLOW_S3_BUCKET, WORKFLOW_S3_PREFIX, and AWS_REGION.

### .github/workflows/deploy-to-ecr.yml

- Add a step that builds Dockerfile.wool for linux/amd64 and pushes it to the cfdb-wool ECR repository so the worker task definition has an image source. No service update is issued — workers are launched on demand via RunTask, not run as a long-lived service. The cfdb-wool repository must exist in ECR (created out of band, like the cfdb repository).

## Verification

- cfn-lint passes on all three templates with no errors (remaining warnings are pre-existing on untouched lines).
- pytest tests/test_api passes; no Python changed.