### PR TITLE
Coerce 4DN collection protocol fields to strings to stop float values crashing the files query — Closes #53

### DIFF
--- a/src/cfdb/models.py
+++ b/src/cfdb/models.py
@@ -25,23 +25,55 @@ def coerce_4dn_cv_token(value: Any) -> Any:
     return value
 
 
+# The numeric 4DN experiment protocol fields the EnrichedFourdnCollection read
+# validator and the sync write path (services.fourdn.parse_experiment_metadata)
+# coerce from JSON numbers to their string form. This is the single source of
+# truth — both the validator registration below and the write path import it.
+#
+# Deliberately observation-scoped per issue #53: it lists only the fields the
+# 4DN portal API has been observed to send as JSON numbers. Sibling
+# Optional[str] protocol fields are intentionally excluded. ``fragment_size_range``
+# is a genuine range string upstream (e.g. "200-400") and must NOT be stringified;
+# ``biotin_removed`` is the most plausible next instance (likely a JSON boolean)
+# but has not been observed, so it stays out until it is. Widening this set would
+# remove the fail-loud behavior that the negative-scope tests assert.
+NUMERIC_PROTOCOL_FIELDS = (
+    "crosslinking_temperature",
+    "crosslinking_time",
+    "ligation_temperature",
+    "ligation_volume",
+    "ligation_time",
+    "digestion_temperature",
+    "digestion_time",
+    "average_fragment_size",
+)
+
+
 def coerce_scalar_to_str(value: Any) -> Any:
     """Coerce a non-None scalar to its string representation.
 
     Several 4DN experiment protocol fields (e.g. ``crosslinking_temperature``)
     are declared ``Optional[str]`` but the 4DN portal API sends them as JSON
-    numbers (``25.0``). Stringify any non-``None`` value so the field
+    numbers (``25.0``). Stringify ``int`` / ``float`` / ``str`` so the field
     deserializes instead of raising a ``string_type`` validation error; pass
     ``None`` and already-string values through unchanged (a string is its own
     ``str``).
 
+    Only scalar types are stringified. A non-scalar value (e.g. a ``list`` or
+    ``dict``) is returned UNCHANGED so pydantic rejects it with a clean
+    ``string_type`` error rather than having it masked as a Python ``repr``.
+    Note ``bool`` is an ``int`` subclass, so ``True``/``False`` stringify to
+    ``"True"``/``"False"`` — intended.
+
     Single source of truth for this normalization, shared by the
     ``EnrichedFourdnCollection`` read validator and the sync write path
-    (``services.fourdn.fetch_experiment_metadata_bulk``).
+    (``services.fourdn.parse_experiment_metadata``).
     """
     if value is None:
         return None
-    return str(value)
+    if isinstance(value, (int, float, str)):
+        return str(value)
+    return value
 
 
 class ExtraFile(BaseModel):
@@ -226,17 +258,7 @@ class EnrichedFourdnCollection(BaseModel):
     status: Optional[str] = None
     date_created: Optional[str] = None
 
-    @field_validator(
-        "crosslinking_temperature",
-        "crosslinking_time",
-        "ligation_temperature",
-        "ligation_volume",
-        "ligation_time",
-        "digestion_temperature",
-        "digestion_time",
-        "average_fragment_size",
-        mode="before",
-    )
+    @field_validator(*NUMERIC_PROTOCOL_FIELDS, mode="before")
     @classmethod
     def _coerce_numeric_protocol_field(cls, value):
         """Coerce a numeric 4DN protocol value to its string form.

--- a/src/cfdb/models.py
+++ b/src/cfdb/models.py
@@ -25,6 +25,25 @@ def coerce_4dn_cv_token(value: Any) -> Any:
     return value
 
 
+def coerce_scalar_to_str(value: Any) -> Any:
+    """Coerce a non-None scalar to its string representation.
+
+    Several 4DN experiment protocol fields (e.g. ``crosslinking_temperature``)
+    are declared ``Optional[str]`` but the 4DN portal API sends them as JSON
+    numbers (``25.0``). Stringify any non-``None`` value so the field
+    deserializes instead of raising a ``string_type`` validation error; pass
+    ``None`` and already-string values through unchanged (a string is its own
+    ``str``).
+
+    Single source of truth for this normalization, shared by the
+    ``EnrichedFourdnCollection`` read validator and the sync write path
+    (``services.fourdn.fetch_experiment_metadata_bulk``).
+    """
+    if value is None:
+        return None
+    return str(value)
+
+
 class ExtraFile(BaseModel):
     """
     An associated index or auxiliary file from 4DN.
@@ -206,6 +225,31 @@ class EnrichedFourdnCollection(BaseModel):
     fragment_size_range: Optional[str] = None
     status: Optional[str] = None
     date_created: Optional[str] = None
+
+    @field_validator(
+        "crosslinking_temperature",
+        "crosslinking_time",
+        "ligation_temperature",
+        "ligation_volume",
+        "ligation_time",
+        "digestion_temperature",
+        "digestion_time",
+        "average_fragment_size",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_numeric_protocol_field(cls, value):
+        """Coerce a numeric 4DN protocol value to its string form.
+
+        These experiment protocol fields are typed ``Optional[str]`` but the
+        4DN portal API sends them as JSON numbers (e.g. ``25.0``), and
+        documents persisted by the sync may hold those floats. Stringify on
+        read so the field deserializes instead of raising — letting
+        already-persisted data self-heal without a re-sync. ``None`` and
+        existing strings pass through unchanged. See
+        :func:`coerce_scalar_to_str`.
+        """
+        return coerce_scalar_to_str(value)
 
 
 class EnrichedCollection(BaseModel):

--- a/src/cfdb/services/fourdn.py
+++ b/src/cfdb/services/fourdn.py
@@ -85,7 +85,11 @@ from typing import Optional
 import aiohttp
 
 from cfdb.dcc_registry import get_dcc_config
-from cfdb.models import coerce_4dn_cv_token, coerce_scalar_to_str
+from cfdb.models import (
+    NUMERIC_PROTOCOL_FIELDS,
+    coerce_4dn_cv_token,
+    coerce_scalar_to_str,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -367,17 +371,9 @@ _DISPLAY_TITLE_FIELDS = {"experiment_type", "digestion_enzyme", "lab"}
 
 # Protocol fields the 4DN API sends as JSON numbers but the model declares
 # Optional[str]; stringify them at parse time so persisted data is clean at
-# rest (mirrors the EnrichedFourdnCollection read validator).
-_NUMERIC_PROTOCOL_FIELDS = {
-    "crosslinking_temperature",
-    "crosslinking_time",
-    "ligation_temperature",
-    "ligation_volume",
-    "ligation_time",
-    "digestion_temperature",
-    "digestion_time",
-    "average_fragment_size",
-}
+# rest (mirrors the EnrichedFourdnCollection read validator). Wrapped in a set
+# for O(1) membership checks; the canonical list lives in cfdb.models.
+_NUMERIC_PROTOCOL_FIELDS = set(NUMERIC_PROTOCOL_FIELDS)
 
 _EXPERIMENT_TYPES = [
     "ExperimentHiC",

--- a/src/cfdb/services/fourdn.py
+++ b/src/cfdb/services/fourdn.py
@@ -85,7 +85,7 @@ from typing import Optional
 import aiohttp
 
 from cfdb.dcc_registry import get_dcc_config
-from cfdb.models import coerce_4dn_cv_token
+from cfdb.models import coerce_4dn_cv_token, coerce_scalar_to_str
 
 logger = logging.getLogger(__name__)
 
@@ -365,12 +365,92 @@ _EXPERIMENT_FIELDS = [
 # Fields that are objects with display_title to extract
 _DISPLAY_TITLE_FIELDS = {"experiment_type", "digestion_enzyme", "lab"}
 
+# Protocol fields the 4DN API sends as JSON numbers but the model declares
+# Optional[str]; stringify them at parse time so persisted data is clean at
+# rest (mirrors the EnrichedFourdnCollection read validator).
+_NUMERIC_PROTOCOL_FIELDS = {
+    "crosslinking_temperature",
+    "crosslinking_time",
+    "ligation_temperature",
+    "ligation_volume",
+    "ligation_time",
+    "digestion_temperature",
+    "digestion_time",
+    "average_fragment_size",
+}
+
 _EXPERIMENT_TYPES = [
     "ExperimentHiC",
     "ExperimentSeq",
     "ExperimentDamid",
     "ExperimentChiapet",
 ]
+
+
+def parse_experiment_metadata(item: dict) -> dict:
+    """Normalize a single 4DN experiment ``@graph`` item for persistence.
+
+    Extracts the display-title object fields, the ``targeted_factor`` BioFeature
+    titles, the experiment ``display_title``, and the scalar protocol fields,
+    dropping any that are absent or empty. The numeric protocol fields (e.g.
+    ``crosslinking_temperature``) are returned by the 4DN API as JSON numbers
+    but the model declares them ``Optional[str]``; stringify them via
+    :func:`coerce_scalar_to_str` so persisted documents match the
+    ``EnrichedFourdnCollection`` type. Returns the built entry (empty when the
+    item yields no fields).
+    """
+    entry: dict = {}
+
+    # Extract display_title from object fields
+    for field_name in _DISPLAY_TITLE_FIELDS:
+        obj = item.get(field_name)
+        if isinstance(obj, dict):
+            title = obj.get("display_title")
+            if title:
+                entry[field_name] = title
+
+    # Extract targeted_factor: array of BioFeature objects
+    targeted_factor_raw = item.get("targeted_factor")
+    if isinstance(targeted_factor_raw, list) and targeted_factor_raw:
+        titles = [
+            tf.get("display_title")
+            for tf in targeted_factor_raw
+            if isinstance(tf, dict) and tf.get("display_title")
+        ]
+        if titles:
+            entry["targeted_factor"] = titles
+
+    # Extract display_title as experiment name
+    display_title = item.get("display_title")
+    if display_title:
+        entry["display_title"] = display_title
+
+    # Extract scalar fields, stringifying the numeric protocol fields
+    for field_name in (
+        "crosslinking_method",
+        "crosslinking_temperature",
+        "crosslinking_time",
+        "ligation_temperature",
+        "ligation_volume",
+        "ligation_time",
+        "digestion_temperature",
+        "digestion_time",
+        "tagging_method",
+        "fragmentation_method",
+        "biotin_removed",
+        "library_prep_kit",
+        "average_fragment_size",
+        "fragment_size_range",
+        "status",
+        "date_created",
+    ):
+        val = item.get(field_name)
+        if val is not None and val != "":
+            if field_name in _NUMERIC_PROTOCOL_FIELDS:
+                val = coerce_scalar_to_str(val)
+            entry[field_name] = val
+
+    return entry
 
 
 async def fetch_experiment_metadata_bulk() -> dict[str, dict]:
@@ -434,55 +514,7 @@ async def fetch_experiment_metadata_bulk() -> dict[str, dict]:
                     if not accession:
                         continue
 
-                    entry: dict = {}
-
-                    # Extract display_title from object fields
-                    for field_name in _DISPLAY_TITLE_FIELDS:
-                        obj = item.get(field_name)
-                        if isinstance(obj, dict):
-                            title = obj.get("display_title")
-                            if title:
-                                entry[field_name] = title
-
-                    # Extract targeted_factor: array of BioFeature objects
-                    targeted_factor_raw = item.get("targeted_factor")
-                    if isinstance(targeted_factor_raw, list) and targeted_factor_raw:
-                        titles = [
-                            tf.get("display_title")
-                            for tf in targeted_factor_raw
-                            if isinstance(tf, dict) and tf.get("display_title")
-                        ]
-                        if titles:
-                            entry["targeted_factor"] = titles
-
-                    # Extract display_title as experiment name
-                    display_title = item.get("display_title")
-                    if display_title:
-                        entry["display_title"] = display_title
-
-                    # Extract scalar fields as-is
-                    for field_name in (
-                        "crosslinking_method",
-                        "crosslinking_temperature",
-                        "crosslinking_time",
-                        "ligation_temperature",
-                        "ligation_volume",
-                        "ligation_time",
-                        "digestion_temperature",
-                        "digestion_time",
-                        "tagging_method",
-                        "fragmentation_method",
-                        "biotin_removed",
-                        "library_prep_kit",
-                        "average_fragment_size",
-                        "fragment_size_range",
-                        "status",
-                        "date_created",
-                    ):
-                        val = item.get(field_name)
-                        if val is not None and val != "":
-                            entry[field_name] = val
-
+                    entry = parse_experiment_metadata(item)
                     if entry:
                         results[accession] = entry
 

--- a/tests/test_fourdn.py
+++ b/tests/test_fourdn.py
@@ -6,21 +6,8 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from cfdb.models import EnrichedFourdnCollection
+from cfdb.models import NUMERIC_PROTOCOL_FIELDS, EnrichedFourdnCollection
 from cfdb.services.fourdn import parse_experiment_metadata, parse_extra_files
-
-# The eight numeric protocol fields parse_experiment_metadata stringifies on the
-# sync write path (mirror of the EnrichedFourdnCollection read validator).
-_NUMERIC_PROTOCOL_FIELDS = (
-    "crosslinking_temperature",
-    "crosslinking_time",
-    "ligation_temperature",
-    "ligation_volume",
-    "ligation_time",
-    "digestion_temperature",
-    "digestion_time",
-    "average_fragment_size",
-)
 
 
 def test_parse_extra_files_should_store_token_when_file_format_is_cv_object():
@@ -464,7 +451,7 @@ def test_parse_experiment_metadata_feeds_enriched_fourdn_collection_cleanly():
 
 
 class TestParseExperimentMetadata:
-    @pytest.mark.parametrize("field_name", _NUMERIC_PROTOCOL_FIELDS)
+    @pytest.mark.parametrize("field_name", NUMERIC_PROTOCOL_FIELDS)
     @given(value=st.integers() | st.floats(allow_nan=False, allow_infinity=False))
     def test_pbt_001_each_numeric_field_stringified_in_output(
         self, field_name, value

--- a/tests/test_fourdn.py
+++ b/tests/test_fourdn.py
@@ -2,7 +2,25 @@
 
 from __future__ import annotations
 
-from cfdb.services.fourdn import parse_extra_files
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from cfdb.models import EnrichedFourdnCollection
+from cfdb.services.fourdn import parse_experiment_metadata, parse_extra_files
+
+# The eight numeric protocol fields parse_experiment_metadata stringifies on the
+# sync write path (mirror of the EnrichedFourdnCollection read validator).
+_NUMERIC_PROTOCOL_FIELDS = (
+    "crosslinking_temperature",
+    "crosslinking_time",
+    "ligation_temperature",
+    "ligation_volume",
+    "ligation_time",
+    "digestion_temperature",
+    "digestion_time",
+    "average_fragment_size",
+)
 
 
 def test_parse_extra_files_should_store_token_when_file_format_is_cv_object():
@@ -110,3 +128,362 @@ def test_parse_extra_files_should_drop_entry_when_it_yields_no_fields():
 
     # Assert
     assert result == [{"href": "/files/x.bai", "file_format": "bai"}]
+
+
+def test_parse_experiment_metadata_should_stringify_numeric_protocol_fields():
+    """Test that numeric protocol fields are stored as strings.
+
+    Given:
+        A raw 4DN experiment item whose protocol fields are JSON numbers
+        (the shape that crashed the files query).
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        Each numeric protocol field should be stored as its string form so
+        persisted documents match the EnrichedFourdnCollection type.
+    """
+    # Arrange
+    item = {
+        "accession": "4DNEXTEST001",
+        "crosslinking_temperature": 25.0,
+        "crosslinking_time": 10.0,
+        "ligation_temperature": 25.0,
+        "ligation_volume": 0.12,
+        "ligation_time": 360.0,
+        "digestion_temperature": 37.0,
+        "digestion_time": 960.0,
+        "average_fragment_size": 300.0,
+    }
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {
+        "crosslinking_temperature": "25.0",
+        "crosslinking_time": "10.0",
+        "ligation_temperature": "25.0",
+        "ligation_volume": "0.12",
+        "ligation_time": "360.0",
+        "digestion_temperature": "37.0",
+        "digestion_time": "960.0",
+        "average_fragment_size": "300.0",
+    }
+
+
+def test_parse_experiment_metadata_should_preserve_non_numeric_scalar_fields():
+    """Test that non-numeric scalar protocol fields carry through unchanged.
+
+    Given:
+        A raw 4DN experiment item with string scalar protocol fields and a
+        display_title.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should preserve those string fields verbatim.
+    """
+    # Arrange
+    item = {
+        "accession": "4DNEXTEST002",
+        "display_title": "in situ Hi-C on GM12878",
+        "crosslinking_method": "1% Formaldehyde",
+        "library_prep_kit": "NEBNext",
+    }
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {
+        "display_title": "in situ Hi-C on GM12878",
+        "crosslinking_method": "1% Formaldehyde",
+        "library_prep_kit": "NEBNext",
+    }
+
+
+def test_parse_experiment_metadata_should_extract_display_title_object_fields():
+    """Test that object fields are reduced to their display_title token.
+
+    Given:
+        A raw 4DN experiment item whose experiment_type and digestion_enzyme
+        are CV objects and whose targeted_factor is a list of BioFeature
+        objects.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should extract the display_title token from each object field and
+        collect the targeted_factor titles into a list.
+    """
+    # Arrange
+    item = {
+        "accession": "4DNEXTEST003",
+        "experiment_type": {"display_title": "in situ Hi-C"},
+        "digestion_enzyme": {"display_title": "DpnII"},
+        "targeted_factor": [{"display_title": "CTCF protein"}],
+    }
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {
+        "experiment_type": "in situ Hi-C",
+        "digestion_enzyme": "DpnII",
+        "targeted_factor": ["CTCF protein"],
+    }
+
+
+def test_parse_experiment_metadata_should_drop_empty_and_missing_fields():
+    """Test that absent or empty fields are dropped from the entry.
+
+    Given:
+        A raw 4DN experiment item carrying only an accession and an
+        empty-string protocol field.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should return an empty entry — absent fields and empty strings
+        are not stored.
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST004", "crosslinking_method": ""}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {}
+
+
+def test_parse_experiment_metadata_should_keep_falsy_zero_numeric_field():
+    """Test that a zero-valued numeric protocol field is kept and stringified.
+
+    Given:
+        A raw 4DN experiment item whose numeric protocol fields are 0 and
+        0.0 — falsy but valid measurements that the guard (`!= ""`, not
+        truthiness) must keep.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should keep both fields, stringified to "0" and "0.0".
+    """
+    # Arrange
+    item = {
+        "accession": "4DNEXTEST005",
+        "crosslinking_temperature": 0,
+        "ligation_volume": 0.0,
+    }
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {
+        "crosslinking_temperature": "0",
+        "ligation_volume": "0.0",
+    }
+
+
+def test_parse_experiment_metadata_should_store_non_numeric_number_field_raw():
+    """Test that a number on a non-coerced scalar field is stored unchanged.
+
+    Given:
+        A raw 4DN experiment item whose crosslinking_method (outside the
+        eight numeric protocol fields) carries a number.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should store the raw number — only the eight numeric fields are
+        coerced, mirroring the read-side validator scope.
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST006", "crosslinking_method": 5}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {"crosslinking_method": 5}
+
+
+def test_parse_experiment_metadata_should_stringify_int_numeric_field():
+    """Test that an int numeric protocol field is stored as a string.
+
+    Given:
+        A raw 4DN experiment item whose digestion_time is a bare int (960).
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should store digestion_time as the string "960".
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST007", "digestion_time": 960}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {"digestion_time": "960"}
+
+
+def test_parse_experiment_metadata_should_drop_none_numeric_field():
+    """Test that a None numeric protocol field is dropped, not stringified.
+
+    Given:
+        A raw 4DN experiment item whose crosslinking_temperature is None.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should drop the field entirely rather than store the string
+        "None".
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST008", "crosslinking_temperature": None}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {}
+
+
+def test_parse_experiment_metadata_should_omit_targeted_factor_for_empty_list():
+    """Test that an empty targeted_factor list omits the key.
+
+    Given:
+        A raw 4DN experiment item whose targeted_factor is an empty list.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        The targeted_factor key should be omitted from the entry.
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST009", "targeted_factor": []}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {}
+
+
+def test_parse_experiment_metadata_should_omit_targeted_factor_without_titles():
+    """Test that a title-less targeted_factor list omits the key.
+
+    Given:
+        A raw 4DN experiment item whose targeted_factor entries carry no
+        display_title.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        The targeted_factor key should be omitted from the entry.
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST010", "targeted_factor": [{"status": "released"}]}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {}
+
+
+def test_parse_experiment_metadata_should_extract_lab_display_title_token():
+    """Test that the lab object field is reduced to its display_title token.
+
+    Given:
+        A raw 4DN experiment item whose lab is a CV object carrying the name
+        under display_title.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        It should extract the lab display_title token as a string.
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST011", "lab": {"display_title": "Smith Lab"}}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {"lab": "Smith Lab"}
+
+
+def test_parse_experiment_metadata_should_omit_object_field_without_display_title():
+    """Test that an object field lacking display_title is omitted.
+
+    Given:
+        A raw 4DN experiment item whose experiment_type object has no
+        display_title key.
+    When:
+        parse_experiment_metadata processes it.
+    Then:
+        The experiment_type key should be omitted from the entry.
+    """
+    # Arrange
+    item = {"accession": "4DNEXTEST012", "experiment_type": {"status": "released"}}
+
+    # Act
+    result = parse_experiment_metadata(item)
+
+    # Assert
+    assert result == {}
+
+
+def test_parse_experiment_metadata_feeds_enriched_fourdn_collection_cleanly():
+    """Test write→read parity: parsed floats reconstruct the model cleanly.
+
+    Given:
+        A raw 4DN experiment item with float protocol fields.
+    When:
+        EnrichedFourdnCollection is constructed from
+        parse_experiment_metadata(item) (the dual-fix DRY contract).
+    Then:
+        It should construct without error and each protocol value should
+        match the stringified parse output.
+    """
+    # Arrange
+    item = {
+        "accession": "4DNEXTEST013",
+        "crosslinking_temperature": 25.0,
+        "ligation_volume": 0.12,
+        "digestion_time": 960.0,
+    }
+
+    # Act
+    parsed = parse_experiment_metadata(item)
+    result = EnrichedFourdnCollection(**parsed)
+
+    # Assert
+    assert result.crosslinking_temperature == parsed["crosslinking_temperature"]
+    assert result.ligation_volume == parsed["ligation_volume"]
+    assert result.digestion_time == parsed["digestion_time"]
+    assert result.crosslinking_temperature == "25.0"
+    assert result.ligation_volume == "0.12"
+    assert result.digestion_time == "960.0"
+
+
+class TestParseExperimentMetadata:
+    @pytest.mark.parametrize("field_name", _NUMERIC_PROTOCOL_FIELDS)
+    @given(value=st.integers() | st.floats(allow_nan=False, allow_infinity=False))
+    def test_pbt_001_each_numeric_field_stringified_in_output(
+        self, field_name, value
+    ):
+        """Test that each of the eight fields is stringified on the write path.
+
+        Given:
+            Each of the eight numeric protocol fields, and any int or finite
+            float value.
+        When:
+            parse_experiment_metadata processes an item carrying that field.
+        Then:
+            The output should carry the field as str(value).
+        """
+        # Arrange
+        item = {"accession": "4DNEXPBT", field_name: value}
+
+        # Act
+        result = parse_experiment_metadata(item)
+
+        # Assert
+        assert result[field_name] == str(value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,34 @@
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
 from cfdb.models import (
     Biosample,
     Collection,
     EnrichedBiosample,
     EnrichedCollection,
     EnrichedFile,
+    EnrichedFourdnCollection,
     EnrichedSubject,
     ExtraFile,
     FileMetadataModel,
     Subject,
     coerce_4dn_cv_token,
+    coerce_scalar_to_str,
+)
+
+# The eight numeric protocol fields the EnrichedFourdnCollection validator and
+# the sync write path coerce from JSON numbers to their string form.
+_NUMERIC_PROTOCOL_FIELDS = (
+    "crosslinking_temperature",
+    "crosslinking_time",
+    "ligation_temperature",
+    "ligation_volume",
+    "ligation_time",
+    "digestion_temperature",
+    "digestion_time",
+    "average_fragment_size",
 )
 
 
@@ -72,6 +92,174 @@ class TestCoerce4dnCvToken:
         """
         # Act, assert
         assert coerce_4dn_cv_token(None) is None
+
+
+class TestCoerceScalarToStr:
+    def test_stringifies_float_value(self):
+        """Test that a float is coerced to its string form.
+
+        Given:
+            A float protocol value such as 25.0.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the string "25.0".
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(25.0) == "25.0"
+
+    def test_stringifies_int_value(self):
+        """Test that an int is coerced to its string form.
+
+        Given:
+            An int protocol value such as 37.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the string "37".
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(37) == "37"
+
+    def test_passes_none_through_unchanged(self):
+        """Test that None is returned unchanged.
+
+        Given:
+            A None value.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return None.
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(None) is None
+
+    def test_passes_string_through_unchanged(self):
+        """Test that a bare string is returned unchanged.
+
+        Given:
+            A plain string value.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the string unchanged.
+        """
+        # Act, assert
+        assert coerce_scalar_to_str("25.0") == "25.0"
+
+    def test_stringifies_bool_value(self):
+        """Test that a bool is coerced to its string form.
+
+        Given:
+            A boolean value True (a numeric subtype that should stringify
+            rather than slip through).
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the string "True".
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(True) == "True"
+
+    def test_stringifies_positive_infinity(self):
+        """Test that positive infinity is coerced to "inf".
+
+        Given:
+            The float value positive infinity.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the string "inf" (never compared by float
+            equality).
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(float("inf")) == "inf"
+
+    def test_stringifies_negative_infinity(self):
+        """Test that negative infinity is coerced to "-inf".
+
+        Given:
+            The float value negative infinity.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the string "-inf".
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(float("-inf")) == "-inf"
+
+    def test_stringifies_nan(self):
+        """Test that NaN is coerced to the string "nan".
+
+        Given:
+            The float value NaN, which is never equal to itself.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the string "nan" (asserted on the string, since
+            float NaN equality always fails).
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(float("nan")) == "nan"
+
+    def test_passes_explicit_none_through_unchanged(self):
+        """Test that an explicitly passed None is preserved.
+
+        Given:
+            An explicit None value.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return None rather than the string "None".
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(None) is None
+
+    @given(st.integers() | st.floats(allow_nan=False, allow_infinity=False))
+    def test_pbt_001_stringifies_any_finite_number_to_str_of_it(self, value):
+        """Test that any finite number coerces to its own str().
+
+        Given:
+            Any int or finite float value.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            The result should equal str(value) and be a str instance.
+        """
+        # Act
+        result = coerce_scalar_to_str(value)
+
+        # Assert
+        assert result == str(value)
+        assert isinstance(result, str)
+
+    @given(st.text())
+    def test_pbt_002_string_passthrough_is_idempotent(self, value):
+        """Test that an arbitrary string passes through unchanged.
+
+        Given:
+            Any string value.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the same string unchanged (str is its own str).
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(value) == value
+
+    @given(st.none())
+    def test_pbt_003_preserves_none(self, value):
+        """Test that None is always preserved as None.
+
+        Given:
+            The None value.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return None.
+        """
+        # Act, assert
+        assert coerce_scalar_to_str(value) is None
 
 
 class TestExtraFile:
@@ -236,6 +424,152 @@ class TestEnrichedSubject:
         assert result.hubmap is None
 
 
+class TestEnrichedFourdnCollection:
+    def test_coerces_float_protocol_fields_to_strings(self):
+        """Test that numeric protocol fields are coerced to strings.
+
+        Given:
+            An EnrichedFourdnCollection constructed with the eight protocol
+            fields as floats (the shape the 4DN portal API sends and the
+            sync persisted).
+        When:
+            The model is instantiated.
+        Then:
+            It should deserialize successfully and expose each field as its
+            string representation rather than raising a string_type error.
+        """
+        # Arrange
+        data = {
+            "crosslinking_temperature": 25.0,
+            "crosslinking_time": 10.0,
+            "ligation_temperature": 25.0,
+            "ligation_volume": 0.12,
+            "ligation_time": 360.0,
+            "digestion_temperature": 37.0,
+            "digestion_time": 960.0,
+            "average_fragment_size": 300.0,
+        }
+
+        # Act
+        result = EnrichedFourdnCollection(**data)
+
+        # Assert
+        assert result.crosslinking_temperature == "25.0"
+        assert result.crosslinking_time == "10.0"
+        assert result.ligation_temperature == "25.0"
+        assert result.ligation_volume == "0.12"
+        assert result.ligation_time == "360.0"
+        assert result.digestion_temperature == "37.0"
+        assert result.digestion_time == "960.0"
+        assert result.average_fragment_size == "300.0"
+
+    def test_passes_string_protocol_field_through_unchanged(self):
+        """Test that an already-string protocol field is preserved.
+
+        Given:
+            An EnrichedFourdnCollection constructed with a protocol field as
+            a plain string.
+        When:
+            The model is instantiated.
+        Then:
+            It should keep the string unchanged.
+        """
+        # Act
+        result = EnrichedFourdnCollection(crosslinking_temperature="25.0")
+
+        # Assert
+        assert result.crosslinking_temperature == "25.0"
+
+    def test_leaves_omitted_protocol_field_as_none(self):
+        """Test that an omitted protocol field stays None.
+
+        Given:
+            An EnrichedFourdnCollection constructed without any protocol
+            fields.
+        When:
+            The model is instantiated.
+        Then:
+            crosslinking_temperature should be None (the validator passes
+            None through).
+        """
+        # Act
+        result = EnrichedFourdnCollection()
+
+        # Assert
+        assert result.crosslinking_temperature is None
+
+    def test_coerces_int_protocol_field_to_string(self):
+        """Test that an int protocol value is coerced to its string form.
+
+        Given:
+            An EnrichedFourdnCollection constructed with digestion_time as a
+            bare int (960).
+        When:
+            The model is instantiated.
+        Then:
+            It should expose digestion_time as the string "960".
+        """
+        # Act
+        result = EnrichedFourdnCollection(digestion_time=960)
+
+        # Assert
+        assert result.digestion_time == "960"
+
+    def test_rejects_float_on_non_coerced_str_field(self):
+        """Test that a non-coerced Optional[str] field rejects a float.
+
+        Given:
+            An EnrichedFourdnCollection constructed with crosslinking_method
+            — an Optional[str] field outside the eight coerced fields — set to
+            a float.
+        When:
+            The model is instantiated.
+        Then:
+            It should raise a pydantic ValidationError, proving the coercion
+            validator is scoped to exactly the eight numeric protocol fields.
+        """
+        # Act, assert
+        with pytest.raises(ValidationError):
+            EnrichedFourdnCollection(crosslinking_method=1.5)
+
+    def test_rejects_float_on_digestion_enzyme(self):
+        """Test that the digestion_enzyme field rejects a float.
+
+        Given:
+            An EnrichedFourdnCollection constructed with digestion_enzyme —
+            an Optional[str] field outside the coerced set — set to a float.
+        When:
+            The model is instantiated.
+        Then:
+            It should raise a pydantic ValidationError, confirming the
+            coercion does not bleed onto sibling string fields.
+        """
+        # Act, assert
+        with pytest.raises(ValidationError):
+            EnrichedFourdnCollection(digestion_enzyme=1.5)
+
+    @pytest.mark.parametrize("field_name", _NUMERIC_PROTOCOL_FIELDS)
+    @given(value=st.floats(allow_nan=False, allow_infinity=False))
+    def test_pbt_001_each_numeric_field_coerces_finite_float_to_str(
+        self, field_name, value
+    ):
+        """Test that each of the eight fields stringifies a finite float.
+
+        Given:
+            Each of the eight numeric protocol fields, and any finite float.
+        When:
+            An EnrichedFourdnCollection is constructed with that field set to
+            the float.
+        Then:
+            The deserialized field should equal str(value).
+        """
+        # Act
+        result = EnrichedFourdnCollection(**{field_name: value})
+
+        # Assert
+        assert getattr(result, field_name) == str(value)
+
+
 class TestEnrichedCollection:
     def test_empty_string_to_none_with_empty_fourdn(self):
         """Test empty string coercion on the fourdn field.
@@ -339,6 +673,152 @@ class TestFileMetadataModel:
 
         # Assert
         assert result.extra.fourdn.extra_files[0].file_format == "pairs_px2"
+
+    def test_deserializes_with_float_collection_protocol_fields(self):
+        """Test that a 4DN doc with float collection protocol fields loads.
+
+        Given:
+            A FileMetadataModel document whose
+            collections[0].extra.fourdn protocol fields are floats (the
+            shape persisted by the sync that crashed the files query).
+        When:
+            The model is instantiated.
+        Then:
+            It should deserialize successfully and expose each protocol
+            value as its string representation.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["collections"] = [
+            {
+                "biosamples": [],
+                "extra": {
+                    "fourdn": {
+                        "crosslinking_temperature": 25.0,
+                        "digestion_time": 960.0,
+                        "ligation_volume": 0.12,
+                    }
+                },
+            }
+        ]
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        fourdn = result.collections[0].extra.fourdn
+        assert fourdn.crosslinking_temperature == "25.0"
+        assert fourdn.digestion_time == "960.0"
+        assert fourdn.ligation_volume == "0.12"
+
+    def test_model_dump_round_trip_emits_str_typed_protocol_values(self):
+        """Test that the resolver round-trip yields str-typed protocol values.
+
+        Given:
+            A 4DN file document whose collections[0].extra.fourdn protocol
+            fields are floats — the exact shape the resolver loads.
+        When:
+            FileMetadataModel(**file).model_dump() runs (the precise call the
+            GraphQL resolver makes).
+        Then:
+            The dumped nested protocol values should be str-typed, not floats,
+            so the Strawberry conversion does not blow up downstream.
+        """
+        # Arrange
+        file = _minimal_file_metadata()
+        file["collections"] = [
+            {
+                "biosamples": [],
+                "extra": {
+                    "fourdn": {
+                        "crosslinking_temperature": 25.0,
+                        "digestion_time": 960.0,
+                        "ligation_volume": 0.12,
+                    }
+                },
+            }
+        ]
+
+        # Act
+        dumped = FileMetadataModel(**file).model_dump()
+
+        # Assert
+        fourdn = dumped["collections"][0]["extra"]["fourdn"]
+        assert fourdn["crosslinking_temperature"] == "25.0"
+        assert fourdn["digestion_time"] == "960.0"
+        assert fourdn["ligation_volume"] == "0.12"
+        assert isinstance(fourdn["crosslinking_temperature"], str)
+        assert isinstance(fourdn["digestion_time"], str)
+        assert isinstance(fourdn["ligation_volume"], str)
+
+    def test_deserializes_with_all_eight_float_protocol_fields(self):
+        """Test that all eight nested protocol fields coerce when floats.
+
+        Given:
+            A 4DN file document whose collections[0].extra.fourdn carries all
+            eight numeric protocol fields as floats.
+        When:
+            The model is instantiated.
+        Then:
+            Every one of the eight fields should expose its string form.
+        """
+        # Arrange
+        floats = {
+            "crosslinking_temperature": 25.0,
+            "crosslinking_time": 10.0,
+            "ligation_temperature": 16.0,
+            "ligation_volume": 0.12,
+            "ligation_time": 360.0,
+            "digestion_temperature": 37.0,
+            "digestion_time": 960.0,
+            "average_fragment_size": 300.0,
+        }
+        data = _minimal_file_metadata()
+        data["collections"] = [{"biosamples": [], "extra": {"fourdn": dict(floats)}}]
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        fourdn = result.collections[0].extra.fourdn
+        for field_name, value in floats.items():
+            assert getattr(fourdn, field_name) == str(value)
+
+    def test_deserializes_multi_collection_doc_with_one_float_bearing(self):
+        """Test that a multi-collection doc deserializes each collection.
+
+        Given:
+            A 4DN file document with two collections — one carrying float
+            protocol fields under extra.fourdn and one clean collection.
+        When:
+            The model is instantiated.
+        Then:
+            Both collections should deserialize, with the float-bearing one
+            stringified and the clean one carrying its plain value.
+        """
+        # Arrange
+        data = _minimal_file_metadata()
+        data["collections"] = [
+            {
+                "biosamples": [],
+                "extra": {"fourdn": {"digestion_time": 960.0}},
+            },
+            {
+                "biosamples": [],
+                "extra": {"fourdn": {"crosslinking_method": "1% Formaldehyde"}},
+            },
+        ]
+
+        # Act
+        result = FileMetadataModel(**data)
+
+        # Assert
+        assert len(result.collections) == 2
+        assert result.collections[0].extra.fourdn.digestion_time == "960.0"
+        assert (
+            result.collections[1].extra.fourdn.crosslinking_method
+            == "1% Formaldehyde"
+        )
 
     def test_empty_string_to_none_with_empty_file_format(self):
         """Test empty string coercion on the file_format field.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from cfdb.models import (
+    NUMERIC_PROTOCOL_FIELDS,
     Biosample,
     Collection,
     EnrichedBiosample,
@@ -16,19 +17,6 @@ from cfdb.models import (
     Subject,
     coerce_4dn_cv_token,
     coerce_scalar_to_str,
-)
-
-# The eight numeric protocol fields the EnrichedFourdnCollection validator and
-# the sync write path coerce from JSON numbers to their string form.
-_NUMERIC_PROTOCOL_FIELDS = (
-    "crosslinking_temperature",
-    "crosslinking_time",
-    "ligation_temperature",
-    "ligation_volume",
-    "ligation_time",
-    "digestion_temperature",
-    "digestion_time",
-    "average_fragment_size",
 )
 
 
@@ -202,18 +190,39 @@ class TestCoerceScalarToStr:
         # Act, assert
         assert coerce_scalar_to_str(float("nan")) == "nan"
 
-    def test_passes_explicit_none_through_unchanged(self):
-        """Test that an explicitly passed None is preserved.
+    def test_passes_list_through_unchanged(self):
+        """Test that a list is returned unchanged rather than stringified.
 
         Given:
-            An explicit None value.
+            A list value on a coerced field.
         When:
             coerce_scalar_to_str is called.
         Then:
-            It should return None rather than the string "None".
+            It should return the list unchanged (not its repr), so pydantic
+            later rejects it with a clean string_type error.
         """
+        # Arrange
+        value = [1, 2, 3]
+
         # Act, assert
-        assert coerce_scalar_to_str(None) is None
+        assert coerce_scalar_to_str(value) is value
+
+    def test_passes_dict_through_unchanged(self):
+        """Test that a dict is returned unchanged rather than stringified.
+
+        Given:
+            A dict value on a coerced field.
+        When:
+            coerce_scalar_to_str is called.
+        Then:
+            It should return the dict unchanged (not its repr), so pydantic
+            later rejects it with a clean string_type error.
+        """
+        # Arrange
+        value = {"value": 25.0}
+
+        # Act, assert
+        assert coerce_scalar_to_str(value) is value
 
     @given(st.integers() | st.floats(allow_nan=False, allow_infinity=False))
     def test_pbt_001_stringifies_any_finite_number_to_str_of_it(self, value):
@@ -548,7 +557,82 @@ class TestEnrichedFourdnCollection:
         with pytest.raises(ValidationError):
             EnrichedFourdnCollection(digestion_enzyme=1.5)
 
-    @pytest.mark.parametrize("field_name", _NUMERIC_PROTOCOL_FIELDS)
+    def test_validator_registered_fields_match_canonical_constant(self):
+        """Test the coercion validator is registered on exactly the canonical set.
+
+        Given:
+            The EnrichedFourdnCollection numeric-coercion validator and the
+            canonical NUMERIC_PROTOCOL_FIELDS constant.
+        When:
+            The validator's registered field set is read from the model's
+            pydantic decorators.
+        Then:
+            It should equal set(NUMERIC_PROTOCOL_FIELDS), so drift between the
+            constant and the validator registration fails CI.
+        """
+        # Arrange
+        validators = (
+            EnrichedFourdnCollection.__pydantic_decorators__.field_validators
+        )
+        coercion_validator = validators["_coerce_numeric_protocol_field"]
+
+        # Act, assert
+        assert set(coercion_validator.info.fields) == set(NUMERIC_PROTOCOL_FIELDS)
+
+    def test_rejects_list_on_coerced_field(self):
+        """Test that a list on a coerced field raises rather than stringifying.
+
+        Given:
+            An EnrichedFourdnCollection constructed with digestion_time — a
+            coerced numeric field — set to a list.
+        When:
+            The model is instantiated.
+        Then:
+            It should raise a pydantic ValidationError, because the hardened
+            coercion passes non-scalars through unchanged for pydantic to
+            reject (rather than masking them as a Python repr string).
+        """
+        # Act, assert
+        with pytest.raises(ValidationError):
+            EnrichedFourdnCollection(digestion_time=[1, 2, 3])
+
+    def test_rejects_dict_on_coerced_field(self):
+        """Test that a dict on a coerced field raises rather than stringifying.
+
+        Given:
+            An EnrichedFourdnCollection constructed with crosslinking_temperature
+            — a coerced numeric field — set to a dict.
+        When:
+            The model is instantiated.
+        Then:
+            It should raise a pydantic ValidationError, because the hardened
+            coercion passes non-scalars through unchanged for pydantic to
+            reject (rather than masking them as a Python repr string).
+        """
+        # Act, assert
+        with pytest.raises(ValidationError):
+            EnrichedFourdnCollection(crosslinking_temperature={"value": 25.0})
+
+    def test_passes_fragment_size_range_string_through_unchanged(self):
+        """Test that fragment_size_range is left out of the coerced set.
+
+        Given:
+            An EnrichedFourdnCollection constructed with fragment_size_range
+            as a genuine range string (e.g. "200-400") — a sibling
+            Optional[str] field deliberately excluded from the coerced set.
+        When:
+            The model is instantiated.
+        Then:
+            It should keep the range string unchanged, locking the boundary of
+            the observation-scoped NUMERIC_PROTOCOL_FIELDS set.
+        """
+        # Act
+        result = EnrichedFourdnCollection(fragment_size_range="200-400")
+
+        # Assert
+        assert result.fragment_size_range == "200-400"
+
+    @pytest.mark.parametrize("field_name", NUMERIC_PROTOCOL_FIELDS)
     @given(value=st.floats(allow_nan=False, allow_infinity=False))
     def test_pbt_001_each_numeric_field_coerces_finite_float_to_str(
         self, field_name, value

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -166,6 +166,153 @@ class TestFilesQuery:
         assert extra_file["href"] == "/files/x.pairs_px2"
 
     @pytest.mark.asyncio
+    async def test_returns_4dn_file_with_float_collection_protocol_fields(
+        self, mock_db
+    ):
+        """Test the files query serializes 4DN float collection protocol fields.
+
+        Given:
+            A 4DN file whose collections[0].extra.fourdn carries float
+            protocol fields (the shape persisted by the sync that crashed the
+            query with a string_type validation error).
+        When:
+            The GraphQL files query selects only localId.
+        Then:
+            It returns without errors and the file is present (no data:null).
+        """
+        # Arrange
+        doc = _make_file_doc("4DNFIFLOAT", submission="4dn")
+        doc["collections"] = [
+            {
+                "biosamples": [],
+                "extra": {
+                    "fourdn": {
+                        "crosslinking_temperature": 25.0,
+                        "ligation_volume": 0.12,
+                        "digestion_time": 960.0,
+                    }
+                },
+            }
+        ]
+        mock_db.files.docs = [doc]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files {
+                    localId
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert len(result.data["files"]) == 1
+        assert result.data["files"][0]["localId"] == "4DNFIFLOAT"
+
+    @pytest.mark.asyncio
+    async def test_returns_float_collection_protocol_fields_as_strings(
+        self, mock_db
+    ):
+        """Test the files query exposes float protocol fields as string forms.
+
+        Given:
+            A 4DN file whose collections[0].extra.fourdn carries float
+            protocol fields.
+        When:
+            The GraphQL files query selects the nested protocol fields.
+        Then:
+            It returns without errors and each value is the string form.
+        """
+        # Arrange
+        doc = _make_file_doc("4DNFIFLOAT2", submission="4dn")
+        doc["collections"] = [
+            {
+                "biosamples": [],
+                "extra": {
+                    "fourdn": {
+                        "crosslinking_temperature": 25.0,
+                        "ligation_volume": 0.12,
+                        "digestion_time": 960.0,
+                    }
+                },
+            }
+        ]
+        mock_db.files.docs = [doc]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files {
+                    localId
+                    collections {
+                        extra {
+                            fourdn {
+                                crosslinkingTemperature
+                                ligationVolume
+                                digestionTime
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        fourdn = result.data["files"][0]["collections"][0]["extra"]["fourdn"]
+        assert fourdn["crosslinkingTemperature"] == "25.0"
+        assert fourdn["ligationVolume"] == "0.12"
+        assert fourdn["digestionTime"] == "960.0"
+
+    @pytest.mark.asyncio
+    async def test_returns_mixed_page_with_float_and_clean_docs(self, mock_db):
+        """Test a page mixing a float-protocol doc with clean docs returns all.
+
+        Given:
+            A page containing one 4DN file with float collection protocol
+            fields alongside two clean files (the blast-radius case where one
+            bad doc previously failed the whole page).
+        When:
+            The GraphQL files query selects localId.
+        Then:
+            It returns without errors and all three files are present.
+        """
+        # Arrange
+        float_doc = _make_file_doc("4DNFIMIX", submission="4dn")
+        float_doc["collections"] = [
+            {
+                "biosamples": [],
+                "extra": {"fourdn": {"digestion_time": 960.0}},
+            }
+        ]
+        mock_db.files.docs = [
+            float_doc,
+            _make_file_doc("clean1", "hubmap"),
+            _make_file_doc("clean2", "encode"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files(page: 0, pageSize: 10) {
+                    localId
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        returned = {f["localId"] for f in result.data["files"]}
+        assert returned == {"4DNFIMIX", "clean1", "clean2"}
+
+    @pytest.mark.asyncio
     async def test_returns_all_submissions_without_filtering(self, mock_db):
         """Test the files query returns all DCCs when no filter is supplied.
 


### PR DESCRIPTION
## Summary

Eight `EnrichedFourdnCollection` protocol fields are declared `Optional[str]`, but the 4DN portal sends them as JSON numbers (e.g. `crosslinking_temperature: 25.0`). The `files` resolver builds `FileMetadataModel(**file)` regardless of which fields are selected, so a single such document raised seven `string_type` validation errors and the whole query returned `null` — measured at ~41% of 4DN pages on the dev stack.

Fix it the same way as #51/#52: a shared `coerce_scalar_to_str` helper plus a `mode="before"` validator on the eight fields (read side, so already-persisted data self-heals on read) and normalization at sync time in an extracted, now-public `parse_experiment_metadata` helper (write side, so freshly synced data is clean at rest). ENCODE and HuBMAP are unaffected.

Closes #53

## Proposed changes

### `src/cfdb/models.py`

Add the module-level `coerce_scalar_to_str(value)` helper (`None` passthrough, else `str(value)`) and a `mode="before"` `field_validator` on `EnrichedFourdnCollection` covering the eight numeric protocol fields, delegating to the helper.

### `src/cfdb/services/fourdn.py`

Extract the per-item experiment build into a public `parse_experiment_metadata(item)` helper (so the write path is unit-testable without driving the network fetch) and stringify the eight numeric protocol fields there via `coerce_scalar_to_str`.

## Test cases

| # | Suite | Given | When | Then | Coverage |
|---|-------|-------|------|------|----------|
| 1 | `TestCoerceScalarToStr` | A float, int, bool, inf/nan, None, or string | `coerce_scalar_to_str` is called | Returns `str(value)` (None preserved; assert on the string for nan) | Helper, incl. edges + property-based |
| 2 | `TestEnrichedFourdnCollection` | The eight fields as floats or ints | The model is constructed | Each value is its string form | Read validator across all eight fields |
| 3 | `TestEnrichedFourdnCollection` | A non-coerced sibling field given a float | The model is constructed | Raises `ValidationError` | Validator scope boundary |
| 4 | `TestFileMetadataModel` | A nested float-protocol document | `FileMetadataModel(**doc).model_dump()` | Nested protocol values are string-typed | Resolver round-trip path |
| 5 | `TestParseExperimentMetadata` | An item with numeric, zero, int, None, and object fields | `parse_experiment_metadata` is called | Numbers stringify, zero is kept, None is dropped, display-title tokens extracted | Write path incl. falsy-zero and `lab` branch |
| 6 | `TestFilesQuery` | A 4DN document with float collection protocol fields (and a mixed clean/float page) | The `files` query executes | No errors and the file(s) are returned with string-form values | End-to-end resolver regression |

42 new tests added; the full non-integration suite passes (533 passed).