### PR TITLE
Bootstrap Mongo indexes automatically on deploy instead of as a manual step — Closes #46

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = ["allpairspy", "debugpy", "httpx", "hypothesis", "mongomock-motor", "moto[
 
 [project.scripts]
 cfdb = "cfdb.cli:cli"
+cfdb-ensure-indexes = "cfdb.ensure_indexes:main"
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]

--- a/scripts/create-indexes.js
+++ b/scripts/create-indexes.js
@@ -184,18 +184,25 @@ db.locks.createIndex({ active: 1 });
 
 print("Creating indexes on 'jobs' collection...");
 // Partial unique index on workflow_key enforces per-source mutex: only one
-// active job (pending|running) may exist per source file. Terminal jobs
-// fall outside the filter so fresh claims can succeed.
+// active job (pending|running) may exist per source file. The filter keys
+// on the boolean `active` discriminator (active == status in
+// ACTIVE_STATUSES), which JobRecord.to_mongo stamps and cfdb.workflows.lock
+// maintains. Terminal jobs have active=false so they fall outside the
+// filter and fresh claims can succeed.
 //
-// IMPORTANT: the status values below MUST stay in sync with
-// cfdb.workflows.models.ACTIVE_STATUSES. Renaming either side without
-// updating both desyncs the partial index from the application's
-// active-status definition and breaks the mutex contract.
+// Why `active` instead of `status: { $in: [...] }`: Amazon DocumentDB
+// rejects the $in operator inside a partialFilterExpression (only $eq,
+// $exists, $and, $gt/$gte/$lt/$lte are supported), so the predicate is
+// expressed as implicit equality on `active`.
 //
-// Compatibility: requires MongoDB >= 3.2 (partial indexes) and a
-// DocumentDB engine version that supports partialFilterExpression.
-// Re-running with a changed predicate raises IndexOptionsConflict;
-// dropIndex first if the active-status set ever changes.
+// IMPORTANT: this MUST stay in sync with operational_index_specs() in
+// cfdb/indexes.py (the application source of truth); a lockstep test
+// guards drift. Renaming/repredicating one side without the other breaks
+// the mutex contract.
+//
+// Compatibility: requires MongoDB >= 3.2 / DocumentDB 5.0 (partial
+// indexes). Re-running with a changed predicate raises
+// IndexOptionsConflict; dropIndex first if the predicate ever changes.
 ensureIndex(
     db.jobs,
     { workflow_key: 1 },
@@ -203,7 +210,7 @@ ensureIndex(
         name: "workflow_key_active_unique",
         unique: true,
         partialFilterExpression: {
-            status: { $in: ["pending", "running"] }
+            active: true
         }
     }
 );
@@ -217,9 +224,11 @@ ensureIndex(
 // TTL index on terminal job rows. Without this, every stale-reclaim
 // transition leaves a permanent ``failed`` document and the collection
 // grows unbounded for any frequently-touched workflow_key. The partial
-// filter excludes active rows so the TTL never reaps an in-flight job.
-// 7 days gives operators a window to investigate recent failures before
-// the row is reclaimed.
+// filter excludes active rows (active=true) so the TTL never reaps an
+// in-flight job. 7 days gives operators a window to investigate recent
+// failures before the row is reclaimed. Filters on `active` (not a status
+// $in list) for DocumentDB partialFilterExpression compatibility — see
+// the workflow_key_active_unique note above.
 ensureIndex(
     db.jobs,
     { updated_at: 1 },
@@ -227,7 +236,7 @@ ensureIndex(
         name: "terminal_ttl",
         expireAfterSeconds: 60 * 60 * 24 * 7,
         partialFilterExpression: {
-            status: { $in: ["completed", "failed"] }
+            active: false
         }
     }
 );

--- a/src/cfdb/api/main.py
+++ b/src/cfdb/api/main.py
@@ -28,11 +28,11 @@ from cfdb.workflows.cache import (
     _build_s3_client,
     check_s3_bucket_or_raise,
 )
+from cfdb.db import mongo_client_kwargs
 from cfdb.indexes import ensure_indexes, operational_index_specs
 from cfdb.workflows.credentials import build_worker_credentials
 from cfdb.workflows.discovery import EcsDiscovery
 from cfdb.workflows.executor import WoolExecutor
-from cfdb.workflows.models import ACTIVE_STATUSES
 from cfdb.workflows.processors.bam import BamIndexProcessor
 from cfdb.workflows.processors.registry import default_registry
 from cfdb.workflows.processors.tabix import TabixIntervalProcessor
@@ -99,44 +99,45 @@ async def _reset_api_globals() -> None:
     api.wool_context = None
 
 
+def _selects_active_rows(pfe: object) -> bool:
+    """True if a partialFilterExpression selects active (active=True) rows.
+
+    Accepts both the implicit-equality form ``{"active": True}`` and the
+    explicit ``{"active": {"$eq": True}}`` form, since MongoDB and
+    DocumentDB may echo either shape back from ``index_information``.
+    """
+    if not isinstance(pfe, dict):
+        return False
+    clause = pfe.get("active")
+    if clause is True:
+        return True
+    return isinstance(clause, dict) and clause.get("$eq") is True
+
+
 async def _warn_if_jobs_index_out_of_sync(db, log: logging.Logger) -> None:
     """Warn if the ``jobs.workflow_key`` mutex index is missing or stale.
 
     Belt-and-suspenders check run *after* :func:`ensure_indexes` has
     created the operational set. The partial-unique index on
-    ``workflow_key`` (filtered to active statuses) is what makes the
-    workflow mutex actually serialize concurrent dispatches; if it is
-    somehow absent or its predicate no longer matches
-    ``ACTIVE_STATUSES``, surface it loudly so a desync is visible in the
-    logs — but don't crash the API, since the ensure step is now the
-    bootstrap and a transient read here shouldn't take the service down.
-
-    The ``$in`` list is sorted on both sides to handle ordering quirks
-    across MongoDB and DocumentDB versions.
+    ``workflow_key`` (filtered to the ``active`` discriminator) is what
+    makes the workflow mutex actually serialize concurrent dispatches; if
+    it is somehow absent or its predicate no longer selects active rows,
+    surface it loudly so a desync is visible in the logs — but don't
+    crash the API, since the ensure step is now the bootstrap and a
+    transient read here shouldn't take the service down.
     """
     info = await db.jobs.index_information()
-    expected_active = sorted(s.value for s in ACTIVE_STATUSES)
     for spec in info.values():
         key_pairs = spec.get("key") or []
         keys = [k for k, _ in key_pairs]
         if not (keys == ["workflow_key"] and spec.get("unique")):
             continue
-        pfe = spec.get("partialFilterExpression")
-        if not isinstance(pfe, dict):
-            continue
-        status_clause = pfe.get("status")
-        if not isinstance(status_clause, dict):
-            continue
-        in_values = status_clause.get("$in")
-        if not isinstance(in_values, list):
-            continue
-        if sorted(in_values) == expected_active:
+        if _selects_active_rows(spec.get("partialFilterExpression")):
             return
     log.warning(
-        "jobs.workflow_key partial-unique index missing or out of sync "
-        "with ACTIVE_STATUSES=%s after ensure_indexes; the workflow mutex "
-        "may not serialize concurrent dispatches",
-        expected_active,
+        "jobs.workflow_key active partial-unique index missing or out of "
+        "sync after ensure_indexes; the workflow mutex may not serialize "
+        "concurrent dispatches"
     )
 
 
@@ -215,23 +216,14 @@ async def _build_discovery(profile: WorkflowProfile) -> AsyncIterator[object]:
 def create_mongodb_client() -> AsyncIOMotorClient:
     """Create MongoDB client with optional TLS authentication."""
     log = logging.getLogger(__name__)
-    kwargs: dict = {}
-
-    if not api.MONGODB_RETRY_WRITES:
-        kwargs["retryWrites"] = False
-
-    if api.MONGODB_TLS_ENABLED:
+    kwargs = mongo_client_kwargs()
+    if kwargs.get("tls"):
         log.info("Connecting to MongoDB at %s with TLS", redact_url(api.DATABASE_URL))
-        return AsyncIOMotorClient(
-            api.DATABASE_URL,
-            tls=True,
-            tlsCAFile=api.MONGODB_CA_PATH,
-            **kwargs,
+    else:
+        log.info(
+            "Connecting to MongoDB at %s (no authentication)",
+            redact_url(api.DATABASE_URL),
         )
-    log.info(
-        "Connecting to MongoDB at %s (no authentication)",
-        redact_url(api.DATABASE_URL),
-    )
     return AsyncIOMotorClient(api.DATABASE_URL, **kwargs)
 
 
@@ -251,18 +243,21 @@ async def lifespan(_: FastAPI):
         # cannot silently degrade to PoC fallback.
         profile = WorkflowProfile.from_env()
 
-        # Self-heal the operational indexes before serving. The partial
-        # unique index on ``jobs.workflow_key`` is the database-side
-        # enforcement of "exactly one active workflow per source file";
-        # without it, ``claim_workflow`` silently degrades to "no mutex"
-        # and every miss dispatches a duplicate workflow. Ensuring them
-        # here (idempotently) means a fresh DocumentDB no longer needs a
-        # manual ``scripts/create-indexes.js`` run to boot. The warning
-        # check that follows is belt-and-suspenders against a desync.
-        if profile is not None:
-            await ensure_indexes(api.db, operational_index_specs())
-            await _warn_if_jobs_index_out_of_sync(api.db, log)
+        # Self-heal the operational indexes before serving, unconditionally
+        # (i.e. regardless of whether the workflow subsystem is enabled).
+        # The ``locks`` collection backs the sync/cutover locks even when
+        # SYNC_DATA_DIR is unset, and the partial-unique index on
+        # ``jobs.workflow_key`` is the database-side enforcement of
+        # "exactly one active workflow per source file" — without it,
+        # ``claim_workflow`` silently degrades to "no mutex" and every
+        # miss dispatches a duplicate workflow. Ensuring them here
+        # (idempotently) means a fresh DocumentDB no longer needs a manual
+        # ``scripts/create-indexes.js`` run to boot. The warning check that
+        # follows is belt-and-suspenders against a desync.
+        await ensure_indexes(api.db, operational_index_specs())
+        await _warn_if_jobs_index_out_of_sync(api.db, log)
 
+        if profile is not None:
             # Fail-fast on mkdir error: an operator who explicitly set
             # SYNC_DATA_DIR has signalled "workflows on"; silently
             # degrading to disabled hides misconfiguration (wrong path,

--- a/src/cfdb/api/main.py
+++ b/src/cfdb/api/main.py
@@ -28,6 +28,7 @@ from cfdb.workflows.cache import (
     _build_s3_client,
     check_s3_bucket_or_raise,
 )
+from cfdb.indexes import ensure_indexes, operational_index_specs
 from cfdb.workflows.credentials import build_worker_credentials
 from cfdb.workflows.discovery import EcsDiscovery
 from cfdb.workflows.executor import WoolExecutor
@@ -98,20 +99,20 @@ async def _reset_api_globals() -> None:
     api.wool_context = None
 
 
-async def _assert_jobs_indexes(db, log: logging.Logger) -> None:
-    """Verify ``scripts/create-indexes.js`` has been applied to ``jobs``.
+async def _warn_if_jobs_index_out_of_sync(db, log: logging.Logger) -> None:
+    """Warn if the ``jobs.workflow_key`` mutex index is missing or stale.
 
-    Specifically checks that the partial-unique index on
-    ``workflow_key`` filtered to active statuses exists. Without it the
-    workflow mutex doesn't actually serialize concurrent dispatches.
+    Belt-and-suspenders check run *after* :func:`ensure_indexes` has
+    created the operational set. The partial-unique index on
+    ``workflow_key`` (filtered to active statuses) is what makes the
+    workflow mutex actually serialize concurrent dispatches; if it is
+    somehow absent or its predicate no longer matches
+    ``ACTIVE_STATUSES``, surface it loudly so a desync is visible in the
+    logs — but don't crash the API, since the ensure step is now the
+    bootstrap and a transient read here shouldn't take the service down.
 
-    The expected filter is derived from ``ACTIVE_STATUSES`` so Python is
-    the single source of truth — if a new status is added to the enum
-    without a matching update to ``scripts/create-indexes.js``, this
-    startup check fires loudly rather than silently admitting duplicate
-    active rows under the partial index. The ``$in`` list is sorted on
-    both sides to handle ordering quirks across MongoDB and DocumentDB
-    versions.
+    The ``$in`` list is sorted on both sides to handle ordering quirks
+    across MongoDB and DocumentDB versions.
     """
     info = await db.jobs.index_information()
     expected_active = sorted(s.value for s in ACTIVE_STATUSES)
@@ -131,16 +132,11 @@ async def _assert_jobs_indexes(db, log: logging.Logger) -> None:
             continue
         if sorted(in_values) == expected_active:
             return
-    log.error(
+    log.warning(
         "jobs.workflow_key partial-unique index missing or out of sync "
-        "with ACTIVE_STATUSES=%s; run scripts/create-indexes.js",
+        "with ACTIVE_STATUSES=%s after ensure_indexes; the workflow mutex "
+        "may not serialize concurrent dispatches",
         expected_active,
-    )
-    raise RuntimeError(
-        "Required Mongo index 'jobs.workflow_key' (partial-unique, "
-        f"filter status in {expected_active}) not found; run "
-        "scripts/create-indexes.js against the target database before "
-        "starting the API."
     )
 
 
@@ -255,13 +251,17 @@ async def lifespan(_: FastAPI):
         # cannot silently degrade to PoC fallback.
         profile = WorkflowProfile.from_env()
 
-        # Fail-fast if the workflow mutex index is missing. The partial
+        # Self-heal the operational indexes before serving. The partial
         # unique index on ``jobs.workflow_key`` is the database-side
         # enforcement of "exactly one active workflow per source file";
         # without it, ``claim_workflow`` silently degrades to "no mutex"
-        # and every miss dispatches a duplicate workflow.
+        # and every miss dispatches a duplicate workflow. Ensuring them
+        # here (idempotently) means a fresh DocumentDB no longer needs a
+        # manual ``scripts/create-indexes.js`` run to boot. The warning
+        # check that follows is belt-and-suspenders against a desync.
         if profile is not None:
-            await _assert_jobs_indexes(api.db, log)
+            await ensure_indexes(api.db, operational_index_specs())
+            await _warn_if_jobs_index_out_of_sync(api.db, log)
 
             # Fail-fast on mkdir error: an operator who explicitly set
             # SYNC_DATA_DIR has signalled "workflows on"; silently

--- a/src/cfdb/db.py
+++ b/src/cfdb/db.py
@@ -1,0 +1,29 @@
+"""Shared MongoDB client configuration.
+
+Single source of truth for the connection kwargs that both the API
+lifespan (``cfdb.api.main.create_mongodb_client``) and the ensure-indexes
+CLI (``cfdb.ensure_indexes``) pass to a Motor client, so the TLS /
+retry-write options can't drift between the two. Imports only the
+``cfdb.api`` config constants (no FastAPI app) so lightweight callers
+stay lightweight.
+"""
+
+from __future__ import annotations
+
+from cfdb import api
+
+
+def mongo_client_kwargs() -> dict:
+    """Build ``AsyncIOMotorClient`` kwargs from the API's Mongo env config.
+
+    Honors ``MONGODB_RETRY_WRITES`` and the ``MONGODB_TLS_*`` settings.
+    Callers pass the result alongside ``DATABASE_URL`` to construct the
+    client.
+    """
+    kwargs: dict = {}
+    if not api.MONGODB_RETRY_WRITES:
+        kwargs["retryWrites"] = False
+    if api.MONGODB_TLS_ENABLED:
+        kwargs["tls"] = True
+        kwargs["tlsCAFile"] = api.MONGODB_CA_PATH
+    return kwargs

--- a/src/cfdb/ensure_indexes.py
+++ b/src/cfdb/ensure_indexes.py
@@ -1,0 +1,88 @@
+"""Operator CLI to ensure cfdb's MongoDB indexes exist.
+
+Run as ``python -m cfdb.ensure_indexes`` (or the ``cfdb-ensure-indexes``
+console script). The API lifespan now self-heals the *operational*
+indexes on startup and the sync pipeline ensures the *data* indexes
+after a load, so this command is an operator convenience / manual escape
+hatch — e.g. to pre-create every index against a fresh cluster, or to
+re-apply after an index predicate change without waiting for a sync.
+
+It honors the same MongoDB connection environment as the API
+(``DATABASE_URL``, ``DATABASE_NAME``, ``MONGODB_TLS_ENABLED``,
+``MONGODB_CA_PATH``, ``MONGODB_RETRY_WRITES``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import click
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from cfdb import api
+from cfdb.indexes import (
+    all_index_specs,
+    data_index_specs,
+    ensure_indexes,
+    operational_index_specs,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["main", "run"]
+
+#: Maps the ``--scope`` choice to the spec builder it selects.
+_SCOPES = {
+    "operational": operational_index_specs,
+    "data": data_index_specs,
+    "all": all_index_specs,
+}
+
+
+def _build_client() -> AsyncIOMotorClient:
+    """Create a Motor client honoring the API's MongoDB env config.
+
+    Mirrors ``cfdb.api.main.create_mongodb_client`` (TLS + retry-writes)
+    without importing the FastAPI app, so the CLI stays lightweight.
+    """
+    kwargs: dict = {}
+    if not api.MONGODB_RETRY_WRITES:
+        kwargs["retryWrites"] = False
+    if api.MONGODB_TLS_ENABLED:
+        kwargs["tls"] = True
+        kwargs["tlsCAFile"] = api.MONGODB_CA_PATH
+    return AsyncIOMotorClient(api.DATABASE_URL, **kwargs)
+
+
+async def run(scope: str) -> int:
+    """Ensure the indexes for ``scope`` and return the count ensured."""
+    specs = _SCOPES[scope]()
+    client = _build_client()
+    try:
+        db = client[api.DATABASE_NAME]
+        return await ensure_indexes(db, specs)
+    finally:
+        client.close()
+
+
+@click.command()
+@click.option(
+    "--scope",
+    type=click.Choice(sorted(_SCOPES)),
+    default="all",
+    show_default=True,
+    help=(
+        "Which index set to ensure: operational (jobs/locks), data "
+        "(query-perf), or all."
+    ),
+)
+def main(scope: str) -> None:
+    """Idempotently ensure cfdb's MongoDB indexes exist."""
+    logging.basicConfig(level=logging.INFO)
+    count = asyncio.run(run(scope))
+    click.echo(f"Ensured {count} {scope} index(es)")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/cfdb/ensure_indexes.py
+++ b/src/cfdb/ensure_indexes.py
@@ -21,6 +21,7 @@ import click
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from cfdb import api
+from cfdb.db import mongo_client_kwargs
 from cfdb.indexes import (
     all_index_specs,
     data_index_specs,
@@ -43,16 +44,11 @@ _SCOPES = {
 def _build_client() -> AsyncIOMotorClient:
     """Create a Motor client honoring the API's MongoDB env config.
 
-    Mirrors ``cfdb.api.main.create_mongodb_client`` (TLS + retry-writes)
-    without importing the FastAPI app, so the CLI stays lightweight.
+    Shares the connection kwargs with ``cfdb.api.main.create_mongodb_client``
+    via :func:`cfdb.db.mongo_client_kwargs` (TLS + retry-writes) without
+    importing the FastAPI app, so the CLI stays lightweight.
     """
-    kwargs: dict = {}
-    if not api.MONGODB_RETRY_WRITES:
-        kwargs["retryWrites"] = False
-    if api.MONGODB_TLS_ENABLED:
-        kwargs["tls"] = True
-        kwargs["tlsCAFile"] = api.MONGODB_CA_PATH
-    return AsyncIOMotorClient(api.DATABASE_URL, **kwargs)
+    return AsyncIOMotorClient(api.DATABASE_URL, **mongo_client_kwargs())
 
 
 async def run(scope: str) -> int:

--- a/src/cfdb/indexes.py
+++ b/src/cfdb/indexes.py
@@ -30,8 +30,6 @@ from dataclasses import dataclass
 
 from pymongo.errors import OperationFailure
 
-from cfdb.workflows.models import ACTIVE_STATUSES, JobStatus
-
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -45,12 +43,16 @@ __all__ = [
 #: pymongo ``OperationFailure`` codes raised when an index already exists
 #: under the requested name but with different options/key spec. We drop
 #: and recreate in that case, matching the JS ``ensureIndex`` helper's
-#: drop-on-option-change behavior so a predicate change (e.g. a new
-#: active status) re-applies cleanly instead of aborting.
+#: drop-on-option-change behavior so a predicate change (e.g. flipping the
+#: mutex partial filter) re-applies cleanly instead of aborting.
 _INDEX_CONFLICT_CODES = (85, 86)  # IndexOptionsConflict, IndexKeySpecsConflict
 
+#: ``OperationFailure.code`` for IndexNotFound — pymongo has no dedicated
+#: exception class, so a ``dropIndex`` of an absent index surfaces as this.
+_INDEX_NOT_FOUND_CODE = 27
 
-def _default_index_name(keys: list[tuple[str, int]]) -> str:
+
+def _default_index_name(keys: tuple[tuple[str, int], ...]) -> str:
     """Reproduce MongoDB's default index name for a key spec.
 
     MongoDB names an unnamed index ``field_dir[_field_dir...]`` (e.g.
@@ -68,17 +70,23 @@ class IndexSpec:
     """A single MongoDB index to ensure on a collection.
 
     ``name`` defaults to MongoDB's derived name for ``keys`` when not
-    given, so plain field indexes need only their key spec.
+    given, so plain field indexes need only their key spec. ``keys`` is
+    normalized to a tuple of ``(field, direction)`` tuples in
+    ``__post_init__`` so a frozen spec holds only immutable data
+    (callers may pass a list for convenience).
     """
 
     collection: str
-    keys: list[tuple[str, int]]
+    keys: tuple[tuple[str, int], ...]
     name: str = ""
     unique: bool = False
     partial_filter: dict | None = None
     expire_after_seconds: int | None = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "keys", tuple((field, direction) for field, direction in self.keys)
+        )
         if not self.name:
             object.__setattr__(self, "name", _default_index_name(self.keys))
 
@@ -94,49 +102,48 @@ class IndexSpec:
         return kwargs
 
 
-def _terminal_statuses() -> list[str]:
-    """Status values excluded from the active mutex set (the complement).
-
-    Derived from :data:`ACTIVE_STATUSES` so the ``terminal_ttl`` filter
-    stays lockstep with the enum: any status that is not active is, by
-    definition, terminal and eligible for TTL reaping.
-    """
-    return [s.value for s in JobStatus if s not in ACTIVE_STATUSES]
-
-
 def operational_index_specs() -> list[IndexSpec]:
     """Indexes that must exist before the API serves traffic.
 
     Mirrors the ``locks`` + ``jobs`` block of
-    ``scripts/create-indexes.js``. The ``jobs.workflow_key`` partial
-    filter and the ``terminal_ttl`` filter are derived from
-    :data:`ACTIVE_STATUSES` rather than hard-coded.
+    ``scripts/create-indexes.js``.
+
+    The ``jobs`` partial indexes filter on the boolean ``active``
+    discriminator (``active == status in ACTIVE_STATUSES``, stamped by
+    :meth:`JobRecord.to_mongo` and maintained by ``workflows.lock``)
+    rather than a ``status`` ``$in`` list. Amazon DocumentDB rejects the
+    ``$in`` operator inside a ``partialFilterExpression`` (only ``$eq``,
+    ``$exists``, ``$and``, ``$gt/$gte/$lt/$lte`` are supported), so the
+    predicate is expressed as implicit equality on ``active`` — which is
+    DocumentDB's documented equivalent of ``$eq`` and what the test
+    doubles also understand. ``ACTIVE_STATUSES`` remains the conceptual
+    source of truth via the ``active`` derivation.
     """
-    active = [s.value for s in ACTIVE_STATUSES]
     return [
         # locks.active — drives the sync cutover lock lookup.
         IndexSpec("locks", [("active", 1)]),
         # Partial-unique mutex: at most one active (pending|running) job
-        # per source file. Terminal jobs fall outside the filter so a
-        # fresh claim can succeed.
+        # per source file. Terminal jobs have active=False so they fall
+        # outside the filter and a fresh claim can succeed.
         IndexSpec(
             "jobs",
             [("workflow_key", 1)],
             name="workflow_key_active_unique",
             unique=True,
-            partial_filter={"status": {"$in": active}},
+            partial_filter={"active": True},
         ),
         IndexSpec("jobs", [("job_id", 1)], name="job_id_unique", unique=True),
         IndexSpec("jobs", [("status", 1), ("updated_at", 1)], name="status_updated_at"),
         # TTL on terminal rows so the collection doesn't grow unbounded.
-        # The partial filter excludes active rows so an in-flight job is
-        # never reaped. 7 days gives operators a window to investigate.
+        # The partial filter excludes active rows (active=True) so an
+        # in-flight job is never reaped. 7 days gives operators a window
+        # to investigate.
         IndexSpec(
             "jobs",
             [("updated_at", 1)],
             name="terminal_ttl",
             expire_after_seconds=60 * 60 * 24 * 7,
-            partial_filter={"status": {"$in": _terminal_statuses()}},
+            partial_filter={"active": False},
         ),
     ]
 
@@ -340,6 +347,25 @@ def all_index_specs() -> list[IndexSpec]:
     return operational_index_specs() + data_index_specs()
 
 
+async def _conflicting_index_name(collection, spec: IndexSpec) -> str:
+    """Resolve the name of the index conflicting with ``spec``.
+
+    On an options/key conflict the existing index may be registered under
+    a different name than ``spec.name`` (e.g. a legacy unnamed index on
+    the same key, or a predicate flipped on the same key pattern). Match
+    by key pattern via ``index_information`` so the recreate path drops
+    the right index rather than blindly dropping ``spec.name`` and tripping
+    IndexNotFound. Falls back to ``spec.name`` when no key match is found.
+    """
+    target_keys = list(spec.keys)
+    info = await collection.index_information()
+    for existing_name, existing in info.items():
+        existing_keys = [tuple(pair) for pair in (existing.get("key") or [])]
+        if existing_keys == target_keys:
+            return existing_name
+    return spec.name
+
+
 async def ensure_indexes(db, specs: list[IndexSpec]) -> int:
     """Idempotently ensure ``specs`` exist on ``db``.
 
@@ -347,26 +373,44 @@ async def ensure_indexes(db, specs: list[IndexSpec]) -> int:
     matching spec is a no-op, so the steady state makes zero changes; an
     index whose options changed (``IndexOptionsConflict`` /
     ``IndexKeySpecsConflict``) is dropped and recreated so a predicate
-    change re-applies cleanly. Returns the number of specs ensured.
+    change re-applies cleanly. The conflicting index is located by key
+    pattern (not assumed to be named ``spec.name``), and an IndexNotFound
+    on the drop is swallowed so a racing/already-dropped index doesn't
+    abort the recreate. Returns the number of specs ensured.
+
+    Note: the drop+recreate path momentarily leaves the index absent. For
+    the ``workflow_key_active_unique`` mutex that is a brief window in
+    which a concurrent claim on another instance could admit a duplicate
+    active row — but this path only fires on a predicate change, not on
+    steady-state startup, so the exposure is limited to a deliberate
+    rollout. It is logged at WARNING so such rebuilds are visible.
 
     ``db`` is a Motor ``AsyncIOMotorDatabase`` (or an API-compatible
-    async stand-in); ``create_index`` / ``drop_index`` are awaited.
+    async stand-in); ``create_index`` / ``drop_index`` /
+    ``index_information`` are awaited.
     """
     for spec in specs:
         collection = db[spec.collection]
         kwargs = spec.create_kwargs()
+        keys = list(spec.keys)
         try:
-            await collection.create_index(spec.keys, **kwargs)
+            await collection.create_index(keys, **kwargs)
         except OperationFailure as exc:
-            if exc.code in _INDEX_CONFLICT_CODES:
-                logger.info(
-                    "Index %s.%s options changed; dropping and recreating",
-                    spec.collection,
-                    spec.name,
-                )
-                await collection.drop_index(spec.name)
-                await collection.create_index(spec.keys, **kwargs)
-            else:
+            if exc.code not in _INDEX_CONFLICT_CODES:
                 raise
+            drop_name = await _conflicting_index_name(collection, spec)
+            logger.warning(
+                "Index %s.%s conflicts with existing %r; dropping and "
+                "recreating (the index is briefly absent during rebuild)",
+                spec.collection,
+                spec.name,
+                drop_name,
+            )
+            try:
+                await collection.drop_index(drop_name)
+            except OperationFailure as drop_exc:
+                if drop_exc.code != _INDEX_NOT_FOUND_CODE:
+                    raise
+            await collection.create_index(keys, **kwargs)
     logger.info("Ensured %d index(es)", len(specs))
     return len(specs)

--- a/src/cfdb/indexes.py
+++ b/src/cfdb/indexes.py
@@ -1,0 +1,372 @@
+"""App-owned MongoDB index definitions and an idempotent applier.
+
+This module is the single source of truth for the indexes cfdb relies
+on. It supersedes ``scripts/create-indexes.js`` for every app-driven
+code path — the API lifespan ensures the *operational* set on startup
+and the sync pipeline ensures the *data* set after a load. The JS file
+is retained only as the bootstrap for the local ``Dockerfile.mongodb``
+image (which has no Python); a test pins the operational specs in
+lockstep between the two so they cannot silently drift.
+
+Two index sets, mirroring the split in the JS file:
+
+* **Operational** — ``jobs`` and ``locks``. These back the workflow
+  mutex and must exist *before* the API serves traffic, so the lifespan
+  ensures them idempotently on every startup. The ``jobs.workflow_key``
+  partial-unique filter and the ``terminal_ttl`` filter are derived from
+  :data:`cfdb.workflows.models.ACTIVE_STATUSES` so Python — not a hand
+  edited predicate — is the source of truth for which statuses hold the
+  mutex.
+* **Data** — the query-performance indexes on ``file``, ``dcc``,
+  ``biosample`` and friends. These are only useful once a sync has
+  loaded data, so they are ensured in the sync/materialize path rather
+  than rebuilt against an empty database on every cold start.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from pymongo.errors import OperationFailure
+
+from cfdb.workflows.models import ACTIVE_STATUSES, JobStatus
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "IndexSpec",
+    "operational_index_specs",
+    "data_index_specs",
+    "all_index_specs",
+    "ensure_indexes",
+]
+
+#: pymongo ``OperationFailure`` codes raised when an index already exists
+#: under the requested name but with different options/key spec. We drop
+#: and recreate in that case, matching the JS ``ensureIndex`` helper's
+#: drop-on-option-change behavior so a predicate change (e.g. a new
+#: active status) re-applies cleanly instead of aborting.
+_INDEX_CONFLICT_CODES = (85, 86)  # IndexOptionsConflict, IndexKeySpecsConflict
+
+
+def _default_index_name(keys: list[tuple[str, int]]) -> str:
+    """Reproduce MongoDB's default index name for a key spec.
+
+    MongoDB names an unnamed index ``field_dir[_field_dir...]`` (e.g.
+    ``id_namespace_1`` / ``submission_1_id_1``). Deriving the same name
+    means specs that mirror the historically-unnamed ``createIndex``
+    calls in ``scripts/create-indexes.js`` resolve to the identical
+    on-disk index, so ensuring them against a database already bootstrapped
+    by the JS file is a no-op rather than a duplicate.
+    """
+    return "_".join(f"{field_name}_{direction}" for field_name, direction in keys)
+
+
+@dataclass(frozen=True)
+class IndexSpec:
+    """A single MongoDB index to ensure on a collection.
+
+    ``name`` defaults to MongoDB's derived name for ``keys`` when not
+    given, so plain field indexes need only their key spec.
+    """
+
+    collection: str
+    keys: list[tuple[str, int]]
+    name: str = ""
+    unique: bool = False
+    partial_filter: dict | None = None
+    expire_after_seconds: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            object.__setattr__(self, "name", _default_index_name(self.keys))
+
+    def create_kwargs(self) -> dict:
+        """Build the keyword arguments for ``Collection.create_index``."""
+        kwargs: dict = {"name": self.name}
+        if self.unique:
+            kwargs["unique"] = True
+        if self.partial_filter is not None:
+            kwargs["partialFilterExpression"] = self.partial_filter
+        if self.expire_after_seconds is not None:
+            kwargs["expireAfterSeconds"] = self.expire_after_seconds
+        return kwargs
+
+
+def _terminal_statuses() -> list[str]:
+    """Status values excluded from the active mutex set (the complement).
+
+    Derived from :data:`ACTIVE_STATUSES` so the ``terminal_ttl`` filter
+    stays lockstep with the enum: any status that is not active is, by
+    definition, terminal and eligible for TTL reaping.
+    """
+    return [s.value for s in JobStatus if s not in ACTIVE_STATUSES]
+
+
+def operational_index_specs() -> list[IndexSpec]:
+    """Indexes that must exist before the API serves traffic.
+
+    Mirrors the ``locks`` + ``jobs`` block of
+    ``scripts/create-indexes.js``. The ``jobs.workflow_key`` partial
+    filter and the ``terminal_ttl`` filter are derived from
+    :data:`ACTIVE_STATUSES` rather than hard-coded.
+    """
+    active = [s.value for s in ACTIVE_STATUSES]
+    return [
+        # locks.active — drives the sync cutover lock lookup.
+        IndexSpec("locks", [("active", 1)]),
+        # Partial-unique mutex: at most one active (pending|running) job
+        # per source file. Terminal jobs fall outside the filter so a
+        # fresh claim can succeed.
+        IndexSpec(
+            "jobs",
+            [("workflow_key", 1)],
+            name="workflow_key_active_unique",
+            unique=True,
+            partial_filter={"status": {"$in": active}},
+        ),
+        IndexSpec("jobs", [("job_id", 1)], name="job_id_unique", unique=True),
+        IndexSpec("jobs", [("status", 1), ("updated_at", 1)], name="status_updated_at"),
+        # TTL on terminal rows so the collection doesn't grow unbounded.
+        # The partial filter excludes active rows so an in-flight job is
+        # never reaped. 7 days gives operators a window to investigate.
+        IndexSpec(
+            "jobs",
+            [("updated_at", 1)],
+            name="terminal_ttl",
+            expire_after_seconds=60 * 60 * 24 * 7,
+            partial_filter={"status": {"$in": _terminal_statuses()}},
+        ),
+    ]
+
+
+def data_index_specs() -> list[IndexSpec]:
+    """Query-performance indexes for the loaded C2M2 data collections.
+
+    Mirrors the data-collection portion of ``scripts/create-indexes.js``.
+    Only useful after a sync has loaded data, so these are ensured in the
+    sync/materialize path rather than at API startup.
+    """
+    specs: list[IndexSpec] = []
+
+    def add(collection: str, *keys: tuple[str, int], unique: bool = False) -> None:
+        specs.append(IndexSpec(collection, list(keys), unique=unique))
+
+    # file
+    for f in (
+        "id_namespace",
+        "local_id",
+        "project_id_namespace",
+        "project_local_id",
+        "persistent_id",
+        "size_in_bytes",
+        "sha256",
+        "md5",
+        "filename",
+        "file_format",
+        "compression_format",
+        "data_type",
+        "assay_type",
+        "analysis_type",
+        "mime_type",
+        "bundle_collection_id_namespace",
+        "bundle_collection_local_id",
+        "dbgap_study_id",
+        "access_url",
+        "submission",
+        "data_access_level",
+    ):
+        add("file", (f, 1))
+    add("file", ("id_namespace", 1), ("local_id", 1))  # composite key
+
+    # dcc
+    for f in (
+        "id",
+        "dcc_name",
+        "dcc_abbreviation",
+        "dcc_description",
+        "contact_email",
+        "contact_name",
+        "dcc_url",
+        "project_id_namespace",
+        "project_local_id",
+        "submission",
+    ):
+        add("dcc", (f, 1))
+
+    # Ontology-style collections: id/name/description + unique (submission, id).
+    for collection in ("file_format", "data_type", "assay_type", "anatomy"):
+        add(collection, ("id", 1))
+        add(collection, ("name", 1))
+        add(collection, ("description", 1))
+        add(collection, ("submission", 1), ("id", 1), unique=True)
+
+    # collection
+    for f in (
+        "id_namespace",
+        "local_id",
+        "persistent_id",
+        "abbreviation",
+        "name",
+        "description",
+        "submission",
+    ):
+        add("collection", (f, 1))
+    add("collection", ("id_namespace", 1), ("local_id", 1))  # composite key
+
+    # biosample
+    for f in (
+        "id_namespace",
+        "local_id",
+        "project_id_namespace",
+        "project_local_id",
+        "persistent_id",
+        "sample_prep_method",
+        "anatomy",
+        "biofluid",
+        "submission",
+    ):
+        add("biosample", (f, 1))
+    add("biosample", ("id_namespace", 1), ("local_id", 1))  # composite key
+
+    # file_in_collection
+    for f in (
+        "file_id_namespace",
+        "file_local_id",
+        "collection_id_namespace",
+        "collection_local_id",
+        "submission",
+    ):
+        add("file_in_collection", (f, 1))
+    add("file_in_collection", ("file_id_namespace", 1), ("file_local_id", 1))
+    add(
+        "file_in_collection",
+        ("collection_id_namespace", 1),
+        ("collection_local_id", 1),
+    )
+
+    # biosample_in_collection
+    for f in (
+        "biosample_id_namespace",
+        "biosample_local_id",
+        "collection_id_namespace",
+        "collection_local_id",
+        "submission",
+    ):
+        add("biosample_in_collection", (f, 1))
+    add(
+        "biosample_in_collection",
+        ("biosample_id_namespace", 1),
+        ("biosample_local_id", 1),
+    )
+    add(
+        "biosample_in_collection",
+        ("collection_id_namespace", 1),
+        ("collection_local_id", 1),
+    )
+
+    # subject
+    for f in (
+        "id_namespace",
+        "local_id",
+        "project_id_namespace",
+        "project_local_id",
+        "persistent_id",
+        "granularity",
+        "sex",
+        "ethnicity",
+        "submission",
+    ):
+        add("subject", (f, 1))
+    add("subject", ("id_namespace", 1), ("local_id", 1))  # composite key
+
+    # biosample_from_subject
+    for f in (
+        "biosample_id_namespace",
+        "biosample_local_id",
+        "subject_id_namespace",
+        "subject_local_id",
+        "submission",
+    ):
+        add("biosample_from_subject", (f, 1))
+    add(
+        "biosample_from_subject",
+        ("biosample_id_namespace", 1),
+        ("biosample_local_id", 1),
+    )
+    add(
+        "biosample_from_subject",
+        ("subject_id_namespace", 1),
+        ("subject_local_id", 1),
+    )
+
+    # subject_race
+    for f in ("subject_id_namespace", "subject_local_id", "race", "submission"):
+        add("subject_race", (f, 1))
+    add("subject_race", ("subject_id_namespace", 1), ("subject_local_id", 1))
+
+    # collection_anatomy
+    add("collection_anatomy", ("collection_id_namespace", 1), ("collection_local_id", 1))
+    add("collection_anatomy", ("anatomy", 1))
+    add("collection_anatomy", ("submission", 1))
+
+    # subject_in_collection
+    add("subject_in_collection", ("collection_id_namespace", 1), ("collection_local_id", 1))
+    add("subject_in_collection", ("subject_id_namespace", 1), ("subject_local_id", 1))
+    add("subject_in_collection", ("submission", 1))
+
+    # ncbi_taxonomy
+    add("ncbi_taxonomy", ("id", 1))
+    add("ncbi_taxonomy", ("name", 1))
+    add("ncbi_taxonomy", ("clade", 1))
+    add("ncbi_taxonomy", ("submission", 1), ("id", 1), unique=True)
+
+    # subject_role_taxonomy
+    for f in ("subject_id_namespace", "subject_local_id", "taxonomy_id", "submission"):
+        add("subject_role_taxonomy", (f, 1))
+    add("subject_role_taxonomy", ("subject_id_namespace", 1), ("subject_local_id", 1))
+
+    # project
+    for f in ("id_namespace", "local_id", "name", "abbreviation", "submission"):
+        add("project", (f, 1))
+    add("project", ("id_namespace", 1), ("local_id", 1))  # composite key
+
+    return specs
+
+
+def all_index_specs() -> list[IndexSpec]:
+    """Operational + data specs, in that order."""
+    return operational_index_specs() + data_index_specs()
+
+
+async def ensure_indexes(db, specs: list[IndexSpec]) -> int:
+    """Idempotently ensure ``specs`` exist on ``db``.
+
+    Mirrors the JS ``ensureIndex`` helper: ``create_index`` with a
+    matching spec is a no-op, so the steady state makes zero changes; an
+    index whose options changed (``IndexOptionsConflict`` /
+    ``IndexKeySpecsConflict``) is dropped and recreated so a predicate
+    change re-applies cleanly. Returns the number of specs ensured.
+
+    ``db`` is a Motor ``AsyncIOMotorDatabase`` (or an API-compatible
+    async stand-in); ``create_index`` / ``drop_index`` are awaited.
+    """
+    for spec in specs:
+        collection = db[spec.collection]
+        kwargs = spec.create_kwargs()
+        try:
+            await collection.create_index(spec.keys, **kwargs)
+        except OperationFailure as exc:
+            if exc.code in _INDEX_CONFLICT_CODES:
+                logger.info(
+                    "Index %s.%s options changed; dropping and recreating",
+                    spec.collection,
+                    spec.name,
+                )
+                await collection.drop_index(spec.name)
+                await collection.create_index(spec.keys, **kwargs)
+            else:
+                raise
+    logger.info("Ensured %d index(es)", len(specs))
+    return len(specs)

--- a/src/cfdb/services/sync.py
+++ b/src/cfdb/services/sync.py
@@ -141,11 +141,13 @@ async def _sync_dccs(task: SyncTask) -> None:
     # Ensure the data-collection query indexes now that data is loaded.
     # Idempotent: a no-op on subsequent syncs. Kept out of API startup
     # (operational indexes only) so we never build these against an
-    # empty database on a cold start.
-    task.current_step = "indexing"
-    task.progress = "Ensuring data indexes..."
-    logger.info(task.progress)
-    await ensure_indexes(api.db, data_index_specs())
+    # empty database on a cold start; likewise skip when no DCC was
+    # actually synced so an empty request doesn't build them either.
+    if task.dcc_names:
+        task.current_step = "indexing"
+        task.progress = "Ensuring data indexes..."
+        logger.info(task.progress)
+        await ensure_indexes(api.db, data_index_specs())
 
     task.progress = "All DCCs synced successfully"
     logger.info(task.progress)

--- a/src/cfdb/services/sync.py
+++ b/src/cfdb/services/sync.py
@@ -22,6 +22,7 @@ from cfdb.dcc_registry import (
     normalize_dcc_name,
 )
 from cfdb.downloader import cleanup_zip, download_file, extract_zip
+from cfdb.indexes import data_index_specs, ensure_indexes
 from cfdb.services import locks
 
 logger = logging.getLogger(__name__)
@@ -136,6 +137,15 @@ async def _sync_dccs(task: SyncTask) -> None:
             await _sync_c2m2_zip(task, data_path, downloads_path)
 
         logger.info(f"{dcc.upper()} synced successfully")
+
+    # Ensure the data-collection query indexes now that data is loaded.
+    # Idempotent: a no-op on subsequent syncs. Kept out of API startup
+    # (operational indexes only) so we never build these against an
+    # empty database on a cold start.
+    task.current_step = "indexing"
+    task.progress = "Ensuring data indexes..."
+    logger.info(task.progress)
+    await ensure_indexes(api.db, data_index_specs())
 
     task.progress = "All DCCs synced successfully"
     logger.info(task.progress)

--- a/src/cfdb/workflows/lock.py
+++ b/src/cfdb/workflows/lock.py
@@ -217,6 +217,10 @@ async def claim_workflow(
             {
                 "$set": {
                     "status": JobStatus.FAILED.value,
+                    # Clear the mutex discriminator in lockstep with the
+                    # terminal status so the row leaves the partial-unique
+                    # index and a fresh claim can succeed.
+                    "active": False,
                     "error": "stale — reclaimed by later request",
                     "updated_at": now,
                 }
@@ -303,7 +307,9 @@ async def mark_running(db, job_id: str) -> None:
     now = _utcnow()
     result = await jobs.update_one(
         {"job_id": job_id, "status": JobStatus.PENDING.value},
-        {"$set": {"status": JobStatus.RUNNING.value, "updated_at": now}},
+        # PENDING→RUNNING stays active; re-assert ``active`` defensively so
+        # the discriminator can never drift from the status.
+        {"$set": {"status": JobStatus.RUNNING.value, "active": True, "updated_at": now}},
     )
     if getattr(result, "matched_count", 0) == 0:
         raise RuntimeError(
@@ -384,6 +390,9 @@ async def release_workflow(
     now = _utcnow()
     update: dict[str, Any] = {
         "status": final_status.value,
+        # Terminal status releases the mutex: drop the discriminator so the
+        # row leaves the partial-unique index and is eligible for TTL reap.
+        "active": False,
         "updated_at": now,
     }
     if error is not None:

--- a/src/cfdb/workflows/models.py
+++ b/src/cfdb/workflows/models.py
@@ -138,6 +138,15 @@ class JobRecord(BaseModel):
             "job_id": self.job_id,
             "workflow_key": self.workflow_key,
             "status": self.status.value,
+            # ``active`` is a pure DB projection of ``status`` (active ==
+            # status in ACTIVE_STATUSES). It backs the partial-filter
+            # predicates on the ``jobs`` indexes: Amazon DocumentDB rejects
+            # ``$in`` inside a partialFilterExpression, so the mutex /
+            # TTL indexes filter on this boolean with implicit equality
+            # ({"active": true}/{"active": false}) instead of a status
+            # ``$in`` list. ``lock.py`` keeps it in lockstep on every
+            # status-changing write.
+            "active": self.status in ACTIVE_STATUSES,
             "dcc": self.dcc,
             "local_id": self.local_id,
             "md5": self.md5,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -558,9 +558,7 @@ def install_jobs_index(mock_db):
     mock_db.jobs.create_index(
         {"workflow_key": 1},
         unique=True,
-        partialFilterExpression={
-            "status": {"$in": [s.value for s in ACTIVE_STATUSES]}
-        },
+        partialFilterExpression={"active": True},
     )
     return mock_db
 

--- a/tests/integration/test_mongo_partial_unique.py
+++ b/tests/integration/test_mongo_partial_unique.py
@@ -52,9 +52,7 @@ async def mongomock_db():
     await db[JOBS_COLLECTION].create_index(
         [("workflow_key", 1)],
         unique=True,
-        partialFilterExpression={
-            "status": {"$in": [s.value for s in ACTIVE_STATUSES]}
-        },
+        partialFilterExpression={"active": True},
     )
     yield db
 

--- a/tests/test_api/test_lifespan_indexes.py
+++ b/tests/test_api/test_lifespan_indexes.py
@@ -1,0 +1,73 @@
+"""Tests for the lifespan's operational-index self-heal."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from cfdb import api
+from cfdb.api import main
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lifespan_should_ensure_operational_indexes_without_workflows(mocker):
+    """Test startup creates the operational indexes when workflows are off.
+
+    Given:
+        A mongomock-motor database and the workflow subsystem disabled
+        (``WorkflowProfile.from_env`` returns None).
+    When:
+        The app lifespan starts up.
+    Then:
+        It should ensure the operational indexes — the workflow_key mutex
+        and locks.active — so a fresh database boots clean rather than
+        crash-looping, even with no workflow subsystem.
+    """
+    # Arrange
+    from mongomock_motor import AsyncMongoMockClient
+
+    client = AsyncMongoMockClient()
+    mocker.patch.object(main, "create_mongodb_client", return_value=client)
+    mocker.patch.object(main.WorkflowProfile, "from_env", return_value=None)
+
+    # Act
+    async with main.lifespan(main.app):
+        db = client[api.DATABASE_NAME]
+        jobs_info = await db.jobs.index_information()
+        locks_info = await db.locks.index_information()
+
+    # Assert
+    assert "workflow_key_active_unique" in jobs_info
+    assert "active_1" in locks_info
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lifespan_should_not_raise_when_mutex_index_present(mocker, caplog):
+    """Test startup does not warn once the mutex index is ensured.
+
+    Given:
+        A mongomock-motor database and the workflow subsystem disabled.
+    When:
+        The lifespan starts up (which ensures the indexes, then runs the
+        belt-and-suspenders desync check).
+    Then:
+        It should complete without raising and without logging the
+        mutex-out-of-sync warning, since ensure created the index first.
+    """
+    # Arrange
+    from mongomock_motor import AsyncMongoMockClient
+
+    client = AsyncMongoMockClient()
+    mocker.patch.object(main, "create_mongodb_client", return_value=client)
+    mocker.patch.object(main.WorkflowProfile, "from_env", return_value=None)
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        async with main.lifespan(main.app):
+            pass
+
+    # Assert
+    assert "partial-unique index missing or out of sync" not in caplog.text

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,23 +1,26 @@
 """CORS middleware tests for the FastAPI application."""
 
-from contextlib import asynccontextmanager
 from unittest.mock import patch
 
 import pytest
+from mongomock_motor import AsyncMongoMockClient
 from starlette.testclient import TestClient
-
-
-@asynccontextmanager
-async def _noop_lifespan(_app):
-    yield
 
 
 @pytest.fixture()
 def client():
-    with patch("cfdb.api.main.lifespan", _noop_lifespan):
-        from cfdb.api.main import app
+    # The app binds the real lifespan at import, so the lifespan runs on
+    # TestClient enter — and it ensures the operational indexes, which
+    # needs a database. Back it with an in-memory mongomock client and
+    # disable the workflow subsystem so the CORS test exercises only the
+    # middleware, no real MongoDB or wool pool.
+    from cfdb.api import main
 
-        with TestClient(app) as c:
+    with (
+        patch.object(main, "create_mongodb_client", return_value=AsyncMongoMockClient()),
+        patch.object(main.WorkflowProfile, "from_env", return_value=None),
+    ):
+        with TestClient(main.app) as c:
             yield c
 
 

--- a/tests/test_ensure_indexes.py
+++ b/tests/test_ensure_indexes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from click.testing import CliRunner
 
+from cfdb import api as cfg
 from cfdb import ensure_indexes as ei
 from cfdb.indexes import all_index_specs, data_index_specs, operational_index_specs
 
@@ -67,6 +68,65 @@ def test_main_should_default_to_all_scope(mocker):
     assert result.exit_code == 0
     passed_specs = ensure_mock.await_args.args[1]
     assert [s.name for s in passed_specs] == [s.name for s in all_index_specs()]
+
+
+@pytest.mark.asyncio
+async def test_run_should_build_a_tls_client_when_tls_enabled(mocker):
+    """Test run() honors the MongoDB TLS env config.
+
+    Given:
+        ``MONGODB_TLS_ENABLED`` set with a CA path and the applier mocked.
+    When:
+        ``run`` is awaited.
+    Then:
+        It should construct the Motor client with TLS + CA file, return
+        the ensured count, and close the client.
+    """
+    # Arrange
+    mocker.patch.object(cfg, "MONGODB_TLS_ENABLED", True)
+    mocker.patch.object(cfg, "MONGODB_CA_PATH", "/ca.pem")
+    mocker.patch.object(cfg, "MONGODB_RETRY_WRITES", False)
+    client = mocker.MagicMock()
+    factory = mocker.patch.object(ei, "AsyncIOMotorClient", return_value=client)
+    mocker.patch.object(ei, "ensure_indexes", mocker.AsyncMock(return_value=3))
+
+    # Act
+    count = await ei.run("operational")
+
+    # Assert
+    assert count == 3
+    _, kwargs = factory.call_args
+    assert kwargs.get("tls") is True
+    assert kwargs.get("tlsCAFile") == "/ca.pem"
+    assert kwargs.get("retryWrites") is False
+    client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_should_build_a_plain_client_when_tls_disabled(mocker):
+    """Test run() builds a plaintext client when TLS is off.
+
+    Given:
+        ``MONGODB_TLS_ENABLED`` false and the applier mocked.
+    When:
+        ``run`` is awaited.
+    Then:
+        It should construct the client without TLS options.
+    """
+    # Arrange
+    mocker.patch.object(cfg, "MONGODB_TLS_ENABLED", False)
+    mocker.patch.object(cfg, "MONGODB_RETRY_WRITES", False)
+    client = mocker.MagicMock()
+    factory = mocker.patch.object(ei, "AsyncIOMotorClient", return_value=client)
+    mocker.patch.object(ei, "ensure_indexes", mocker.AsyncMock(return_value=0))
+
+    # Act
+    await ei.run("all")
+
+    # Assert
+    _, kwargs = factory.call_args
+    assert "tls" not in kwargs
+    assert kwargs.get("retryWrites") is False
 
 
 def test_main_should_reject_unknown_scope(mocker):

--- a/tests/test_ensure_indexes.py
+++ b/tests/test_ensure_indexes.py
@@ -1,0 +1,115 @@
+"""Tests for the ``cfdb.ensure_indexes`` operator CLI."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from cfdb import ensure_indexes as ei
+from cfdb.indexes import all_index_specs, data_index_specs, operational_index_specs
+
+
+@pytest.mark.parametrize(
+    "scope, builder",
+    [
+        ("operational", operational_index_specs),
+        ("data", data_index_specs),
+        ("all", all_index_specs),
+    ],
+)
+def test_main_should_ensure_the_selected_scope(mocker, scope, builder):
+    """Test the CLI ensures the index set named by ``--scope``.
+
+    Given:
+        The CLI with the Mongo client and applier mocked at the boundary.
+    When:
+        ``main`` is invoked with a ``--scope`` value.
+    Then:
+        It should pass that scope's specs to ensure_indexes and exit 0.
+    """
+    # Arrange
+    ensure_mock = mocker.patch.object(
+        ei, "ensure_indexes", mocker.AsyncMock(return_value=len(builder()))
+    )
+    mocker.patch.object(ei, "AsyncIOMotorClient")
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(ei.main, ["--scope", scope])
+
+    # Assert
+    assert result.exit_code == 0
+    passed_specs = ensure_mock.await_args.args[1]
+    assert [s.name for s in passed_specs] == [s.name for s in builder()]
+
+
+def test_main_should_default_to_all_scope(mocker):
+    """Test the CLI ensures every index when no scope is given.
+
+    Given:
+        The CLI invoked with no ``--scope`` flag.
+    When:
+        ``main`` runs.
+    Then:
+        It should ensure the combined operational + data spec set.
+    """
+    # Arrange
+    ensure_mock = mocker.patch.object(
+        ei, "ensure_indexes", mocker.AsyncMock(return_value=1)
+    )
+    mocker.patch.object(ei, "AsyncIOMotorClient")
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(ei.main, [])
+
+    # Assert
+    assert result.exit_code == 0
+    passed_specs = ensure_mock.await_args.args[1]
+    assert [s.name for s in passed_specs] == [s.name for s in all_index_specs()]
+
+
+def test_main_should_reject_unknown_scope(mocker):
+    """Test an invalid scope is rejected before any DB work.
+
+    Given:
+        The CLI invoked with a scope outside the allowed choices.
+    When:
+        ``main`` runs.
+    Then:
+        It should exit non-zero and never build a client.
+    """
+    # Arrange
+    client_factory = mocker.patch.object(ei, "AsyncIOMotorClient")
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(ei.main, ["--scope", "bogus"])
+
+    # Assert
+    assert result.exit_code != 0
+    client_factory.assert_not_called()
+
+
+def test_main_should_close_the_client(mocker):
+    """Test the Mongo client is closed after ensuring indexes.
+
+    Given:
+        The CLI with the applier mocked and a stand-in Mongo client.
+    When:
+        ``main`` completes successfully.
+    Then:
+        It should close the client it opened.
+    """
+    # Arrange
+    mocker.patch.object(ei, "ensure_indexes", mocker.AsyncMock(return_value=0))
+    client = mocker.MagicMock()
+    mocker.patch.object(ei, "AsyncIOMotorClient", return_value=client)
+    runner = CliRunner()
+
+    # Act
+    result = runner.invoke(ei.main, ["--scope", "operational"])
+
+    # Assert
+    assert result.exit_code == 0
+    client.close.assert_called_once()

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -1,0 +1,418 @@
+"""Tests for the app-owned index definitions and applier."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pymongo.errors import OperationFailure
+
+from cfdb.indexes import (
+    IndexSpec,
+    all_index_specs,
+    data_index_specs,
+    ensure_indexes,
+    operational_index_specs,
+)
+from cfdb.workflows.models import ACTIVE_STATUSES, JobStatus
+
+#: The hand-maintained JS bootstrap kept for the local mongo image. The
+#: lockstep tests pin its operational specs to the Python source of truth.
+_CREATE_INDEXES_JS = (
+    Path(__file__).resolve().parents[1] / "scripts" / "create-indexes.js"
+)
+
+
+def _spec_by_name(specs: list[IndexSpec], name: str) -> IndexSpec:
+    """Return the single spec named ``name`` (KeyError-style assert if absent)."""
+    matches = [s for s in specs if s.name == name]
+    assert len(matches) == 1, f"expected exactly one spec named {name}"
+    return matches[0]
+
+
+def _js_array(values: list[str]) -> str:
+    """Render values the way create-indexes.js renders a ``$in`` array."""
+    return "[" + ", ".join(f'"{v}"' for v in values) + "]"
+
+
+class TestIndexSpec:
+    def test___init___should_derive_default_name_when_name_omitted(self):
+        """Test that an unnamed spec gets MongoDB's default index name.
+
+        Given:
+            An IndexSpec built with a compound key and no explicit name.
+        When:
+            The spec is constructed.
+        Then:
+            It should derive the ``field_dir_field_dir`` name MongoDB
+            would assign to an otherwise-unnamed index.
+        """
+        # Act
+        spec = IndexSpec("file", [("id_namespace", 1), ("local_id", 1)])
+
+        # Assert
+        assert spec.name == "id_namespace_1_local_id_1"
+
+    def test___init___should_keep_explicit_name(self):
+        """Test that an explicit name is preserved.
+
+        Given:
+            An IndexSpec built with an explicit ``name``.
+        When:
+            The spec is constructed.
+        Then:
+            It should keep the provided name rather than deriving one.
+        """
+        # Act
+        spec = IndexSpec("jobs", [("workflow_key", 1)], name="workflow_key_active_unique")
+
+        # Assert
+        assert spec.name == "workflow_key_active_unique"
+
+    def test_create_kwargs_should_include_only_set_options(self):
+        """Test that create_kwargs omits unset options.
+
+        Given:
+            A plain single-field spec with no unique/partial/TTL options.
+        When:
+            ``create_kwargs`` is called.
+        Then:
+            It should contain only the index name.
+        """
+        # Arrange
+        spec = IndexSpec("file", [("filename", 1)])
+
+        # Act
+        kwargs = spec.create_kwargs()
+
+        # Assert
+        assert kwargs == {"name": "filename_1"}
+
+    def test_create_kwargs_should_render_partial_unique_ttl_options(self):
+        """Test that create_kwargs renders unique, partial, and TTL options.
+
+        Given:
+            A spec with unique, partialFilterExpression, and TTL set.
+        When:
+            ``create_kwargs`` is called.
+        Then:
+            It should map each onto the pymongo keyword arguments.
+        """
+        # Arrange
+        spec = IndexSpec(
+            "jobs",
+            [("updated_at", 1)],
+            name="terminal_ttl",
+            unique=True,
+            partial_filter={"status": {"$in": ["completed"]}},
+            expire_after_seconds=10,
+        )
+
+        # Act
+        kwargs = spec.create_kwargs()
+
+        # Assert
+        assert kwargs == {
+            "name": "terminal_ttl",
+            "unique": True,
+            "partialFilterExpression": {"status": {"$in": ["completed"]}},
+            "expireAfterSeconds": 10,
+        }
+
+
+class TestOperationalIndexSpecs:
+    def test_operational_index_specs_should_derive_mutex_filter_from_active_statuses(self):
+        """Test the workflow_key mutex index tracks ACTIVE_STATUSES.
+
+        Given:
+            The operational index specs.
+        When:
+            The ``workflow_key_active_unique`` spec is inspected.
+        Then:
+            It should be a unique partial index whose ``$in`` filter is
+            exactly the active status values, in lockstep with the enum.
+        """
+        # Arrange
+        specs = operational_index_specs()
+        expected_active = [s.value for s in ACTIVE_STATUSES]
+
+        # Act
+        spec = _spec_by_name(specs, "workflow_key_active_unique")
+
+        # Assert
+        assert spec.collection == "jobs"
+        assert spec.keys == [("workflow_key", 1)]
+        assert spec.unique is True
+        assert spec.partial_filter == {"status": {"$in": expected_active}}
+
+    def test_operational_index_specs_should_derive_ttl_filter_from_terminal_statuses(self):
+        """Test the terminal_ttl index covers the complement of active.
+
+        Given:
+            The operational index specs.
+        When:
+            The ``terminal_ttl`` spec is inspected.
+        Then:
+            It should be a TTL index whose ``$in`` filter is exactly the
+            non-active (terminal) status values.
+        """
+        # Arrange
+        specs = operational_index_specs()
+        expected_terminal = [s.value for s in JobStatus if s not in ACTIVE_STATUSES]
+
+        # Act
+        spec = _spec_by_name(specs, "terminal_ttl")
+
+        # Assert
+        assert spec.expire_after_seconds == 60 * 60 * 24 * 7
+        assert spec.partial_filter == {"status": {"$in": expected_terminal}}
+
+    def test_operational_index_specs_should_include_locks_active(self):
+        """Test the operational set includes the locks.active index.
+
+        Given:
+            The operational index specs.
+        When:
+            The specs are filtered to the ``locks`` collection.
+        Then:
+            It should include the ``active_1`` index.
+        """
+        # Act
+        specs = operational_index_specs()
+
+        # Assert
+        locks = [s for s in specs if s.collection == "locks"]
+        assert [s.name for s in locks] == ["active_1"]
+
+
+class TestDataIndexSpecs:
+    def test_data_index_specs_should_cover_core_collections(self):
+        """Test the data specs cover the materialized C2M2 collections.
+
+        Given:
+            The data index specs.
+        When:
+            The set of collections they target is collected.
+        Then:
+            It should include the central queryable collections.
+        """
+        # Act
+        collections = {s.collection for s in data_index_specs()}
+
+        # Assert
+        assert {"file", "dcc", "biosample", "collection", "project"} <= collections
+
+    def test_data_index_specs_should_mark_ontology_submission_id_unique(self):
+        """Test ontology collections get a unique (submission, id) index.
+
+        Given:
+            The data index specs.
+        When:
+            The ``file_format`` composite (submission, id) spec is found.
+        Then:
+            It should be marked unique (one term per DCC submission).
+        """
+        # Arrange
+        specs = data_index_specs()
+
+        # Act
+        spec = _spec_by_name(
+            [s for s in specs if s.collection == "file_format"],
+            "submission_1_id_1",
+        )
+
+        # Assert
+        assert spec.unique is True
+
+    def test_all_index_specs_should_concatenate_operational_then_data(self):
+        """Test all_index_specs is operational followed by data.
+
+        Given:
+            The operational, data, and combined spec lists.
+        When:
+            Their lengths and ordering are compared.
+        Then:
+            all_index_specs should equal operational + data.
+        """
+        # Act
+        combined = all_index_specs()
+
+        # Assert
+        assert combined == operational_index_specs() + data_index_specs()
+
+
+class TestCreateIndexesJsLockstep:
+    def test_create_indexes_js_should_match_active_status_filter(self):
+        """Test the JS mutex predicate matches ACTIVE_STATUSES.
+
+        Given:
+            The committed scripts/create-indexes.js and the Python active
+            status values.
+        When:
+            The JS source is read.
+        Then:
+            It should contain the active-status ``$in`` array the Python
+            workflow_key spec produces, so the two can't drift.
+        """
+        # Arrange
+        js = _CREATE_INDEXES_JS.read_text()
+        active = [s.value for s in ACTIVE_STATUSES]
+
+        # Assert
+        assert _js_array(active) in js
+
+    def test_create_indexes_js_should_match_terminal_status_filter(self):
+        """Test the JS TTL predicate matches the terminal status set.
+
+        Given:
+            The committed scripts/create-indexes.js and the Python
+            terminal status values.
+        When:
+            The JS source is read.
+        Then:
+            It should contain the terminal-status ``$in`` array the
+            Python terminal_ttl spec produces.
+        """
+        # Arrange
+        js = _CREATE_INDEXES_JS.read_text()
+        terminal = [s.value for s in JobStatus if s not in ACTIVE_STATUSES]
+
+        # Assert
+        assert _js_array(terminal) in js
+
+    def test_create_indexes_js_should_define_all_operational_index_names(self):
+        """Test the JS defines every named operational index.
+
+        Given:
+            The committed scripts/create-indexes.js and the operational
+            specs that carry explicit names.
+        When:
+            The JS source is read.
+        Then:
+            It should reference each named operational index, so the
+            local-mongo bootstrap stays in lockstep with the app.
+        """
+        # Arrange
+        js = _CREATE_INDEXES_JS.read_text()
+        named = [
+            "workflow_key_active_unique",
+            "job_id_unique",
+            "status_updated_at",
+            "terminal_ttl",
+        ]
+
+        # Assert
+        for name in named:
+            assert name in js
+        assert "db.locks.createIndex({ active: 1 })" in js
+
+
+class TestEnsureIndexes:
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_should_create_specs(self):
+        """Test ensure_indexes creates the requested indexes.
+
+        Given:
+            A fresh in-memory Mongo (mongomock-motor) and the operational
+            specs.
+        When:
+            ensure_indexes is awaited.
+        Then:
+            It should create each index and report the count ensured.
+        """
+        # Arrange
+        from mongomock_motor import AsyncMongoMockClient
+
+        db = AsyncMongoMockClient()["test"]
+        specs = operational_index_specs()
+
+        # Act
+        count = await ensure_indexes(db, specs)
+
+        # Assert
+        assert count == len(specs)
+        info = await db.jobs.index_information()
+        assert "workflow_key_active_unique" in info
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_should_be_idempotent_on_repeat(self):
+        """Test a second ensure_indexes call is a no-op.
+
+        Given:
+            A database that already has the operational indexes ensured.
+        When:
+            ensure_indexes is awaited a second time with the same specs.
+        Then:
+            It should succeed without error and report the same count.
+        """
+        # Arrange
+        from mongomock_motor import AsyncMongoMockClient
+
+        db = AsyncMongoMockClient()["test"]
+        specs = operational_index_specs()
+        await ensure_indexes(db, specs)
+
+        # Act
+        count = await ensure_indexes(db, specs)
+
+        # Assert
+        assert count == len(specs)
+
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_should_drop_and_recreate_on_options_conflict(
+        self, mocker
+    ):
+        """Test a changed index spec is dropped and recreated.
+
+        Given:
+            A collection whose create_index first raises an
+            IndexOptionsConflict (code 85) then succeeds.
+        When:
+            ensure_indexes is awaited with that spec.
+        Then:
+            It should drop the named index and recreate it.
+        """
+        # Arrange
+        collection = mocker.Mock()
+        collection.create_index = mocker.AsyncMock(
+            side_effect=[OperationFailure("conflict", 85), None]
+        )
+        collection.drop_index = mocker.AsyncMock()
+        db = {"jobs": collection}
+        spec = IndexSpec("jobs", [("job_id", 1)], name="job_id_unique", unique=True)
+
+        # Act
+        count = await ensure_indexes(db, [spec])
+
+        # Assert
+        assert count == 1
+        collection.drop_index.assert_awaited_once_with("job_id_unique")
+        assert collection.create_index.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_should_reraise_unexpected_failure(self, mocker):
+        """Test an unrelated OperationFailure is not swallowed.
+
+        Given:
+            A collection whose create_index raises a non-conflict
+            OperationFailure (e.g. an auth error, code 13).
+        When:
+            ensure_indexes is awaited.
+        Then:
+            It should propagate the error rather than drop the index.
+        """
+        # Arrange
+        collection = mocker.Mock()
+        collection.create_index = mocker.AsyncMock(
+            side_effect=OperationFailure("unauthorized", 13)
+        )
+        collection.drop_index = mocker.AsyncMock()
+        db = {"jobs": collection}
+        spec = IndexSpec("jobs", [("job_id", 1)], name="job_id_unique")
+
+        # Act & assert
+        with pytest.raises(OperationFailure):
+            await ensure_indexes(db, [spec])
+        collection.drop_index.assert_not_awaited()

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -14,25 +15,68 @@ from cfdb.indexes import (
     ensure_indexes,
     operational_index_specs,
 )
-from cfdb.workflows.models import ACTIVE_STATUSES, JobStatus
 
 #: The hand-maintained JS bootstrap kept for the local mongo image. The
-#: lockstep tests pin its operational specs to the Python source of truth.
+#: lockstep tests pin its specs to the Python source of truth.
 _CREATE_INDEXES_JS = (
     Path(__file__).resolve().parents[1] / "scripts" / "create-indexes.js"
 )
+_JS = _CREATE_INDEXES_JS.read_text()
 
 
 def _spec_by_name(specs: list[IndexSpec], name: str) -> IndexSpec:
-    """Return the single spec named ``name`` (KeyError-style assert if absent)."""
+    """Return the single spec named ``name`` (asserts uniqueness)."""
     matches = [s for s in specs if s.name == name]
     assert len(matches) == 1, f"expected exactly one spec named {name}"
     return matches[0]
 
 
-def _js_array(values: list[str]) -> str:
-    """Render values the way create-indexes.js renders a ``$in`` array."""
-    return "[" + ", ".join(f'"{v}"' for v in values) + "]"
+def _js_active_predicate(name: str) -> bool | None:
+    """Read the ``active`` partial-filter bool for a named JS jobs index.
+
+    Returns True/False for ``partialFilterExpression: { active: <bool> }``
+    or None when the named index or predicate isn't found.
+    """
+    m = re.search(
+        r'name:\s*"'
+        + re.escape(name)
+        + r'".*?partialFilterExpression:\s*\{\s*active:\s*(true|false)\s*\}',
+        _JS,
+        re.DOTALL,
+    )
+    return None if m is None else (m.group(1) == "true")
+
+
+def _parse_js_keys(src: str) -> tuple[tuple[str, int], ...]:
+    """Parse a JS key object body like ``id_namespace: 1, local_id: 1``."""
+    keys: list[tuple[str, int]] = []
+    for part in src.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        field, _, direction = part.partition(":")
+        keys.append((field.strip(), int(direction.strip())))
+    return tuple(keys)
+
+
+def _parse_js_data_indexes() -> set[tuple[str, tuple[tuple[str, int], ...], bool]]:
+    """Parse ``db.<coll>.createIndex(...)`` calls into a comparable set.
+
+    Excludes the operational collections (``jobs`` uses the ``ensureIndex``
+    helper, not ``createIndex``; ``locks`` is operational) so the result
+    mirrors ``data_index_specs()``.
+    """
+    pattern = re.compile(
+        r"db\.(\w+)\.createIndex\(\s*\{([^}]*)\}\s*(?:,\s*\{([^}]*)\})?\s*\)"
+    )
+    result: set[tuple[str, tuple[tuple[str, int], ...], bool]] = set()
+    for match in pattern.finditer(_JS):
+        collection, keys_src, opts_src = match.group(1), match.group(2), match.group(3)
+        if collection in ("jobs", "locks"):
+            continue
+        unique = "unique:true" in (opts_src or "").replace(" ", "")
+        result.add((collection, _parse_js_keys(keys_src), unique))
+    return result
 
 
 class TestIndexSpec:
@@ -52,6 +96,23 @@ class TestIndexSpec:
 
         # Assert
         assert spec.name == "id_namespace_1_local_id_1"
+
+    def test___init___should_coerce_keys_to_tuple(self):
+        """Test that a list of keys is normalized to a tuple.
+
+        Given:
+            An IndexSpec built with a list of key pairs.
+        When:
+            The spec is constructed.
+        Then:
+            It should store ``keys`` as a tuple of tuples so the frozen
+            spec holds only immutable data.
+        """
+        # Act
+        spec = IndexSpec("file", [("filename", 1)])
+
+        # Assert
+        assert spec.keys == (("filename", 1),)
 
     def test___init___should_keep_explicit_name(self):
         """Test that an explicit name is preserved.
@@ -104,7 +165,7 @@ class TestIndexSpec:
             [("updated_at", 1)],
             name="terminal_ttl",
             unique=True,
-            partial_filter={"status": {"$in": ["completed"]}},
+            partial_filter={"active": False},
             expire_after_seconds=10,
         )
 
@@ -115,304 +176,423 @@ class TestIndexSpec:
         assert kwargs == {
             "name": "terminal_ttl",
             "unique": True,
-            "partialFilterExpression": {"status": {"$in": ["completed"]}},
+            "partialFilterExpression": {"active": False},
             "expireAfterSeconds": 10,
         }
 
 
-class TestOperationalIndexSpecs:
-    def test_operational_index_specs_should_derive_mutex_filter_from_active_statuses(self):
-        """Test the workflow_key mutex index tracks ACTIVE_STATUSES.
+def test_operational_index_specs_should_filter_mutex_on_active_true():
+    """Test the workflow_key mutex index filters on active=True.
 
-        Given:
-            The operational index specs.
-        When:
-            The ``workflow_key_active_unique`` spec is inspected.
-        Then:
-            It should be a unique partial index whose ``$in`` filter is
-            exactly the active status values, in lockstep with the enum.
-        """
-        # Arrange
-        specs = operational_index_specs()
-        expected_active = [s.value for s in ACTIVE_STATUSES]
+    Given:
+        The operational index specs.
+    When:
+        The ``workflow_key_active_unique`` spec is inspected.
+    Then:
+        It should be a unique partial index whose filter is the
+        DocumentDB-safe implicit-equality predicate ``{"active": True}``
+        (no ``$in``).
+    """
+    # Arrange
+    specs = operational_index_specs()
 
-        # Act
-        spec = _spec_by_name(specs, "workflow_key_active_unique")
+    # Act
+    spec = _spec_by_name(specs, "workflow_key_active_unique")
 
-        # Assert
-        assert spec.collection == "jobs"
-        assert spec.keys == [("workflow_key", 1)]
-        assert spec.unique is True
-        assert spec.partial_filter == {"status": {"$in": expected_active}}
-
-    def test_operational_index_specs_should_derive_ttl_filter_from_terminal_statuses(self):
-        """Test the terminal_ttl index covers the complement of active.
-
-        Given:
-            The operational index specs.
-        When:
-            The ``terminal_ttl`` spec is inspected.
-        Then:
-            It should be a TTL index whose ``$in`` filter is exactly the
-            non-active (terminal) status values.
-        """
-        # Arrange
-        specs = operational_index_specs()
-        expected_terminal = [s.value for s in JobStatus if s not in ACTIVE_STATUSES]
-
-        # Act
-        spec = _spec_by_name(specs, "terminal_ttl")
-
-        # Assert
-        assert spec.expire_after_seconds == 60 * 60 * 24 * 7
-        assert spec.partial_filter == {"status": {"$in": expected_terminal}}
-
-    def test_operational_index_specs_should_include_locks_active(self):
-        """Test the operational set includes the locks.active index.
-
-        Given:
-            The operational index specs.
-        When:
-            The specs are filtered to the ``locks`` collection.
-        Then:
-            It should include the ``active_1`` index.
-        """
-        # Act
-        specs = operational_index_specs()
-
-        # Assert
-        locks = [s for s in specs if s.collection == "locks"]
-        assert [s.name for s in locks] == ["active_1"]
+    # Assert
+    assert spec.collection == "jobs"
+    assert spec.keys == (("workflow_key", 1),)
+    assert spec.unique is True
+    assert spec.partial_filter == {"active": True}
 
 
-class TestDataIndexSpecs:
-    def test_data_index_specs_should_cover_core_collections(self):
-        """Test the data specs cover the materialized C2M2 collections.
+def test_operational_index_specs_should_filter_ttl_on_active_false():
+    """Test the terminal_ttl index filters on active=False.
 
-        Given:
-            The data index specs.
-        When:
-            The set of collections they target is collected.
-        Then:
-            It should include the central queryable collections.
-        """
-        # Act
-        collections = {s.collection for s in data_index_specs()}
+    Given:
+        The operational index specs.
+    When:
+        The ``terminal_ttl`` spec is inspected.
+    Then:
+        It should be a TTL index whose filter is ``{"active": False}``.
+    """
+    # Arrange
+    specs = operational_index_specs()
 
-        # Assert
-        assert {"file", "dcc", "biosample", "collection", "project"} <= collections
+    # Act
+    spec = _spec_by_name(specs, "terminal_ttl")
 
-    def test_data_index_specs_should_mark_ontology_submission_id_unique(self):
-        """Test ontology collections get a unique (submission, id) index.
-
-        Given:
-            The data index specs.
-        When:
-            The ``file_format`` composite (submission, id) spec is found.
-        Then:
-            It should be marked unique (one term per DCC submission).
-        """
-        # Arrange
-        specs = data_index_specs()
-
-        # Act
-        spec = _spec_by_name(
-            [s for s in specs if s.collection == "file_format"],
-            "submission_1_id_1",
-        )
-
-        # Assert
-        assert spec.unique is True
-
-    def test_all_index_specs_should_concatenate_operational_then_data(self):
-        """Test all_index_specs is operational followed by data.
-
-        Given:
-            The operational, data, and combined spec lists.
-        When:
-            Their lengths and ordering are compared.
-        Then:
-            all_index_specs should equal operational + data.
-        """
-        # Act
-        combined = all_index_specs()
-
-        # Assert
-        assert combined == operational_index_specs() + data_index_specs()
+    # Assert
+    assert spec.expire_after_seconds == 60 * 60 * 24 * 7
+    assert spec.partial_filter == {"active": False}
 
 
-class TestCreateIndexesJsLockstep:
-    def test_create_indexes_js_should_match_active_status_filter(self):
-        """Test the JS mutex predicate matches ACTIVE_STATUSES.
+def test_operational_index_specs_should_not_use_in_operator():
+    """Test no operational partial filter uses the $in operator.
 
-        Given:
-            The committed scripts/create-indexes.js and the Python active
-            status values.
-        When:
-            The JS source is read.
-        Then:
-            It should contain the active-status ``$in`` array the Python
-            workflow_key spec produces, so the two can't drift.
-        """
-        # Arrange
-        js = _CREATE_INDEXES_JS.read_text()
-        active = [s.value for s in ACTIVE_STATUSES]
+    Given:
+        The operational index specs (DocumentDB rejects $in in a
+        partialFilterExpression).
+    When:
+        Their partial filters are inspected.
+    Then:
+        None should contain a ``$in`` clause.
+    """
+    # Act
+    filters = [s.partial_filter for s in operational_index_specs() if s.partial_filter]
 
-        # Assert
-        assert _js_array(active) in js
-
-    def test_create_indexes_js_should_match_terminal_status_filter(self):
-        """Test the JS TTL predicate matches the terminal status set.
-
-        Given:
-            The committed scripts/create-indexes.js and the Python
-            terminal status values.
-        When:
-            The JS source is read.
-        Then:
-            It should contain the terminal-status ``$in`` array the
-            Python terminal_ttl spec produces.
-        """
-        # Arrange
-        js = _CREATE_INDEXES_JS.read_text()
-        terminal = [s.value for s in JobStatus if s not in ACTIVE_STATUSES]
-
-        # Assert
-        assert _js_array(terminal) in js
-
-    def test_create_indexes_js_should_define_all_operational_index_names(self):
-        """Test the JS defines every named operational index.
-
-        Given:
-            The committed scripts/create-indexes.js and the operational
-            specs that carry explicit names.
-        When:
-            The JS source is read.
-        Then:
-            It should reference each named operational index, so the
-            local-mongo bootstrap stays in lockstep with the app.
-        """
-        # Arrange
-        js = _CREATE_INDEXES_JS.read_text()
-        named = [
-            "workflow_key_active_unique",
-            "job_id_unique",
-            "status_updated_at",
-            "terminal_ttl",
-        ]
-
-        # Assert
-        for name in named:
-            assert name in js
-        assert "db.locks.createIndex({ active: 1 })" in js
+    # Assert
+    assert all("$in" not in repr(f) for f in filters)
 
 
-class TestEnsureIndexes:
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_ensure_indexes_should_create_specs(self):
-        """Test ensure_indexes creates the requested indexes.
+def test_operational_index_specs_should_include_locks_active():
+    """Test the operational set includes the locks.active index.
 
-        Given:
-            A fresh in-memory Mongo (mongomock-motor) and the operational
-            specs.
-        When:
-            ensure_indexes is awaited.
-        Then:
-            It should create each index and report the count ensured.
-        """
-        # Arrange
-        from mongomock_motor import AsyncMongoMockClient
+    Given:
+        The operational index specs.
+    When:
+        The specs are filtered to the ``locks`` collection.
+    Then:
+        It should include the ``active_1`` index.
+    """
+    # Act
+    specs = operational_index_specs()
 
-        db = AsyncMongoMockClient()["test"]
-        specs = operational_index_specs()
+    # Assert
+    locks = [s for s in specs if s.collection == "locks"]
+    assert [s.name for s in locks] == ["active_1"]
 
-        # Act
-        count = await ensure_indexes(db, specs)
 
-        # Assert
-        assert count == len(specs)
-        info = await db.jobs.index_information()
-        assert "workflow_key_active_unique" in info
+def test_data_index_specs_should_cover_core_collections():
+    """Test the data specs cover the materialized C2M2 collections.
 
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    async def test_ensure_indexes_should_be_idempotent_on_repeat(self):
-        """Test a second ensure_indexes call is a no-op.
+    Given:
+        The data index specs.
+    When:
+        The set of collections they target is collected.
+    Then:
+        It should include the central queryable collections.
+    """
+    # Act
+    collections = {s.collection for s in data_index_specs()}
 
-        Given:
-            A database that already has the operational indexes ensured.
-        When:
-            ensure_indexes is awaited a second time with the same specs.
-        Then:
-            It should succeed without error and report the same count.
-        """
-        # Arrange
-        from mongomock_motor import AsyncMongoMockClient
+    # Assert
+    assert {"file", "dcc", "biosample", "collection", "project"} <= collections
 
-        db = AsyncMongoMockClient()["test"]
-        specs = operational_index_specs()
-        await ensure_indexes(db, specs)
 
-        # Act
-        count = await ensure_indexes(db, specs)
+def test_data_index_specs_should_mark_ontology_submission_id_unique():
+    """Test ontology collections get a unique (submission, id) index.
 
-        # Assert
-        assert count == len(specs)
+    Given:
+        The data index specs.
+    When:
+        The ``file_format`` composite (submission, id) spec is found.
+    Then:
+        It should be marked unique (one term per DCC submission).
+    """
+    # Arrange
+    specs = data_index_specs()
 
-    @pytest.mark.asyncio
-    async def test_ensure_indexes_should_drop_and_recreate_on_options_conflict(
-        self, mocker
+    # Act
+    spec = _spec_by_name(
+        [s for s in specs if s.collection == "file_format"],
+        "submission_1_id_1",
+    )
+
+    # Assert
+    assert spec.unique is True
+
+
+def test_all_index_specs_should_concatenate_operational_then_data():
+    """Test all_index_specs is operational followed by data.
+
+    Given:
+        The operational, data, and combined spec lists.
+    When:
+        Their ordering is compared.
+    Then:
+        all_index_specs should equal operational + data.
+    """
+    # Act
+    combined = all_index_specs()
+
+    # Assert
+    assert combined == operational_index_specs() + data_index_specs()
+
+
+def test_create_indexes_js_should_not_use_in_in_partial_filters():
+    """Test the JS bootstrap has no $in (DocumentDB-incompatible).
+
+    Given:
+        The committed scripts/create-indexes.js.
+    When:
+        The source is scanned.
+    Then:
+        Its executable code (comments stripped) should contain no ``$in``
+        operator, since DocumentDB rejects ``$in`` inside a
+        partialFilterExpression.
+    """
+    # Arrange
+    code = re.sub(r"//.*", "", _JS)
+
+    # Assert
+    assert "$in" not in code
+
+
+def test_create_indexes_js_operational_predicates_should_match_python():
+    """Test the JS jobs partial predicates match the Python specs.
+
+    Given:
+        The committed JS and the operational specs.
+    When:
+        The JS ``active`` predicates for the named jobs indexes are read.
+    Then:
+        They should equal the Python specs' ``active`` filter values, so
+        the local-mongo bootstrap can't drift from the app.
+    """
+    # Arrange
+    specs = {s.name: s for s in operational_index_specs()}
+
+    # Assert
+    assert (
+        _js_active_predicate("workflow_key_active_unique")
+        is specs["workflow_key_active_unique"].partial_filter["active"]
+    )
+    assert (
+        _js_active_predicate("terminal_ttl")
+        is specs["terminal_ttl"].partial_filter["active"]
+    )
+
+
+def test_create_indexes_js_should_define_all_operational_index_names():
+    """Test the JS defines every named operational index.
+
+    Given:
+        The committed JS and the operational specs that carry names.
+    When:
+        The JS source is read.
+    Then:
+        It should reference each named operational index and the
+        locks.active index.
+    """
+    # Assert
+    for name in (
+        "workflow_key_active_unique",
+        "job_id_unique",
+        "status_updated_at",
+        "terminal_ttl",
     ):
-        """Test a changed index spec is dropped and recreated.
+        assert name in _JS
+    assert "db.locks.createIndex({ active: 1 })" in _JS
 
-        Given:
-            A collection whose create_index first raises an
-            IndexOptionsConflict (code 85) then succeeds.
-        When:
-            ensure_indexes is awaited with that spec.
-        Then:
-            It should drop the named index and recreate it.
-        """
-        # Arrange
-        collection = mocker.Mock()
-        collection.create_index = mocker.AsyncMock(
-            side_effect=[OperationFailure("conflict", 85), None]
-        )
-        collection.drop_index = mocker.AsyncMock()
-        db = {"jobs": collection}
-        spec = IndexSpec("jobs", [("job_id", 1)], name="job_id_unique", unique=True)
 
-        # Act
-        count = await ensure_indexes(db, [spec])
+def test_create_indexes_js_data_indexes_should_match_python():
+    """Test the JS data indexes stay in lockstep with data_index_specs.
 
-        # Assert
-        assert count == 1
-        collection.drop_index.assert_awaited_once_with("job_id_unique")
-        assert collection.create_index.await_count == 2
+    Given:
+        The data createIndex calls parsed from the committed JS and the
+        Python data specs.
+    When:
+        Both are reduced to (collection, keys, unique) sets.
+    Then:
+        The two sets should be equal, guarding drift in the ~150 data
+        indexes the local-mongo image bootstraps.
+    """
+    # Arrange
+    py_set = {(s.collection, s.keys, s.unique) for s in data_index_specs()}
 
-    @pytest.mark.asyncio
-    async def test_ensure_indexes_should_reraise_unexpected_failure(self, mocker):
-        """Test an unrelated OperationFailure is not swallowed.
+    # Act
+    js_set = _parse_js_data_indexes()
 
-        Given:
-            A collection whose create_index raises a non-conflict
-            OperationFailure (e.g. an auth error, code 13).
-        When:
-            ensure_indexes is awaited.
-        Then:
-            It should propagate the error rather than drop the index.
-        """
-        # Arrange
-        collection = mocker.Mock()
-        collection.create_index = mocker.AsyncMock(
-            side_effect=OperationFailure("unauthorized", 13)
-        )
-        collection.drop_index = mocker.AsyncMock()
-        db = {"jobs": collection}
-        spec = IndexSpec("jobs", [("job_id", 1)], name="job_id_unique")
+    # Assert
+    assert js_set == py_set
 
-        # Act & assert
-        with pytest.raises(OperationFailure):
-            await ensure_indexes(db, [spec])
-        collection.drop_index.assert_not_awaited()
+
+def _conflict_collection(mocker, *, existing_info: dict, create_side_effect):
+    """Build a Mongo-shaped collection mock for conflict-recovery tests."""
+    collection = mocker.MagicMock()
+    collection.create_index = mocker.AsyncMock(side_effect=create_side_effect)
+    collection.index_information = mocker.AsyncMock(return_value=existing_info)
+    collection.drop_index = mocker.AsyncMock()
+    return collection
+
+
+def _db_for(mocker, collection):
+    """Wrap a collection mock in a Mongo-shaped db (``db[name]``)."""
+    db = mocker.MagicMock()
+    db.__getitem__.return_value = collection
+    return db
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ensure_indexes_should_create_specs():
+    """Test ensure_indexes creates the requested indexes.
+
+    Given:
+        A fresh in-memory Mongo (mongomock-motor) and the operational
+        specs.
+    When:
+        ensure_indexes is awaited.
+    Then:
+        It should create each index and report the count ensured.
+    """
+    # Arrange
+    from mongomock_motor import AsyncMongoMockClient
+
+    db = AsyncMongoMockClient()["test"]
+    specs = operational_index_specs()
+
+    # Act
+    count = await ensure_indexes(db, specs)
+
+    # Assert
+    assert count == len(specs)
+    info = await db.jobs.index_information()
+    assert "workflow_key_active_unique" in info
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ensure_indexes_should_be_idempotent_on_repeat():
+    """Test a second ensure_indexes call is a no-op.
+
+    Given:
+        A database that already has the operational indexes ensured.
+    When:
+        ensure_indexes is awaited a second time with the same specs.
+    Then:
+        It should succeed without error and report the same count.
+    """
+    # Arrange
+    from mongomock_motor import AsyncMongoMockClient
+
+    db = AsyncMongoMockClient()["test"]
+    specs = operational_index_specs()
+    await ensure_indexes(db, specs)
+
+    # Act
+    count = await ensure_indexes(db, specs)
+
+    # Assert
+    assert count == len(specs)
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_should_drop_and_recreate_on_options_conflict(mocker):
+    """Test a changed index spec is dropped and recreated.
+
+    Given:
+        A collection whose create_index first raises an
+        IndexOptionsConflict (code 85) then succeeds, with the existing
+        index registered under the spec's own name.
+    When:
+        ensure_indexes is awaited with that spec.
+    Then:
+        It should drop the named index and recreate it.
+    """
+    # Arrange
+    collection = _conflict_collection(
+        mocker,
+        existing_info={"job_id_unique": {"key": [("job_id", 1)], "unique": True}},
+        create_side_effect=[OperationFailure("conflict", 85), None],
+    )
+    db = _db_for(mocker, collection)
+    spec = IndexSpec("jobs", [("job_id", 1)], name="job_id_unique", unique=True)
+
+    # Act
+    count = await ensure_indexes(db, [spec])
+
+    # Assert
+    assert count == 1
+    collection.drop_index.assert_awaited_once_with("job_id_unique")
+    assert collection.create_index.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_should_drop_conflicting_index_under_different_name(mocker):
+    """Test recovery drops a same-key index registered under another name.
+
+    Given:
+        A conflict (code 85) where the existing index on the same key is
+        registered under a legacy name, not the spec's name.
+    When:
+        ensure_indexes is awaited.
+    Then:
+        It should drop the existing index by its actual name and recreate.
+    """
+    # Arrange
+    collection = _conflict_collection(
+        mocker,
+        existing_info={"legacy_wf": {"key": [("workflow_key", 1)], "unique": True}},
+        create_side_effect=[OperationFailure("conflict", 85), None],
+    )
+    db = _db_for(mocker, collection)
+    spec = IndexSpec(
+        "jobs", [("workflow_key", 1)], name="workflow_key_active_unique", unique=True
+    )
+
+    # Act
+    await ensure_indexes(db, [spec])
+
+    # Assert
+    collection.drop_index.assert_awaited_once_with("legacy_wf")
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_should_ignore_index_not_found_on_drop(mocker):
+    """Test an IndexNotFound during the drop is swallowed.
+
+    Given:
+        A conflict whose drop_index raises IndexNotFound (code 27)
+        because the conflicting index vanished underneath us.
+    When:
+        ensure_indexes is awaited.
+    Then:
+        It should not raise and should still recreate the index.
+    """
+    # Arrange
+    collection = _conflict_collection(
+        mocker,
+        existing_info={},
+        create_side_effect=[OperationFailure("conflict", 85), None],
+    )
+    collection.drop_index = mocker.AsyncMock(
+        side_effect=OperationFailure("not found", 27)
+    )
+    db = _db_for(mocker, collection)
+    spec = IndexSpec("jobs", [("job_id", 1)], name="job_id_unique", unique=True)
+
+    # Act
+    count = await ensure_indexes(db, [spec])
+
+    # Assert
+    assert count == 1
+    assert collection.create_index.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_should_reraise_unexpected_failure(mocker):
+    """Test an unrelated OperationFailure is not swallowed.
+
+    Given:
+        A collection whose create_index raises a non-conflict
+        OperationFailure (e.g. an auth error, code 13).
+    When:
+        ensure_indexes is awaited.
+    Then:
+        It should propagate the error rather than drop the index.
+    """
+    # Arrange
+    collection = _conflict_collection(
+        mocker,
+        existing_info={},
+        create_side_effect=OperationFailure("unauthorized", 13),
+    )
+    db = _db_for(mocker, collection)
+    spec = IndexSpec("jobs", [("job_id", 1)], name="job_id_unique")
+
+    # Act & assert
+    with pytest.raises(OperationFailure):
+        await ensure_indexes(db, [spec])
+    collection.drop_index.assert_not_awaited()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4,11 +4,74 @@ from __future__ import annotations
 
 import pytest
 
+from cfdb.services import sync as sync_module
 from cfdb.services.sync import (
+    SyncTask,
     _enrich_hubmap_collections_and_subjects,
     _enrich_hubmap_files,
     _prune_non_public_hubmap_raw_records,
+    _sync_dccs,
 )
+from cfdb.indexes import data_index_specs
+
+
+class TestSyncDccsDataIndexing:
+    @pytest.mark.asyncio
+    async def test__sync_dccs_should_ensure_data_indexes_after_load(
+        self, mocker, mock_db, tmp_path
+    ):
+        """Test that a sync ensures the data indexes after loading.
+
+        Given:
+            A sync of one DCC with the per-DCC load and the applier mocked.
+        When:
+            ``_sync_dccs`` runs.
+        Then:
+            It should ensure ``data_index_specs()`` once, after the load
+            loop.
+        """
+        # Arrange
+        mocker.patch.object(sync_module, "DATA_DIR", str(tmp_path))
+        mocker.patch.object(sync_module, "get_dcc_type", return_value="rest_api")
+        mocker.patch.object(sync_module, "_sync_encode", mocker.AsyncMock())
+        ensure_mock = mocker.patch.object(
+            sync_module, "ensure_indexes", mocker.AsyncMock()
+        )
+        task = SyncTask(id="t1", dcc_names=["encode"])
+
+        # Act
+        await _sync_dccs(task)
+
+        # Assert
+        ensure_mock.assert_awaited_once()
+        specs = ensure_mock.await_args.args[1]
+        assert [s.name for s in specs] == [s.name for s in data_index_specs()]
+
+    @pytest.mark.asyncio
+    async def test__sync_dccs_should_skip_indexing_when_no_dccs(
+        self, mocker, mock_db, tmp_path
+    ):
+        """Test that an empty sync does not build data indexes.
+
+        Given:
+            A sync task with no DCC names.
+        When:
+            ``_sync_dccs`` runs.
+        Then:
+            It should not call the index applier (nothing was loaded).
+        """
+        # Arrange
+        mocker.patch.object(sync_module, "DATA_DIR", str(tmp_path))
+        ensure_mock = mocker.patch.object(
+            sync_module, "ensure_indexes", mocker.AsyncMock()
+        )
+        task = SyncTask(id="t2", dcc_names=[])
+
+        # Act
+        await _sync_dccs(task)
+
+        # Assert
+        ensure_mock.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflows/test_models.py
+++ b/tests/test_workflows/test_models.py
@@ -332,6 +332,28 @@ class TestJobRecord:
         # Assert
         assert payload["status"] == status.value
 
+    @pytest.mark.parametrize("status", list(JobStatus))
+    def test_to_mongo_should_derive_active_from_status(self, status):
+        """Test that to_mongo stamps the active mutex discriminator.
+
+        Given:
+            Each JobStatus enum value.
+        When:
+            ``to_mongo`` is invoked.
+        Then:
+            ``payload["active"]`` should be True exactly for the active
+            statuses, so the boolean backing the partial-unique index
+            stays in lockstep with ACTIVE_STATUSES.
+        """
+        # Arrange
+        job = _make_job(status=status)
+
+        # Act
+        payload = job.to_mongo()
+
+        # Assert
+        assert payload["active"] is (status in ACTIVE_STATUSES)
+
     def test_to_mongo_should_isolate_artifact_cache_keys_dict_from_caller_mutations(
         self,
     ):


### PR DESCRIPTION
## Summary

A fresh deployment used to crash-loop the API until someone manually ran `scripts/create-indexes.js`: the lifespan hard-failed when the `jobs.workflow_key` partial-unique index was absent, and nothing created it on a new DocumentDB — what blocked the first `cfdb-backend-dev` deploy.

This makes index creation automatic and app-owned. A new `cfdb.indexes` module is the single source of truth, split into an **operational** set (`jobs`/`locks`, required before the API serves) and a **data** set (the C2M2 query-performance indexes, only useful after a load). The API lifespan ensures the operational set idempotently on every startup; the data set is ensured by the sync pipeline once data is loaded.

Critically, the operational partial indexes filter on a boolean `active` discriminator rather than a `status` `$in` list, because Amazon DocumentDB rejects `$in` inside a `partialFilterExpression` — the original `$in` predicate (inherited from the manual script) would have made the auto-bootstrap crash-loop on DocumentDB exactly as before. `active` is a pure projection of `status` (`active == status in ACTIVE_STATUSES`), stamped by `JobRecord.to_mongo` and maintained by the workflow lock on every transition. `scripts/create-indexes.js` is kept as the local mongo-image bootstrap, with lockstep tests guarding both the operational predicates and the full data-index set.

Closes #46

## Proposed changes

- **`cfdb.indexes` (new)** — `IndexSpec` plus `operational_index_specs()`, `data_index_specs()`, `all_index_specs()`. Operational partial filters use the DocumentDB-safe `{"active": True}` / `{"active": False}` predicates (no `$in`). `ensure_indexes` is idempotent and self-heals on a predicate change: it locates a conflicting index by key pattern (not by assumed name), drops it by its actual name, ignores `IndexNotFound`, and logs the rebuild at WARNING. `IndexSpec.keys` is normalized to a tuple.
- **Mutex data model** — `JobRecord.to_mongo` stamps `active`; `workflows.lock` keeps it in lockstep (reclaim/release set it False, mark_running sets it True). Query filters keep `status` `$in` (supported in queries, only the index predicate was the problem).
- **`cfdb.api.main`** — the lifespan ensures the operational indexes unconditionally before serving (the `locks` collection is used by sync even when the workflow subsystem is off) and downgrades the former hard `_assert_jobs_indexes` to a non-raising `_warn_if_jobs_index_out_of_sync` keyed on the `active` predicate.
- **`cfdb.services.sync`** — ensures the data indexes after a load, skipped when no DCC was synced so an empty request never builds them against an empty database.
- **`cfdb.ensure_indexes` (new) + `pyproject.toml`** — `python -m cfdb.ensure_indexes [--scope operational|data|all]` operator CLI / manual escape hatch, plus a `cfdb-ensure-indexes` console script.
- **`cfdb.db` (new)** — shared `mongo_client_kwargs()` used by both the API client builder and the CLI so TLS / retry-write options can't drift.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestIndexSpec` | A spec built from a list of keys | The spec is constructed | It derives the default name and stores keys as a tuple | Spec construction |
| 2 | `test_operational_index_specs` | The operational specs | The mutex and TTL specs are inspected | They filter on `active` true/false with no `$in` | DocumentDB-safe predicates |
| 3 | `test_create_indexes_js_*` | The committed JS and the Python specs | The JS is parsed structurally | Operational predicates match, no `$in` appears, and data indexes match by `(collection, keys, unique)` | Python to JS lockstep |
| 4 | `test_ensure_indexes` | A mongomock DB or a mocked collection | ensure runs, repeats, and hits an options conflict | It creates, no-ops, drops the conflicting index by its real name, swallows IndexNotFound, and re-raises other failures | Idempotency + conflict recovery |
| 5 | `TestJobRecord` | Each JobStatus value | `to_mongo` is called | `active` is True exactly for the active statuses | Discriminator derivation |
| 6 | `test_lifespan_*` | A mongomock DB with workflows disabled | The lifespan starts up | It ensures the operational indexes and neither raises nor warns | Self-heal at startup |
| 7 | `TestSyncDccsDataIndexing` | A sync with and without DCCs | `_sync_dccs` runs | Data indexes are ensured after a load and skipped for an empty sync | Data-index hook |
| 8 | `test_run_*` / `test_main_*` | The CLI with a mocked client and applier | `run` / `main` run per scope | The right specs are ensured, TLS config is honored, and the client is closed | CLI behavior |
| 9 | `test_mongo_partial_unique` | The active partial-unique index on mongomock | Concurrent `claim_workflow` races | The mutex still admits exactly one active row | Mutex contract |
| 10 | `TestCORS` | The app started against an in-memory mongomock client | A preflight and a simple cross-origin request are sent | The CORS middleware allows the origin | Lifespan startup without a live MongoDB |
