### PR TITLE
4DN extra_files file_format dict crashes the GraphQL files query — Closes #51

### DIFF
--- a/src/cfdb/api/gql/schema.py
+++ b/src/cfdb/api/gql/schema.py
@@ -42,6 +42,23 @@ ALLOWED_DISTINCT_FIELDS: frozenset[str] = frozenset(
 
 
 def from_pydantic(gql_type, obj):
+    """Build a Strawberry type from a fully-dumped model dict.
+
+    ``obj`` is expected to be a complete ``model_dump()`` of the
+    corresponding pydantic model (every field key present); callers pass
+    ``FileMetadataModel(...).model_dump()``. Mutates ``obj`` in place,
+    recursively converting nested-model fields (and lists thereof) into
+    their Strawberry types before constructing ``gql_type``.
+
+    Field nesting is resolved by peeling Strawberry's wrapper types: a
+    ``StrawberryOptional`` / ``StrawberryList`` exposes ``of_type`` but
+    not ``__strawberry_definition__``, while a concrete generated type
+    exposes ``__strawberry_definition__``. This distinction is a
+    Strawberry-internal contract — re-verify it on a major Strawberry
+    upgrade, as a change there would silently leave nested values as raw
+    dicts (the bug fixed in #51/#52). Scalar and JSON fields peel to a
+    leaf with no ``__strawberry_definition__`` and are left untouched.
+    """
     if obj is None:
         return obj
     for field_name, field_type in gql_type.__annotations__.items():

--- a/src/cfdb/api/gql/schema.py
+++ b/src/cfdb/api/gql/schema.py
@@ -45,18 +45,26 @@ def from_pydantic(gql_type, obj):
     if obj is None:
         return obj
     for field_name, field_type in gql_type.__annotations__.items():
-        if field_name in obj:
-            if hasattr(field_type, "__strawberry_definition__"):
-                obj[field_name] = from_pydantic(field_type, obj[field_name])
-            elif hasattr(field_type, "of_type") and hasattr(
-                field_type.of_type, "__strawberry_definition__"
-            ):
-                if isinstance(obj[field_name], list):
-                    obj[field_name] = [
-                        from_pydantic(field_type.of_type, o) for o in obj[field_name]
-                    ]
-                else:
-                    obj[field_name] = from_pydantic(field_type.of_type, obj[field_name])
+        if field_name not in obj or obj[field_name] is None:
+            continue
+        # Peel any nesting of Strawberry wrappers (StrawberryOptional /
+        # StrawberryList — both expose ``of_type`` but not
+        # ``__strawberry_definition__``) down to the concrete Strawberry
+        # type. This handles bare ``X``, ``Optional[X]``, ``List[X]`` and
+        # ``Optional[List[X]]`` alike — the last being how nested model
+        # lists such as ``extra.fourdn.extra_files`` are typed.
+        inner = field_type
+        while hasattr(inner, "of_type") and not hasattr(
+            inner, "__strawberry_definition__"
+        ):
+            inner = inner.of_type
+        if not hasattr(inner, "__strawberry_definition__"):
+            continue  # scalar / JSON field — leave the value untouched
+        value = obj[field_name]
+        if isinstance(value, list):
+            obj[field_name] = [from_pydantic(inner, o) for o in value]
+        else:
+            obj[field_name] = from_pydantic(inner, value)
 
     return gql_type(**obj)
 

--- a/src/cfdb/api/routers/index.py
+++ b/src/cfdb/api/routers/index.py
@@ -35,6 +35,7 @@ from cfdb.api.routers.cache_stream import (
     stream_upstream_url,
 )
 from cfdb.dcc_registry import get_all_dcc_names, get_dcc_config, normalize_dcc_name
+from cfdb.models import coerce_4dn_cv_token
 from cfdb.services import locks
 from cfdb.workflows.models import ArtifactKind
 from cfdb.workflows.urlsafe import UnsafeOutboundURL, validate_outbound_url
@@ -345,9 +346,7 @@ def _resolve_fourdn_sidecar(
     for candidate in extra_files:
         if not isinstance(candidate, dict):
             continue
-        raw_fmt = candidate.get("file_format")
-        if isinstance(raw_fmt, dict):
-            raw_fmt = raw_fmt.get("display_title")
+        raw_fmt = coerce_4dn_cv_token(candidate.get("file_format"))
         # Only a string carries a usable token; anything else (a dict with
         # no display_title, None, or an unexpected type) is a non-match,
         # never an AttributeError on .lower().

--- a/src/cfdb/models.py
+++ b/src/cfdb/models.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, field_validator
+
+
+def coerce_4dn_cv_token(value: Any) -> Any:
+    """Coerce a 4DN controlled-vocabulary object to its string token.
+
+    The 4DN portal API represents fields like ``extra_files[].file_format``
+    as an embedded CV object carrying the human token under
+    ``display_title`` (e.g. ``{"display_title": "pairs_px2", ...}``).
+    Return that token when ``value`` is such a dict (``None`` if the dict
+    lacks ``display_title``); pass strings, ``None``, and any other type
+    through unchanged.
+
+    Single source of truth for this normalization, shared by the
+    ``ExtraFile`` read validator, the sync write path
+    (``services.fourdn.parse_extra_files``), and the ``/index`` sidecar
+    resolver (``api.routers.index``).
+    """
+    if isinstance(value, dict):
+        return value.get("display_title")
+    return value
 
 
 class ExtraFile(BaseModel):
@@ -34,19 +54,13 @@ class ExtraFile(BaseModel):
     @field_validator("file_format", mode="before")
     @classmethod
     def _coerce_file_format_token(cls, value):
-        """Coerce a 4DN CV-object ``file_format`` to its string token.
+        """Coerce a dict-shaped 4DN ``file_format`` to its string token.
 
-        The 4DN portal API represents ``extra_files[].file_format`` as an
-        embedded CV object carrying the token under ``display_title``, and
-        documents persisted by the sync may hold that dict. Extract the
-        token so the field deserializes as a string instead of raising —
-        matching the normalization the ``/index`` sidecar path applies on
-        read. Strings and ``None`` pass through unchanged; a dict without
-        ``display_title`` becomes ``None``.
+        Documents persisted by the sync may hold the 4DN CV object rather
+        than a bare string; normalize on read so the field deserializes
+        instead of raising. See :func:`coerce_4dn_cv_token`.
         """
-        if isinstance(value, dict):
-            return value.get("display_title")
-        return value
+        return coerce_4dn_cv_token(value)
 
 
 class EnrichedFourdnFile(BaseModel):

--- a/src/cfdb/models.py
+++ b/src/cfdb/models.py
@@ -31,6 +31,23 @@ class ExtraFile(BaseModel):
     file_size: Optional[int] = None
     file_format: Optional[str] = None
 
+    @field_validator("file_format", mode="before")
+    @classmethod
+    def _coerce_file_format_token(cls, value):
+        """Coerce a 4DN CV-object ``file_format`` to its string token.
+
+        The 4DN portal API represents ``extra_files[].file_format`` as an
+        embedded CV object carrying the token under ``display_title``, and
+        documents persisted by the sync may hold that dict. Extract the
+        token so the field deserializes as a string instead of raising —
+        matching the normalization the ``/index`` sidecar path applies on
+        read. Strings and ``None`` pass through unchanged; a dict without
+        ``display_title`` becomes ``None``.
+        """
+        if isinstance(value, dict):
+            return value.get("display_title")
+        return value
+
 
 class EnrichedFourdnFile(BaseModel):
     """4DN file-level metadata from the materializer and Search API."""

--- a/src/cfdb/services/fourdn.py
+++ b/src/cfdb/services/fourdn.py
@@ -127,6 +127,31 @@ def extract_experiment_accession(persistent_id: str) -> Optional[str]:
     return match.group(0) if match else None
 
 
+def _parse_extra_files(extra_files_raw: list) -> list[dict]:
+    """Normalize 4DN ``extra_files`` entries for persistence.
+
+    Copies the ``href`` / ``md5sum`` / ``file_size`` / ``file_format``
+    fields from each raw entry, dropping any that are absent. The 4DN
+    portal API returns ``file_format`` as an embedded CV object carrying
+    the token under ``display_title``; store just that token (a string)
+    so persisted documents match the ``ExtraFile.file_format`` type and
+    the ``/index`` sidecar normalization. Entries that yield no fields
+    are dropped.
+    """
+    parsed_files: list[dict] = []
+    for ef in extra_files_raw:
+        parsed: dict = {}
+        for k in ("href", "md5sum", "file_size", "file_format"):
+            v = ef.get(k)
+            if k == "file_format" and isinstance(v, dict):
+                v = v.get("display_title")
+            if v is not None:
+                parsed[k] = v
+        if parsed:
+            parsed_files.append(parsed)
+    return parsed_files
+
+
 async def fetch_file_metadata_bulk() -> dict[str, dict]:
     """
     Fetch file metadata from the 4DN Search API for FileProcessed and FileFastq types.
@@ -224,19 +249,9 @@ async def fetch_file_metadata_bulk() -> dict[str, dict]:
                                 entry[key] = val
 
                     # Extra files (index files like .px2, .bai)
-                    extra_files_raw = item.get("extra_files", [])
-                    if extra_files_raw:
-                        extra_files = []
-                        for ef in extra_files_raw:
-                            parsed = {}
-                            for k in ("href", "md5sum", "file_size", "file_format"):
-                                v = ef.get(k)
-                                if v is not None:
-                                    parsed[k] = v
-                            if parsed:
-                                extra_files.append(parsed)
-                        if extra_files:
-                            entry["extra_files"] = extra_files
+                    extra_files = _parse_extra_files(item.get("extra_files", []))
+                    if extra_files:
+                        entry["extra_files"] = extra_files
 
                     if entry:
                         results[accession] = entry

--- a/src/cfdb/services/fourdn.py
+++ b/src/cfdb/services/fourdn.py
@@ -85,6 +85,7 @@ from typing import Optional
 import aiohttp
 
 from cfdb.dcc_registry import get_dcc_config
+from cfdb.models import coerce_4dn_cv_token
 
 logger = logging.getLogger(__name__)
 
@@ -127,24 +128,23 @@ def extract_experiment_accession(persistent_id: str) -> Optional[str]:
     return match.group(0) if match else None
 
 
-def _parse_extra_files(extra_files_raw: list) -> list[dict]:
+def parse_extra_files(extra_files_raw: list) -> list[dict]:
     """Normalize 4DN ``extra_files`` entries for persistence.
 
     Copies the ``href`` / ``md5sum`` / ``file_size`` / ``file_format``
     fields from each raw entry, dropping any that are absent. The 4DN
-    portal API returns ``file_format`` as an embedded CV object carrying
-    the token under ``display_title``; store just that token (a string)
-    so persisted documents match the ``ExtraFile.file_format`` type and
-    the ``/index`` sidecar normalization. Entries that yield no fields
-    are dropped.
+    portal API returns ``file_format`` as an embedded CV object; store
+    just its token (via :func:`coerce_4dn_cv_token`) so persisted
+    documents match the ``ExtraFile.file_format`` type and the ``/index``
+    sidecar normalization. Entries that yield no fields are dropped.
     """
     parsed_files: list[dict] = []
     for ef in extra_files_raw:
         parsed: dict = {}
         for k in ("href", "md5sum", "file_size", "file_format"):
             v = ef.get(k)
-            if k == "file_format" and isinstance(v, dict):
-                v = v.get("display_title")
+            if k == "file_format":
+                v = coerce_4dn_cv_token(v)
             if v is not None:
                 parsed[k] = v
         if parsed:
@@ -249,7 +249,7 @@ async def fetch_file_metadata_bulk() -> dict[str, dict]:
                                 entry[key] = val
 
                     # Extra files (index files like .px2, .bai)
-                    extra_files = _parse_extra_files(item.get("extra_files", []))
+                    extra_files = parse_extra_files(item.get("extra_files", []))
                     if extra_files:
                         entry["extra_files"] = extra_files
 

--- a/tests/test_fourdn.py
+++ b/tests/test_fourdn.py
@@ -1,0 +1,112 @@
+"""Tests for 4DN enrichment helpers."""
+
+from __future__ import annotations
+
+from cfdb.services.fourdn import _parse_extra_files
+
+
+def test__parse_extra_files_normalizes_dict_file_format_to_token():
+    """Test that a CV-object file_format is stored as its token.
+
+    Given:
+        A raw 4DN extra_files entry whose file_format is an embedded CV
+        object carrying the token under display_title.
+    When:
+        _parse_extra_files processes it.
+    Then:
+        The stored file_format should be the display_title string.
+    """
+    # Arrange
+    raw = [
+        {
+            "href": "/files/x.pairs_px2",
+            "file_format": {
+                "principals_allowed": {"view": ["system.Everyone"]},
+                "status": "released",
+                "display_title": "pairs_px2",
+            },
+        }
+    ]
+
+    # Act
+    result = _parse_extra_files(raw)
+
+    # Assert
+    assert result == [{"href": "/files/x.pairs_px2", "file_format": "pairs_px2"}]
+
+
+def test__parse_extra_files_preserves_string_file_format_and_other_fields():
+    """Test that a string file_format and the other fields carry through.
+
+    Given:
+        A raw entry with a bare-string file_format plus href, md5sum, and
+        file_size.
+    When:
+        _parse_extra_files processes it.
+    Then:
+        It should preserve every field unchanged.
+    """
+    # Arrange
+    raw = [
+        {
+            "href": "/files/x.bai",
+            "md5sum": "d41d8cd98f00b204e9800998ecf8427e",
+            "file_size": 1024,
+            "file_format": "bai",
+        }
+    ]
+
+    # Act
+    result = _parse_extra_files(raw)
+
+    # Assert
+    assert result == [
+        {
+            "href": "/files/x.bai",
+            "md5sum": "d41d8cd98f00b204e9800998ecf8427e",
+            "file_size": 1024,
+            "file_format": "bai",
+        }
+    ]
+
+
+def test__parse_extra_files_returns_empty_list_for_empty_input():
+    """Test that an empty extra_files list yields an empty list.
+
+    Given:
+        An empty list of raw extra_files entries.
+    When:
+        _parse_extra_files is called.
+    Then:
+        It should return an empty list.
+    """
+    # Act
+    result = _parse_extra_files([])
+
+    # Assert
+    assert result == []
+
+
+def test__parse_extra_files_drops_entry_yielding_no_fields():
+    """Test that an entry with no usable fields is dropped.
+
+    Given:
+        A raw extra_files entry whose only key is a dict file_format with
+        no display_title (so it normalizes away) alongside an entry with
+        usable fields.
+    When:
+        _parse_extra_files processes the list.
+    Then:
+        It should drop the empty entry and keep the usable one.
+    """
+    # Arrange
+    raw = [
+        {"file_format": {"status": "released"}},
+        {"href": "/files/x.bai", "file_format": "bai"},
+    ]
+
+    # Act
+    result = _parse_extra_files(raw)
+
+    # Assert
+    assert result == [{"href": "/files/x.bai", "file_format": "bai"}]

--- a/tests/test_fourdn.py
+++ b/tests/test_fourdn.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from cfdb.services.fourdn import _parse_extra_files
+from cfdb.services.fourdn import parse_extra_files
 
 
-def test__parse_extra_files_normalizes_dict_file_format_to_token():
+def test_parse_extra_files_should_store_token_when_file_format_is_cv_object():
     """Test that a CV-object file_format is stored as its token.
 
     Given:
         A raw 4DN extra_files entry whose file_format is an embedded CV
         object carrying the token under display_title.
     When:
-        _parse_extra_files processes it.
+        parse_extra_files processes it.
     Then:
         The stored file_format should be the display_title string.
     """
@@ -29,20 +29,20 @@ def test__parse_extra_files_normalizes_dict_file_format_to_token():
     ]
 
     # Act
-    result = _parse_extra_files(raw)
+    result = parse_extra_files(raw)
 
     # Assert
     assert result == [{"href": "/files/x.pairs_px2", "file_format": "pairs_px2"}]
 
 
-def test__parse_extra_files_preserves_string_file_format_and_other_fields():
+def test_parse_extra_files_should_preserve_string_file_format_and_other_fields():
     """Test that a string file_format and the other fields carry through.
 
     Given:
         A raw entry with a bare-string file_format plus href, md5sum, and
         file_size.
     When:
-        _parse_extra_files processes it.
+        parse_extra_files processes it.
     Then:
         It should preserve every field unchanged.
     """
@@ -57,7 +57,7 @@ def test__parse_extra_files_preserves_string_file_format_and_other_fields():
     ]
 
     # Act
-    result = _parse_extra_files(raw)
+    result = parse_extra_files(raw)
 
     # Assert
     assert result == [
@@ -70,24 +70,24 @@ def test__parse_extra_files_preserves_string_file_format_and_other_fields():
     ]
 
 
-def test__parse_extra_files_returns_empty_list_for_empty_input():
+def test_parse_extra_files_should_return_empty_list_when_input_empty():
     """Test that an empty extra_files list yields an empty list.
 
     Given:
         An empty list of raw extra_files entries.
     When:
-        _parse_extra_files is called.
+        parse_extra_files is called.
     Then:
         It should return an empty list.
     """
     # Act
-    result = _parse_extra_files([])
+    result = parse_extra_files([])
 
     # Assert
     assert result == []
 
 
-def test__parse_extra_files_drops_entry_yielding_no_fields():
+def test_parse_extra_files_should_drop_entry_when_it_yields_no_fields():
     """Test that an entry with no usable fields is dropped.
 
     Given:
@@ -95,7 +95,7 @@ def test__parse_extra_files_drops_entry_yielding_no_fields():
         no display_title (so it normalizes away) alongside an entry with
         usable fields.
     When:
-        _parse_extra_files processes the list.
+        parse_extra_files processes the list.
     Then:
         It should drop the empty entry and keep the usable one.
     """
@@ -106,7 +106,7 @@ def test__parse_extra_files_drops_entry_yielding_no_fields():
     ]
 
     # Act
-    result = _parse_extra_files(raw)
+    result = parse_extra_files(raw)
 
     # Assert
     assert result == [{"href": "/files/x.bai", "file_format": "bai"}]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,70 @@ from cfdb.models import (
     ExtraFile,
     FileMetadataModel,
     Subject,
+    coerce_4dn_cv_token,
 )
+
+
+class TestCoerce4dnCvToken:
+    def test_returns_display_title_for_cv_object(self):
+        """Test that a CV object resolves to its display_title token.
+
+        Given:
+            A 4DN CV object carrying the token under display_title.
+        When:
+            coerce_4dn_cv_token is called.
+        Then:
+            It should return the display_title string.
+        """
+        # Act
+        result = coerce_4dn_cv_token(
+            {"status": "released", "display_title": "pairs_px2"}
+        )
+
+        # Assert
+        assert result == "pairs_px2"
+
+    def test_returns_none_for_cv_object_without_display_title(self):
+        """Test that a CV object lacking display_title resolves to None.
+
+        Given:
+            A dict with no display_title key.
+        When:
+            coerce_4dn_cv_token is called.
+        Then:
+            It should return None.
+        """
+        # Act
+        result = coerce_4dn_cv_token({"status": "released"})
+
+        # Assert
+        assert result is None
+
+    def test_passes_string_through_unchanged(self):
+        """Test that a bare string is returned unchanged.
+
+        Given:
+            A plain string token.
+        When:
+            coerce_4dn_cv_token is called.
+        Then:
+            It should return the string unchanged.
+        """
+        # Act, assert
+        assert coerce_4dn_cv_token("bai") == "bai"
+
+    def test_passes_none_through_unchanged(self):
+        """Test that None is returned unchanged.
+
+        Given:
+            A None value.
+        When:
+            coerce_4dn_cv_token is called.
+        Then:
+            It should return None.
+        """
+        # Act, assert
+        assert coerce_4dn_cv_token(None) is None
 
 
 class TestExtraFile:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,9 +5,84 @@ from cfdb.models import (
     EnrichedCollection,
     EnrichedFile,
     EnrichedSubject,
+    ExtraFile,
     FileMetadataModel,
     Subject,
 )
+
+
+class TestExtraFile:
+    def test_file_format_dict_coerced_to_display_title_token(self):
+        """Test that a CV-object file_format is coerced to its token.
+
+        Given:
+            An ExtraFile constructed with file_format as a 4DN CV object
+            carrying the token under display_title.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce file_format to the display_title string.
+        """
+        # Act
+        result = ExtraFile(
+            file_format={
+                "principals_allowed": {"view": ["system.Everyone"]},
+                "status": "released",
+                "display_title": "pairs_px2",
+            }
+        )
+
+        # Assert
+        assert result.file_format == "pairs_px2"
+
+    def test_file_format_string_passes_through(self):
+        """Test that a bare string file_format is preserved.
+
+        Given:
+            An ExtraFile constructed with file_format as a plain string.
+        When:
+            The model is instantiated.
+        Then:
+            It should keep the string unchanged.
+        """
+        # Act
+        result = ExtraFile(file_format="bai")
+
+        # Assert
+        assert result.file_format == "bai"
+
+    def test_file_format_dict_without_display_title_coerced_to_none(self):
+        """Test that a CV object lacking display_title becomes None.
+
+        Given:
+            An ExtraFile constructed with file_format as a dict that has
+            no display_title key.
+        When:
+            The model is instantiated.
+        Then:
+            It should coerce file_format to None rather than raise.
+        """
+        # Act
+        result = ExtraFile(file_format={"status": "released"})
+
+        # Assert
+        assert result.file_format is None
+
+    def test_file_format_defaults_to_none_when_omitted(self):
+        """Test that an omitted file_format stays None.
+
+        Given:
+            An ExtraFile constructed without a file_format.
+        When:
+            The model is instantiated.
+        Then:
+            file_format should be None (the validator passes None through).
+        """
+        # Act
+        result = ExtraFile(href="/files/x.bai")
+
+        # Assert
+        assert result.file_format is None
 
 
 class TestEnrichedFile:
@@ -167,6 +242,41 @@ class TestEnrichedBiosample:
 
 
 class TestFileMetadataModel:
+    def test_deserializes_with_dict_shaped_extra_file_format(self):
+        """Test that a 4DN doc with a CV-object extra_files file_format loads.
+
+        Given:
+            A FileMetadataModel document whose
+            extra.fourdn.extra_files[0].file_format is a 4DN CV object
+            (the shape persisted by the sync that crashed the files query).
+        When:
+            The model is instantiated.
+        Then:
+            It should deserialize successfully and expose the file_format
+            display_title token as a string.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["extra"] = {
+            "fourdn": {
+                "extra_files": [
+                    {
+                        "href": "/files/4DNFITEST001/x.pairs_px2",
+                        "file_format": {
+                            "status": "released",
+                            "display_title": "pairs_px2",
+                        },
+                    }
+                ]
+            }
+        }
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert result.extra.fourdn.extra_files[0].file_format == "pairs_px2"
+
     def test_empty_string_to_none_with_empty_file_format(self):
         """Test empty string coercion on the file_format field.
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,8 +4,42 @@ from __future__ import annotations
 
 import pytest
 
-from cfdb.api.gql.schema import schema
+from cfdb.api.gql.schema import from_pydantic, schema
+from cfdb.api.gql.types import FileMetadataType
+from cfdb.models import FileMetadataModel
 from cfdb.services import locks
+
+
+def test_from_pydantic_should_convert_nested_model_lists_and_leave_json_untouched():
+    """Test from_pydantic resolves Optional[List[Model]] and passes JSON through.
+
+    Given:
+        A dumped FileMetadataModel with a nested Optional[List[ExtraFile]]
+        (extra.fourdn.extra_files) and a JSON dict field
+        (collections[].extra.hubmap.metadata).
+    When:
+        from_pydantic builds the FileMetadataType.
+    Then:
+        It should convert the nested list items to the Strawberry type
+        (the #52 peel fix) while leaving the JSON dict field untouched.
+    """
+    # Arrange
+    payload = FileMetadataModel(
+        dcc={"dcc_abbreviation": "4DN_DCIC"},
+        collections=[
+            {"biosamples": [], "extra": {"hubmap": {"metadata": {"k": "v", "n": 1}}}}
+        ],
+        extra={"fourdn": {"extra_files": [{"href": "/x", "file_format": "pairs_px2"}]}},
+    ).model_dump()
+
+    # Act
+    result = from_pydantic(FileMetadataType, payload)
+
+    # Assert
+    extra_file = result.extra.fourdn.extra_files[0]
+    assert hasattr(type(extra_file), "__strawberry_definition__")
+    assert extra_file.file_format == "pairs_px2"
+    assert result.collections[0].extra.hubmap.metadata == {"k": "v", "n": 1}
 
 
 def _make_file_doc(local_id: str, submission: str = "hubmap") -> dict:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -84,6 +84,54 @@ class TestFilesQuery:
         assert len(result.data["files"]) == 2
 
     @pytest.mark.asyncio
+    async def test_returns_4dn_file_with_dict_shaped_extra_file_format(self, mock_db):
+        """Test the files query serializes 4DN extra_files with a CV-object format.
+
+        Given:
+            A 4DN file whose extra.fourdn.extra_files[0].file_format is a 4DN
+            CV object (a dict carrying the token under display_title) — the
+            shape that crashed the query.
+        When:
+            The GraphQL files query selects extra.fourdn.extraFiles.fileFormat.
+        Then:
+            It returns without errors and exposes the display_title token.
+        """
+        # Arrange
+        doc = _make_file_doc("4DNFITEST", submission="4dn")
+        doc["extra"] = {
+            "fourdn": {
+                "extra_files": [
+                    {
+                        "href": "/files/x.pairs_px2",
+                        "file_format": {
+                            "status": "released",
+                            "display_title": "pairs_px2",
+                        },
+                    }
+                ]
+            }
+        }
+        mock_db.files.docs = [doc]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files {
+                    localId
+                    extra { fourdn { extraFiles { href fileFormat } } }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        extra_file = result.data["files"][0]["extra"]["fourdn"]["extraFiles"][0]
+        assert extra_file["fileFormat"] == "pairs_px2"
+        assert extra_file["href"] == "/files/x.pairs_px2"
+
+    @pytest.mark.asyncio
     async def test_returns_all_submissions_without_filtering(self, mock_db):
         """Test the files query returns all DCCs when no filter is supplied.
 


### PR DESCRIPTION
## Summary

A `POST /metadata` (`files`) query returned `data: null` whenever the result set included a 4DN file with companion index files (`.px2`/`.bai`). The 4DN portal API represents `extra_files[].file_format` as an embedded CV object (a dict carrying the token under `display_title`), but `ExtraFile.file_format` is typed as a string — so `FileMetadataModel` construction in the GraphQL resolver raised, and because one bad document fails the whole page, the entire query errored.

Fixing the deserialization unmasked a second, latent bug: the hand-rolled `from_pydantic` that maps Mongo docs to Strawberry types never converted `Optional[List[X]]` nested model lists, so Strawberry received raw dicts for `extra.fourdn.extra_files`.

This fixes both layers and normalizes the data on write so future syncs persist a string. Following review, the dict→token coercion (previously inlined in three places) was consolidated into one shared helper, the write helper was made public for direct testing, and `from_pydantic`'s contract was documented and pinned with a unit test. Reproduced and verified end-to-end against the AWS dev stack and a local containerized stack.

Closes #51

## Proposed changes

- **Normalize 4DN `extra_files.file_format` to its token** (`src/cfdb/models.py`, `src/cfdb/services/fourdn.py`) — a `field_validator` on `ExtraFile.file_format` normalizes a dict to its `display_title` token on read (fixing already-persisted data without a re-sync; strings/`None` pass through), and the 4DN enrichment stores the token via `parse_extra_files` so new syncs persist a string.
- **Single-source the CV-token coercion** (`src/cfdb/models.py`, `src/cfdb/services/fourdn.py`, `src/cfdb/api/routers/index.py`) — extract `coerce_4dn_cv_token(value)` and call it from the `ExtraFile` validator, `parse_extra_files`, and the `/index` sidecar resolver (which keeps its lowercase + allowlist match on top), removing the prior triplication. `_parse_extra_files` is promoted to the public `parse_extra_files`.
- **Serialize `Optional[List[X]]` nested model lists in the resolver** (`src/cfdb/api/gql/schema.py`) — rework `from_pydantic` to peel any nesting of `StrawberryOptional`/`StrawberryList` wrappers down to the concrete Strawberry type, then convert by the runtime value's list-ness. Bare types, `Optional[X]`, `List[X]`, and scalar/JSON fields keep their prior behavior. Adds a docstring documenting the helper's contract and its coupling to Strawberry internals.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestExtraFile` | A CV-object `file_format` with `display_title` | `ExtraFile` is constructed | Coerces to the token string | Read-time dict to token |
| 2 | `TestExtraFile` | A bare-string / dict-without-token / omitted `file_format` | `ExtraFile` is constructed | Preserved / None / None | Validator input space |
| 3 | `TestCoerce4dnCvToken` | A CV dict, dict without token, string, and None | `coerce_4dn_cv_token` is called | Token / None / string / None | Shared helper unit coverage |
| 4 | `TestFileMetadataModel` | A doc with dict-shaped `extra.fourdn.extra_files` `file_format` | `FileMetadataModel` is constructed | Deserializes and exposes the token | Model end-to-end |
| 5 | `test_parse_extra_files` | A dict / string / empty / no-field entry | `parse_extra_files` runs | Token / preserved / empty list / dropped | Write-time normalization |
| 6 | `test_from_pydantic` | A dumped model with a nested `Optional[List[ExtraFile]]` and a JSON dict field | `from_pydantic` builds the type | List items become the Strawberry type; JSON dict left untouched | Resolver peel + passthrough |
| 7 | `TestFilesQuery` | A 4DN file with a dict-shaped `extra_files` `file_format` via the real schema | The `files` GraphQL query runs | Returns without errors, exposing the token | End-to-end GraphQL serialization |
| 8 | `tests/test_index.py` | The `/index` 4DN sidecar resolver after the helper refactor | Sidecar lookup runs | Unchanged behavior (regression guard) | Refactor safety |
