### PR TITLE
Drop the non-functional live-image verify step from the deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -160,44 +160,6 @@ jobs:
             --cluster "$CLUSTER" \
             --services "$SERVICE"
 
-      # Best-effort guard against the "bootstrap not done" failure mode: if the
-      # task definition still pins a :<sha> instead of the moving :$MOVING_TAG,
-      # this deploy reports green (push + update-service + wait all succeed) but
-      # ships nothing — the service re-pulled the old pinned image. Warn rather
-      # than fail: we cannot read the task definition directly (the cfdb-deploy
-      # role intentionally lacks ecs:DescribeTaskDefinition), so we inspect the
-      # image of a running task via list-tasks -> describe-tasks (both granted)
-      # and check it ends in :$MOVING_TAG. continue-on-error keeps a transient
-      # describe hiccup from failing an otherwise-good deploy.
-      - name: Verify live image is moving tag
-        continue-on-error: true
-        env:
-          CLUSTER: ${{ vars.BACKEND_CLUSTER }}
-          SERVICE: ${{ vars.BACKEND_SERVICE }}
-        run: |
-          TASK_ARN=$(aws ecs list-tasks \
-            --region "$AWS_REGION" \
-            --cluster "$CLUSTER" \
-            --service-name "$SERVICE" \
-            --desired-status RUNNING \
-            --query 'taskArns[0]' --output text)
-          if [ -z "$TASK_ARN" ] || [ "$TASK_ARN" = "None" ]; then
-            echo "::warning::No running task found; skipping live-image check"
-            exit 0
-          fi
-          IMAGE=$(aws ecs describe-tasks \
-            --region "$AWS_REGION" \
-            --cluster "$CLUSTER" \
-            --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].image' --output text)
-          echo "Live API image: $IMAGE"
-          case "$IMAGE" in
-            *:"$MOVING_TAG")
-              echo "Live image references the moving :$MOVING_TAG tag." ;;
-            *)
-              echo "::warning::Live API image ($IMAGE) does not reference :$MOVING_TAG — the one-time task-definition bootstrap may not have been run, so this deploy may not have shipped new code. See the README CI auto-deploy bootstrap note." ;;
-          esac
-
       # No ECS step for the worker fleet: the worker task definition also
       # references :$MOVING_TAG, and the workers are ephemeral — the next
       # EcsProvisioner RunTask (issued by the API role at workflow dispatch)


### PR DESCRIPTION
## Summary

The `Verify live image is moving tag` step in the deploy workflow emits a `[failure]` annotation on every `master` deploy (e.g. run for the #56 merge), even though the deploy itself succeeds. It calls `aws ecs list-tasks`, which the `cfdb-deploy` CI role cannot perform: the role's `ecs:ListTasks` grant is scoped to `service/*` / `task/*` resource ARNs, but `ListTasks` authorizes against the **cluster** resource — so every run hits `AccessDeniedException`. The step is `continue-on-error`, so it does not fail the deploy, but it produces a misleading red annotation and cannot be made to work without widening the role's IAM.

There is no permission-compatible way for the role to read the live image (the alternatives need `ecs:DescribeTaskDefinition`, also intentionally not granted), so the guard can't fulfil its purpose. The deploy already has a real completion signal — `aws ecs wait services-stable` — and the README documents the bootstrap-not-done failure mode the guard was meant to catch. So this removes the guard rather than papering over it.

The moving-tag deploy is otherwise confirmed working end-to-end: the #56 merge deploy pushed `cfdb:dev` and the live service re-pulled that exact digest (`rolloutState=COMPLETED`).

## Proposed changes

### `.github/workflows/deploy-to-ecr.yml`

Remove the `Verify live image is moving tag` step (and its explanatory comment). No other steps change; the worker-fleet comment that followed it is retained.

## Notes

Out of scope (separate follow-up): the workflow also surfaces a Node 20 deprecation warning on the pinned `actions/checkout` and `aws-actions/configure-aws-credentials` actions — bumping those action SHAs to Node 24-targeting versions would clear it.