### PR TITLE
Fix ECS discovery double-enter + auto-deploy API and workers — Closes #48, #50

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -44,12 +44,11 @@ jobs:
       # bundles UCSC's x86_64-only bigBedToBed. The cfdb-wool repository must
       # exist in ECR (created out of band, like the cfdb repository).
       #
-      # This publishes the image only — it does NOT roll the worker fleet.
-      # The worker task definition pins `Image: !Ref WorkerImageURI`, so
-      # rolling workers is a deliberate `aws cloudformation deploy` of the
-      # workers stack with WorkerImageURI set to the :$SHA_TAG URI pushed
-      # here (see README "Deploying the CloudFormation stacks"). :latest is
-      # pushed only as a convenience pointer.
+      # This step only builds + pushes the image; the "Deploy worker fleet"
+      # step below redeploys the workers stack with WorkerImageURI set to the
+      # :$SHA_TAG URI, which registers a new task-definition revision that
+      # EcsProvisioner launches on the next dispatch. :latest is pushed only
+      # as a convenience pointer; the task def pins the immutable :$SHA_TAG.
       - name: Build wool worker image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -83,12 +82,50 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:latest
           docker push $REGISTRY/$REPOSITORY:$SHA_TAG
 
-      - name: Deploy to ECS
+      # Deploy the freshly-pushed images by redeploying the CloudFormation
+      # stacks with the SHA-pinned image URIs. This is the real deploy:
+      # `aws cloudformation deploy` registers a new task-definition revision
+      # for the changed image and rolls the service, so each merge to master
+      # ships new code for BOTH the API and the worker fleet in lockstep.
+      #
+      # CloudFormation reuses every other parameter's previous value, so only
+      # the image URI is overridden. `--no-fail-on-empty-changeset` lets a
+      # no-op redeploy (unchanged SHA) succeed instead of erroring. Immutable
+      # `:<sha>` pinning is kept (not `:latest`), so the running fleet is
+      # traceable to a commit and rollback is a redeploy of a prior SHA.
+      #
+      # Workers are deployed first because the backend stack imports the
+      # workers stack's exports.
+      #
+      # Requires the CI role (AWS_IAM_ROLE) to be able to deploy these stacks:
+      # cloudformation:*ChangeSet*/DescribeStacks/DescribeStackEvents/
+      # GetTemplate*, ecs:RegisterTaskDefinition/UpdateService/Describe*/
+      # DeregisterTaskDefinition, and iam:PassRole on the stacks' task and
+      # execution roles. See README "Deploying the CloudFormation stacks".
+      - name: Deploy worker fleet (CloudFormation)
         env:
-          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
-          ECS_SERVICE: ${{ secrets.ECS_SERVICE }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          WORKERS_STACK: ${{ secrets.WORKERS_STACK_NAME }}
         run: |
-          aws ecs update-service \
-            --cluster $ECS_CLUSTER \
-            --service $ECS_SERVICE \
-            --force-new-deployment
+          SHA_TAG=${GITHUB_SHA::8}
+          aws cloudformation deploy \
+            --region us-east-2 \
+            --stack-name "$WORKERS_STACK" \
+            --template-file cloudformation/workers.yml \
+            --parameter-overrides WorkerImageURI=$REGISTRY/cfdb-wool:$SHA_TAG \
+            --capabilities CAPABILITY_IAM \
+            --no-fail-on-empty-changeset
+
+      - name: Deploy API (CloudFormation)
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          BACKEND_STACK: ${{ secrets.BACKEND_STACK_NAME }}
+        run: |
+          SHA_TAG=${GITHUB_SHA::8}
+          aws cloudformation deploy \
+            --region us-east-2 \
+            --stack-name "$BACKEND_STACK" \
+            --template-file cloudformation/backend.yml \
+            --parameter-overrides ImageURI=$REGISTRY/cfdb:$SHA_TAG \
+            --capabilities CAPABILITY_IAM \
+            --no-fail-on-empty-changeset

--- a/README.md
+++ b/README.md
@@ -99,7 +99,14 @@ Production runs on four CloudFormation stacks under `cloudformation/`. Deploy th
 
 Tear down in the reverse order (`backend` → `workers` → `database` → `network`); `backend` imports the worker exports, so it must be deleted first. The `cfdb-wool` ECR repository is a prerequisite created out of band (like the `cfdb` repository); consider giving it an `IMMUTABLE` tag policy and a lifecycle policy to prune untagged images.
 
-**Rolling the worker fleet.** The CI pipeline builds, scans, and pushes the worker image to `cfdb-wool:<sha>` on every merge to `master`, but it does not roll workers — the worker task definition pins `Image: !Ref WorkerImageURI`. To deploy a new worker image, redeploy the workers stack with the SHA-tagged URI:
+**CI auto-deploy.** Every merge to `master` runs `.github/workflows/deploy-to-ecr.yml`, which builds and pushes the API (`cfdb:<sha>`) and worker (`cfdb-wool:<sha>`) images, then **deploys both** by running `aws cloudformation deploy` on the workers stack (`WorkerImageURI=…/cfdb-wool:<sha>`) and the backend stack (`ImageURI=…/cfdb:<sha>`). CloudFormation reuses every other parameter's previous value, so only the image URI changes; it registers a new task-definition revision and rolls the service. The API and the worker fleet always advance to the same commit in lockstep. Immutable `:<sha>` pinning is kept (not `:latest`), so the running fleet is traceable to a commit and **rollback is a redeploy of a prior SHA** (re-run the workflow on that commit, or run the two `cloudformation deploy` commands by hand with the prior `:<sha>`). Worker task-def revisions take effect on the next `EcsProvisioner` dispatch; the API service rolls immediately.
+
+This needs two pieces of one-time configuration:
+
+- **GitHub secrets** (in addition to the existing `AWS_IAM_ROLE`): `BACKEND_STACK_NAME` and `WORKERS_STACK_NAME` — the CloudFormation stack names to deploy (e.g. `cfdb-backend-dev` and `cfdb-workers-dev`).
+- **CI role IAM**: the `AWS_IAM_ROLE` the workflow assumes must be able to deploy those stacks — `cloudformation:*ChangeSet*`, `cloudformation:DescribeStacks`/`DescribeStackEvents`/`GetTemplate*`, `ecs:RegisterTaskDefinition`/`UpdateService`/`Describe*`/`DeregisterTaskDefinition`, and `iam:PassRole` on the stacks' task and execution roles. An image-only redeploy only updates the task definition + service, but CloudFormation still executes the changeset as this role.
+
+To deploy out of band (rollback, or a manual redeploy), run the same commands the workflow runs:
 
 ```bash
 aws cloudformation deploy \
@@ -107,9 +114,12 @@ aws cloudformation deploy \
   --template-file cloudformation/workers.yml \
   --parameter-overrides WorkerImageURI=<account>.dkr.ecr.<region>.amazonaws.com/cfdb-wool:<sha> \
   --capabilities CAPABILITY_IAM
+aws cloudformation deploy \
+  --stack-name <backend-stack> \
+  --template-file cloudformation/backend.yml \
+  --parameter-overrides ImageURI=<account>.dkr.ecr.<region>.amazonaws.com/cfdb:<sha> \
+  --capabilities CAPABILITY_IAM
 ```
-
-This registers a new task-definition revision that `EcsProvisioner` launches on the next workflow dispatch. Pin to an immutable `:<sha>` (not `:latest`) so the running fleet is traceable to a commit and rollback is a redeploy with the prior SHA.
 
 **Tearing down the cache.** CloudFormation cannot delete a non-empty S3 bucket, so empty the `CacheBucket` before deleting the workers stack or the delete will fail and roll back.
 

--- a/src/cfdb/api/main.py
+++ b/src/cfdb/api/main.py
@@ -191,24 +191,27 @@ def _build_provisioner(profile: WorkflowProfile) -> Optional[EcsProvisioner]:
 async def _build_discovery(profile: WorkflowProfile) -> AsyncIterator[object]:
     """Build the wool-compatible discovery layer for ``profile``.
 
-    The ``ecs`` profile yields an :class:`EcsDiscovery` context — the
-    background ``ListTasks`` / ``DescribeTasks`` poller starts on
-    ``__aenter__`` and is cancelled on ``__aexit__``. The ``local``
-    and ``s3-cached`` profiles fall through to :class:`LanDiscovery`
-    over zeroconf/mDNS against a manually-started wool pool.
+    The ``ecs`` profile yields an :class:`EcsDiscovery`; the ``local``
+    and ``s3-cached`` profiles yield a :class:`LanDiscovery` over
+    zeroconf/mDNS against a manually-started wool pool.
 
-    Either branch yields a shape ``wool.WorkerPool`` accepts via its
-    ``discovery=`` arg so the lifespan wires it through without
-    branching at the call site.
+    Both branches yield the discovery object **un-entered**.
+    ``wool.WorkerPool.__aenter__`` enters whatever is passed to its
+    ``discovery=`` arg itself (``create_proxy`` ->
+    ``_enter_context(discovery)``), so the pool owns the discovery
+    lifecycle — its ``ListTasks`` / ``DescribeTasks`` poller starts when
+    the pool starts and is cancelled when the pool exits. Entering it
+    here as well would call ``EcsDiscovery.__aenter__`` twice and trip
+    its re-entry guard (the LAN profile already relied on this, which is
+    why only the ECS profile crashed on startup).
     """
     if profile.ecs is not None and profile.ecs.task_family is not None:
-        async with EcsDiscovery(
+        yield EcsDiscovery(
             cluster=profile.ecs.cluster,
             task_definition_family=profile.ecs.task_family,
             endpoint_url=profile.aws_endpoint_url,
             region_name=profile.aws_region,
-        ) as discovery:
-            yield discovery
+        )
         return
     yield LanDiscovery(api.WORKFLOW_POOL_NAMESPACE)
 

--- a/tests/test_api/test_build_discovery.py
+++ b/tests/test_api/test_build_discovery.py
@@ -1,0 +1,71 @@
+"""Tests for the lifespan's discovery builder."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cfdb.api import main
+
+
+@pytest.mark.asyncio
+async def test_build_discovery_should_yield_ecs_discovery_unentered(mocker):
+    """Test the ECS profile yields an un-entered EcsDiscovery.
+
+    Given:
+        An ECS profile and a stubbed EcsDiscovery.
+    When:
+        ``_build_discovery`` is entered.
+    Then:
+        It should construct and yield the EcsDiscovery without entering
+        it, leaving the enter/exit to wool.WorkerPool — otherwise the
+        discovery would be entered twice and trip its re-entry guard.
+    """
+    # Arrange
+    ecs_instance = mocker.MagicMock()
+    ecs_instance.__aenter__ = mocker.AsyncMock(return_value=ecs_instance)
+    ecs_instance.__aexit__ = mocker.AsyncMock(return_value=None)
+    ecs_cls = mocker.patch.object(main, "EcsDiscovery", return_value=ecs_instance)
+    profile = SimpleNamespace(
+        ecs=SimpleNamespace(cluster="cfdb-cluster", task_family="cfdb-worker"),
+        aws_endpoint_url=None,
+        aws_region="us-east-2",
+    )
+
+    # Act
+    async with main._build_discovery(profile) as discovery:
+        entered_during = ecs_instance.__aenter__.await_count
+
+    # Assert
+    assert discovery is ecs_instance
+    ecs_cls.assert_called_once()
+    assert entered_during == 0
+    ecs_instance.__aenter__.assert_not_awaited()
+    ecs_instance.__aexit__.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_discovery_should_yield_lan_discovery_unentered(mocker):
+    """Test the local profile yields an un-entered LanDiscovery.
+
+    Given:
+        A non-ECS profile and a stubbed LanDiscovery.
+    When:
+        ``_build_discovery`` is entered.
+    Then:
+        It should yield the LanDiscovery instance without entering it,
+        symmetric with the ECS branch.
+    """
+    # Arrange
+    lan_instance = mocker.MagicMock()
+    lan_cls = mocker.patch.object(main, "LanDiscovery", return_value=lan_instance)
+    profile = SimpleNamespace(ecs=None, aws_endpoint_url=None, aws_region="us-east-2")
+
+    # Act
+    async with main._build_discovery(profile) as discovery:
+        pass
+
+    # Assert
+    assert discovery is lan_instance
+    lan_cls.assert_called_once()


### PR DESCRIPTION
This branch carries two changes; each is tracked by its own issue.

## 1. Fix: ECS lifespan double-enters EcsDiscovery (Closes #48)

On the ECS Fargate profile the API crash-looped at startup with `AssertionError: EcsDiscovery context entered twice`. `wool.WorkerPool.__aenter__` enters whatever is passed to its `discovery=` arg itself (`create_proxy` -> `_enter_context(discovery)`), so the pool owns the discovery lifecycle — but the lifespan's `_build_discovery` also entered the `EcsDiscovery` via `async with`, so `EcsDiscovery.__aenter__` ran twice and tripped its re-entry guard. The LAN branch already yielded its discovery un-entered, which is why only the ECS profile crashed.

Fix: yield the `EcsDiscovery` un-entered, symmetric with `LanDiscovery`, and let `wool.WorkerPool` enter/exit it.

- `src/cfdb/api/main.py` — `_build_discovery` yields the discovery without entering it.
- `tests/test_api/test_build_discovery.py` — regression tests that both the ECS and LAN branches yield the discovery un-entered.

## 2. CI: Auto-deploy the API and worker fleet on merge to master (Closes #50)

The deploy workflow pushed new images but only ran `update-service --force-new-deployment` on the API service. Because the task definitions pin immutable `:<sha>` image URIs, that restart re-ran the same code, so neither the API nor the workers actually picked up new builds without a manual CloudFormation redeploy — and the workers were never rolled at all.

Replace the restart with real deploys: `aws cloudformation deploy` of the workers stack then the backend stack, overriding only the image URI to the freshly-pushed `:<sha>`. CloudFormation reuses every other parameter's previous value, registers a new task-definition revision, and rolls the service, so each merge advances the API and the worker fleet to the same commit in lockstep. Immutable SHA pinning is kept, so rollback is a redeploy of a prior SHA.

- `.github/workflows/deploy-to-ecr.yml` — replace the force-new-deployment step with two `cloudformation deploy` steps (workers then backend).
- `README.md` — document the auto-deploy behavior, the rollback path, and the prerequisites.

### Prerequisites before the next master merge (or the deploy step fails)

- **GitHub secrets**: add `BACKEND_STACK_NAME` and `WORKERS_STACK_NAME` (e.g. `cfdb-backend-dev` / `cfdb-workers-dev`).
- **CI role IAM**: the `AWS_IAM_ROLE` the workflow assumes needs `cloudformation:*ChangeSet*` / `DescribeStacks` / `DescribeStackEvents` / `GetTemplate*`, `ecs:RegisterTaskDefinition` / `UpdateService` / `Describe*` / `DeregisterTaskDefinition`, and `iam:PassRole` on the stacks' task and execution roles. (The previous step only needed `ecs:UpdateService`.)

## Tests

| # | Test Suite | Given | When | Then |
|---|------------|-------|------|------|
| 1 | `test_build_discovery` | An ECS profile and a stubbed EcsDiscovery | `_build_discovery` is entered | It yields the discovery without entering it |
| 2 | `test_build_discovery` | A non-ECS profile and a stubbed LanDiscovery | `_build_discovery` is entered | It yields the LanDiscovery un-entered |

(The CI workflow change is validated by YAML parse; it has no Python tests.)
