### PR TITLE
Add fileCount GraphQL query for match counts without paging — Closes #77

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ The `cloudformation/backend.yml` `ImageURI` and `cloudformation/workers.yml` `Wo
 
 ### Queries
 
-The API exposes three queries: `files` (paginated list), `file` (single lookup by MongoDB ObjectId), and `distinctValues` (unique values for a set of queryable fields).
+The API exposes four queries: `files` (paginated list), `file` (single lookup by MongoDB ObjectId), `fileCount` (match count for a filter, without fetching any documents), and `distinctValues` (unique values for a set of queryable fields).
 
-`files` returns a `FileList` envelope rather than a bare list: `items` carries the requested page, and `totalCount` reports how many documents match `input` in total — before `page`/`pageSize` are applied — so clients can size pagination controls.
+`files` returns a `FileList` envelope rather than a bare list: `items` carries the requested page, and `totalCount` reports how many documents match `input` in total — before `page`/`pageSize` are applied — so clients can size pagination controls. Use `fileCount` when only the count is needed: it runs the same filter without materializing a page of documents.
 
 ```graphql
 query {
@@ -259,6 +259,8 @@ curl -X POST http://localhost:8000/metadata \
 ```
 
 Single file lookup: `{ file(id: "507f1f77bcf86cd799439011") { filename accessUrl } }`
+
+File count for a filter: `{ fileCount(input: [{ dcc: [{ dccAbbreviation: ["4DN"] }] }]) }` — returns the number of matching files without fetching any documents. It accepts the same `FileMetadataInput` filter shape as `files`; with no `input` it counts every file.
 
 ### Query Mechanics
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -511,6 +511,7 @@ type Query {
   files(input: [FileMetadataInput!] = null, page: Int! = 0, pageSize: Int! = 25): FileList!
   file(id: ObjectIdScalar!): FileMetadataType
   distinctValues(fields: [String!]!, input: [FileMetadataInput!] = null): [DistinctFieldType!]!
+  fileCount(input: [FileMetadataInput!] = null): Int!
 }
 
 input SubjectInput {

--- a/src/cfdb/api/gql/schema.py
+++ b/src/cfdb/api/gql/schema.py
@@ -161,5 +161,19 @@ class Query:
             for field, values in zip(fields, all_values)
         ]
 
+    @strawberry.field
+    async def file_count(
+        self,
+        _: strawberry.Info,
+        input: list[FileMetadataInput] | None = None,
+    ) -> int:
+        # Wait for any database cutover to complete
+        await locks.wait_for_cutover()
+
+        assert api.db is not None
+        query = to_query(to_dict(input)) if input else {}
+
+        return await api.db.files.count_documents(query)
+
 
 schema = strawberry.Schema(query=Query)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -945,3 +945,357 @@ class TestDistinctValuesQuery:
         # Assert
         assert result.errors is not None
         assert "file_format" in result.errors[0].message
+
+
+# DCC abbreviations the fileCount property test draws documents and filters
+# from. Kept small so generated docs use fake-resolvable dict paths
+# (``dcc.dcc_abbreviation``).
+_DCC_POOL = ["hubmap", "4dn", "encode"]
+
+
+class TestFileCountQuery:
+    @pytest.fixture(autouse=True)
+    def _patch_cutover(self, mocker):
+        """No-op ``locks.wait_for_cutover`` for every test in this class."""
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_return_total_when_no_filter(self, mock_db):
+        """Test the file count reflects every document when no filter is supplied.
+
+        Given:
+            Three files spanning multiple DCCs
+        When:
+            The fileCount query is executed with no input filter
+        Then:
+            It should return the total number of files
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("h1", "hubmap"),
+            _make_file_doc("f1", "4dn"),
+            _make_file_doc("e1", "encode"),
+        ]
+
+        # Act
+        result = await schema.execute("query { fileCount }")
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 3
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_count_only_matches_when_filter_applied(
+        self, mock_db
+    ):
+        """Test the file count honors an input filter.
+
+        Given:
+            Three files, two from HuBMAP and one from 4DN
+        When:
+            The fileCount query is executed with a DCC filter for HuBMAP
+        Then:
+            It should return only the count of matching files
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("h1", "hubmap"),
+            _make_file_doc("h2", "hubmap"),
+            _make_file_doc("f1", "4dn"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                fileCount(input: [{ dcc: [{ dccAbbreviation: ["hubmap"] }] }])
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 2
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_return_zero_when_filter_matches_nothing(
+        self, mock_db
+    ):
+        """Test the file count is zero when no document satisfies the filter.
+
+        Given:
+            Three files, none from the filtered DCC
+        When:
+            The fileCount query is executed with a DCC filter for an absent DCC
+        Then:
+            It should return zero
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("h1", "hubmap"),
+            _make_file_doc("h2", "hubmap"),
+            _make_file_doc("f1", "4dn"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                fileCount(input: [{ dcc: [{ dccAbbreviation: ["encode"] }] }])
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 0
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_return_zero_when_database_empty(self, mock_db):
+        """Test the file count is zero against an empty collection.
+
+        Given:
+            An empty database
+        When:
+            The fileCount query is executed with no input filter
+        Then:
+            It should return zero
+        """
+        # Arrange
+        mock_db.files.docs = []
+
+        # Act
+        result = await schema.execute("query { fileCount }")
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 0
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_count_all_when_input_is_an_empty_list(
+        self, mock_db
+    ):
+        """Test a present-but-empty input list counts every document.
+
+        Given:
+            Three files and an explicitly empty input list
+        When:
+            The fileCount query is executed with input: []
+        Then:
+            It should return the total, since an empty list is falsy and
+            builds no filter (distinct from an omitted/null input)
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("h1", "hubmap"),
+            _make_file_doc("f1", "4dn"),
+            _make_file_doc("e1", "encode"),
+        ]
+
+        # Act
+        result = await schema.execute("query { fileCount(input: []) }")
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 3
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_count_the_union_when_a_field_lists_multiple_values(
+        self, mock_db
+    ):
+        """Test multiple values in one field are combined as an OR union.
+
+        Given:
+            Three files, one each from HuBMAP, 4DN, and ENCODE
+        When:
+            The fileCount query is executed with a DCC filter listing two
+            abbreviations (["hubmap", "4dn"])
+        Then:
+            It should return the union count of the two DCCs, excluding ENCODE
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("h1", "hubmap"),
+            _make_file_doc("f1", "4dn"),
+            _make_file_doc("e1", "encode"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                fileCount(input: [{ dcc: [{ dccAbbreviation: ["hubmap", "4dn"] }] }])
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 2
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_count_the_union_when_input_has_multiple_entries(
+        self, mock_db
+    ):
+        """Test multiple entries in the outer input list are combined as an OR.
+
+        Given:
+            Three files with distinct local IDs
+        When:
+            The fileCount query is executed with two separate input entries,
+            each filtering a different local ID
+        Then:
+            It should return the union count of the two entries
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("h1", "hubmap"),
+            _make_file_doc("f1", "4dn"),
+            _make_file_doc("e1", "encode"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                fileCount(input: [{ localId: ["h1"] }, { localId: ["f1"] }])
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 2
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_count_the_intersection_when_multiple_fields_filter(
+        self, mock_db
+    ):
+        """Test multiple fields in one entry are combined as an AND intersection.
+
+        Given:
+            Three files: a public HuBMAP file, a non-public HuBMAP file, and a
+            public 4DN file
+        When:
+            The fileCount query is executed with a filter combining a DCC field
+            and a data-access-level field (HuBMAP AND public)
+        Then:
+            It should return only the file matching both conditions, excluding
+            the non-public HuBMAP file and the public 4DN file
+        """
+        # Arrange
+        public_hubmap = _make_file_doc("h1", "hubmap")
+        protected_hubmap = _make_file_doc("h2", "hubmap")
+        protected_hubmap["data_access_level"] = "protected"
+        public_4dn = _make_file_doc("f1", "4dn")
+        mock_db.files.docs = [public_hubmap, protected_hubmap, public_4dn]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                fileCount(input: [{
+                    dcc: [{ dccAbbreviation: ["hubmap"] }],
+                    dataAccessLevel: ["public"]
+                }])
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == 1
+
+    @pytest.mark.asyncio
+    async def test_file_count_should_equal_the_files_result_length_for_the_same_filter(
+        self, mock_db
+    ):
+        """Test fileCount agrees with the number of files the same filter returns.
+
+        Given:
+            A mixed multi-DCC dataset smaller than one page
+        When:
+            The fileCount and files queries are executed with the same filter
+        Then:
+            fileCount should equal the length of the files result
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("h1", "hubmap"),
+            _make_file_doc("h2", "hubmap"),
+            _make_file_doc("f1", "4dn"),
+            _make_file_doc("e1", "encode"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                fileCount(input: [{ dcc: [{ dccAbbreviation: ["hubmap"] }] }])
+                files(input: [{ dcc: [{ dccAbbreviation: ["hubmap"] }] }], pageSize: 100) {
+                    items {
+                        localId
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == len(result.data["files"]["items"])
+        assert result.data["fileCount"] == 2
+
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[
+            HealthCheck.function_scoped_fixture,
+            HealthCheck.too_slow,
+        ],
+    )
+    @given(
+        abbreviations=st.lists(st.sampled_from(_DCC_POOL), max_size=15),
+        selected=st.lists(st.sampled_from(_DCC_POOL), unique=True),
+    )
+    def test_file_count_should_equal_the_number_of_matching_documents(
+        self, mock_db, abbreviations, selected
+    ):
+        """Test the count equals the number of documents matching the filter.
+
+        Given:
+            An arbitrary set of files each tagged with a DCC abbreviation drawn
+            from a small pool, and an arbitrary (possibly empty) subset of
+            abbreviations as the filter
+        When:
+            The fileCount query is executed with that filter (or no filter when
+            the subset is empty)
+        Then:
+            It should equal the number of files whose abbreviation is in the
+            subset, and the total when the subset is empty
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc(f"f{i}", abbr) for i, abbr in enumerate(abbreviations)
+        ]
+        variables = (
+            {"input": [{"dcc": [{"dccAbbreviation": selected}]}]} if selected else None
+        )
+        expected = (
+            sum(1 for abbr in abbreviations if abbr in selected)
+            if selected
+            else len(abbreviations)
+        )
+
+        # Act
+        result = asyncio.run(
+            schema.execute(
+                "query FileCount($input: [FileMetadataInput!]) {"
+                " fileCount(input: $input) }",
+                variable_values=variables,
+            )
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["fileCount"] == expected


### PR DESCRIPTION
## Summary

Add a `fileCount` GraphQL query that returns the number of files matching a filter without fetching any file documents. Obtaining a match count previously meant issuing the `files` query, which also fetches and hydrates a page of documents the caller then discards — wasteful for clients that only need the size of a result set (pagination controls, "N files match" labels, faceting UIs that count many filter permutations).

The new resolver mirrors the existing `distinctValues` query in form: it accepts the same `[FileMetadataInput]` filter shape as `files`/`distinctValues`, reuses the shared `to_query(to_dict(input))` filter-building path and the `wait_for_cutover` guard, and returns a scalar `Int!` by running only `count_documents` against the filter. An absent (or empty) filter counts every file.

This branch is standalone on `master`, where `files` still returns a bare list; there is no `totalCount` envelope to reconcile (that work lives on a separate branch/PR).

Closes #77

## Example

Count files from a specific DCC:

```graphql
query {
  fileCount(input: [{ dcc: [{ dccAbbreviation: ["4DN"] }] }])
}
```

Count every file (no filter):

```graphql
query {
  fileCount
}
```

Response:

```json
{ "data": { "fileCount": 1234 } }
```

Over HTTP:

```bash
curl -X POST http://localhost:8000/metadata \
  -H "Content-Type: application/json" \
  -d '{"query": "{ fileCount(input: [{ dcc: [{ dccAbbreviation: [\"4DN\"] }] }]) }"}'
```

## Proposed changes

### Add the `fileCount` resolver

Add `Query.file_count` in `src/cfdb/api/gql/schema.py`, exposed in the schema as `fileCount(input: [FileMetadataInput!] = null): Int!`. It awaits `locks.wait_for_cutover()`, builds the Mongo filter with `to_query(to_dict(input)) if input else {}` (identical to `files`/`distinct_values`), and returns `await api.db.files.count_documents(query)`. Regenerate the committed `schema.graphql` SDL snapshot to add the field.

### Document the query

Note `fileCount` in the README GraphQL Queries section with an example, showing it takes the same `FileMetadataInput` filter as `files` and returns a count without fetching documents.

### Cover the query with tests

Add `TestFileCountQuery` to `tests/test_schema.py` exercising the resolver end-to-end through `schema.execute`, including OR/AND filter construction, cross-query agreement with `files`, and a property-based invariant.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestFileCountQuery` | Three files spanning multiple DCCs | `fileCount` runs with no input | Returns the total (3) | Empty-filter count-all |
| 2 | `TestFileCountQuery` | Two HuBMAP files and one 4DN file | `fileCount` runs with a DCC filter for HuBMAP | Returns only the matches (2) | Single-field filter honored |
| 3 | `TestFileCountQuery` | Three files, none from the filtered DCC | `fileCount` runs with a filter for an absent DCC | Returns 0 | Filter matching nothing |
| 4 | `TestFileCountQuery` | An empty database | `fileCount` runs with no input | Returns 0 | Empty database |
| 5 | `TestFileCountQuery` | Three files | `fileCount` runs with an empty input list | Returns the total (3) | Empty-list truthiness edge |
| 6 | `TestFileCountQuery` | Files across HuBMAP, 4DN, and ENCODE | `fileCount` runs with one field listing two abbreviations | Returns the union of the two DCCs | OR across list values |
| 7 | `TestFileCountQuery` | Three files with distinct local IDs | `fileCount` runs with two separate input entries | Returns the union of the entries | OR across input entries |
| 8 | `TestFileCountQuery` | A public and a non-public HuBMAP file plus a public 4DN file | `fileCount` runs with a DCC and a data-access-level filter | Returns only the file matching both | AND across fields |
| 9 | `TestFileCountQuery` | A mixed multi-DCC dataset smaller than one page | `fileCount` and `files` run with the same filter | `fileCount` equals the `files` result length | Cross-query agreement |
| 10 | `TestFileCountQuery` | A generated set of files and a generated filter subset | `fileCount` runs with that filter | Equals the number of matching documents | Count invariant over a wide domain |
