### PR TITLE
Add a prod deployment environment mirroring the dev stack — Closes #80

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -1,5 +1,10 @@
 name: Deploy CFDB to ECR
 
+# DEV ONLY. This pipeline is the dev environment's auto-deploy: every push to
+# master builds, scans, pushes, and rolls the dev service via the moving :dev
+# tag. Production never advances from here — it is promoted manually by
+# .github/workflows/promote-to-prod.yml, which re-tags a SHA this pipeline
+# already shipped onto :prod. Keep MOVING_TAG below as `dev`.
 on:
   push:
     branches:

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -1,0 +1,145 @@
+name: Promote CFDB to prod
+
+# MANUAL ONLY. Unlike deploy-to-ecr.yml — which fires on every push to master
+# and ships dev — this workflow has no automatic trigger: production only ever
+# advances because a human dispatched this run and an environment reviewer
+# approved it.
+#
+# It does not build anything. Promotion re-tags an image that the dev pipeline
+# already built, scanned, and shipped, so prod runs bytes byte-identical to
+# what dev exercised. Rebuilding from source could produce a different image
+# than the one validated, which is the failure mode this avoids.
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: >
+          Short commit SHA tag to promote (the 8-character :<sha> tag the dev
+          deploy pushed, e.g. 8816b30a). Must already exist in BOTH the cfdb
+          and cfdb-wool repositories.
+        required: true
+        type: string
+
+# AWS_REGION pins the ECR/ECS region. MOVING_TAG is the environment-scoped
+# mutable tag the PROD task definitions reference — rolling the prod service
+# makes it re-pull this tag, which is the whole deploy.
+env:
+  AWS_REGION: us-east-2
+  MOVING_TAG: prod
+
+# Serialize promotions so two dispatches cannot interleave their re-tag and
+# roll steps. cancel-in-progress is false for the same reason as the dev
+# pipeline: a promotion in flight must finish rather than leave :prod pointing
+# at a half-applied state.
+concurrency:
+  group: promote-prod
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: github.repository == 'abdenlab/cfdb'
+    runs-on: ubuntu-24.04
+    # Gates the run on the `prod` GitHub Environment's protection rules
+    # (required reviewers), and scopes the PROD_BACKEND_* variables below.
+    environment: prod
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      # Fail before touching ECR if the deploy target is unconfigured, rather
+      # than discovering it at the roll step with :prod already moved.
+      - name: Pre-flight — required environment variables
+        env:
+          CLUSTER: ${{ vars.PROD_BACKEND_CLUSTER }}
+          SERVICE: ${{ vars.PROD_BACKEND_SERVICE }}
+        run: |
+          [ -n "$CLUSTER" ] && [ -n "$SERVICE" ] || {
+            echo "::error::Set PROD_BACKEND_CLUSTER and PROD_BACKEND_SERVICE on the prod environment"
+            exit 1
+          }
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Confirm the requested SHA exists in BOTH repositories before moving
+      # either tag. The API and worker must advance together — promoting one
+      # while the other's tag is missing would leave prod split across two
+      # commits, which the dispatch contract does not guarantee to survive.
+      - name: Verify source images exist
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          for repo in cfdb cfdb-wool; do
+            aws ecr describe-images \
+              --region "$AWS_REGION" \
+              --repository-name "$repo" \
+              --image-ids imageTag="$SHA" >/dev/null || {
+              echo "::error::$repo:$SHA not found in ECR — promote a SHA the dev pipeline shipped"
+              exit 1
+            }
+            echo "found $repo:$SHA"
+          done
+
+      # Re-tag by copying the existing manifest rather than pulling and
+      # re-pushing: the promoted image is the same digest dev validated, and
+      # the step needs only ecr:BatchGetImage + ecr:PutImage.
+      - name: Re-tag images to :prod
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          for repo in cfdb cfdb-wool; do
+            manifest="$(aws ecr batch-get-image \
+              --region "$AWS_REGION" \
+              --repository-name "$repo" \
+              --image-ids imageTag="$SHA" \
+              --query 'images[0].imageManifest' \
+              --output text)"
+            aws ecr put-image \
+              --region "$AWS_REGION" \
+              --repository-name "$repo" \
+              --image-tag "$MOVING_TAG" \
+              --image-manifest "$manifest" >/dev/null
+            echo "re-tagged $repo:$SHA -> :$MOVING_TAG"
+          done
+
+      # Ship the API: the prod task definition references :$MOVING_TAG, so a
+      # forced deployment launches fresh Fargate tasks that re-pull the tag
+      # just moved. Needs only ecs:UpdateService — no RegisterTaskDefinition,
+      # CloudFormation, or iam:PassRole.
+      - name: Roll prod API service
+        env:
+          CLUSTER: ${{ vars.PROD_BACKEND_CLUSTER }}
+          SERVICE: ${{ vars.PROD_BACKEND_SERVICE }}
+        run: |
+          aws ecs update-service \
+            --region "$AWS_REGION" \
+            --cluster "$CLUSTER" \
+            --service "$SERVICE" \
+            --force-new-deployment
+
+      - name: Wait for prod rollout
+        env:
+          CLUSTER: ${{ vars.PROD_BACKEND_CLUSTER }}
+          SERVICE: ${{ vars.PROD_BACKEND_SERVICE }}
+        run: |
+          aws ecs wait services-stable \
+            --region "$AWS_REGION" \
+            --cluster "$CLUSTER" \
+            --services "$SERVICE"
+
+      - name: Record promoted image
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          echo "Promoted cfdb:$SHA and cfdb-wool:$SHA -> :$MOVING_TAG" >> "$GITHUB_STEP_SUMMARY"
+
+      # No ECS step for the worker fleet: the prod worker task definition also
+      # references :$MOVING_TAG and the workers are ephemeral, so the next
+      # EcsProvisioner RunTask pulls the freshly-tagged image. Note this means
+      # the API rolls immediately while in-flight workers may still be running
+      # the previous image until they drain — keep the API<->worker dispatch
+      # contract compatible across adjacent promotions.

--- a/README.md
+++ b/README.md
@@ -91,16 +91,91 @@ Run `./certs/generate-certs.sh --help` for full usage information.
 
 ### Deploying the CloudFormation stacks
 
-Production runs on four CloudFormation stacks under `cloudformation/`. Deploy them in dependency order (each imports exports from the earlier ones):
+Each deployed environment runs on the same four CloudFormation stacks under `cloudformation/`, deployed under environment-specific stack names. Deploy them in dependency order (each imports exports from the earlier ones):
 
 1. `network.yml` — VPC, subnets, security groups (including the worker SG), S3 gateway endpoint.
 2. `database.yml` — DocumentDB cluster and connection-URL secret.
 3. `workers.yml` — wool worker task definition, S3 artifact cache, worker IAM roles.
 4. `backend.yml` — API service, ALB, and the IAM/env wiring that dispatches to the worker fleet.
 
-Tear down in the reverse order (`backend` → `workers` → `database` → `network`); `backend` imports the worker exports, so it must be deleted first. Both the `cfdb` and `cfdb-wool` ECR repositories are prerequisites created out of band. Each MUST allow tag mutability (`MUTABLE`), because the moving-tag CI deploy re-pushes the `:dev` tag on every merge and an `IMMUTABLE` repository would reject the second `:dev` push. If you want `:<sha>` tags to stay immutable while still allowing the moving `:dev` tag to be re-pushed, configure ECR `IMMUTABLE_WITH_EXCLUSION` with a wildcard filter exempting `dev` (so `:<sha>` is immutable and `:dev` is mutable). Give both repositories a lifecycle policy to prune untagged images.
+Tear down in the reverse order (`backend` → `workers` → `database` → `network`); `backend` imports the worker exports, so it must be deleted first. Both the `cfdb` and `cfdb-wool` ECR repositories are prerequisites created out of band. Each MUST allow tag mutability (`MUTABLE`), because the moving-tag deploys re-push the `:dev` and `:prod` tags and an `IMMUTABLE` repository would reject the second push of either. If you want `:<sha>` tags to stay immutable while still allowing the moving tags to be re-pushed, configure ECR `IMMUTABLE_WITH_EXCLUSION` with wildcard filters exempting both `dev` and `prod` (so `:<sha>` is immutable and the moving tags are mutable). Give both repositories a lifecycle policy to prune untagged images.
 
-**CI auto-deploy (moving-tag steady state).** Every merge to `master` runs `.github/workflows/deploy-to-ecr.yml`, which builds the API (`cfdb`) and worker (`cfdb-wool`) images, trivy-scans the worker image, pushes both images, then rolls the API service — using only the permissions the `cfdb-deploy` CI role already holds (ECR push/pull on both repos, and `ecs:UpdateService`/`DescribeServices`/`DescribeTasks`/`ListTasks` on `cfdb-backend-dev-cluster`). Only the worker (`cfdb-wool`) image is trivy-scanned for HIGH/CRITICAL vulnerabilities — the worker shells out to `samtools`/`tabix`/`bigBedToBed` over untrusted upstream bytes — and that scan gates both pushes, so a scan failure leaves ECR fully on the prior images; the API image is not scanned. The role has **no** `cloudformation:*`, `ecs:RegisterTaskDefinition`, or `iam:PassRole`, so deploys no longer run `aws cloudformation deploy`; they use the **moving-tag** pattern instead. Each image is pushed to two tags: the immutable `:<sha>` (traceable to a commit, used for audit and rollback) and a moving, environment-scoped `:dev`. The ECS task definitions reference `:dev`. The workflow then runs `aws ecs update-service --force-new-deployment` on the backend service, which launches fresh Fargate tasks that re-pull `:dev` — shipping the new API code without registering a task definition — and waits for the rollout to stabilize with `aws ecs wait services-stable`. The worker fleet needs no ECS step: the worker task def also references `:dev`, and the workers are ephemeral, so the next `EcsProvisioner` `RunTask` (issued by the API role at workflow dispatch) pulls the freshly-pushed image. **Rollback is an ECR re-tag, not a redeploy:** re-tag the desired `:<sha>` onto `:dev` (`docker pull` the old `:<sha>`, re-tag it `:dev`, `docker push`; or `aws ecr batch-get-image` + `put-image`, both granted to the role), then `aws ecs update-service --force-new-deployment` to roll the API onto it (the workers re-pull on their next dispatch).
+#### Environments
+
+Two environments share the account `605134458779` and region `us-east-2`. Every cross-stack export is `${AWS::StackName}`-scoped, so the two sets of stacks coexist without collisions — but the physical names that AWS requires to be account- and region-unique (the ALB target group in particular) MUST be passed per environment, which is why `TargetGroupName` is a parameter.
+
+| | dev | prod |
+|---|---|---|
+| Stack names | `cfdb-network-dev`, `cfdb-db-dev`, `cfdb-workers-dev`, `cfdb-backend-dev` | `cfdb-network-prod`, `cfdb-db-prod`, `cfdb-workers-prod`, `cfdb-backend-prod` |
+| Domain | `dev.cfdb.vis-api.link` | `cfdb.visualizationhub.org` |
+| Hosted zone | `vis-api.link` (`Z09477406JQAR0KB7G87`) | `visualizationhub.org` (`Z02332581YW11QLMXBXY4`) |
+| Moving tag | `:dev` | `:prod` |
+| VPC CIDR | `10.2.0.0/21` | `10.3.0.0/21` |
+| Ships when | every merge to `master`, automatically | a human dispatches **Promote CFDB to prod** and a reviewer approves |
+
+Note the templates' parameter defaults (`cfdb.vis-api.link`, `10.2.0.0/21`, `cfdb-tg`) match *neither* live environment — they exist only so a bare `cloudformation deploy` is not rejected for missing parameters. Always pass explicit overrides.
+
+#### Deploying the prod stacks
+
+One-time, run by an IAM-capable principal (not the `cfdb-deploy` CI role, which has no `cloudformation:*` or `iam:PassRole`). The CIDRs deliberately do not overlap dev's so the two VPCs can be peered later if needed.
+
+```bash
+aws cloudformation deploy --region us-east-2 \
+  --stack-name cfdb-network-prod \
+  --template-file cloudformation/network.yml \
+  --parameter-overrides \
+    CidrBlock=10.3.0.0/21 \
+    CidrPublicSubnetA=10.3.0.0/24 CidrPublicSubnetB=10.3.1.0/24 \
+    CidrPrivateSubnetA=10.3.2.0/24 CidrPrivateSubnetB=10.3.3.0/24 \
+  --capabilities CAPABILITY_IAM
+
+aws cloudformation deploy --region us-east-2 \
+  --stack-name cfdb-db-prod \
+  --template-file cloudformation/database.yml \
+  --parameter-overrides \
+    NetworkStackName=cfdb-network-prod \
+    DBMasterUsername=<username> \
+  --capabilities CAPABILITY_IAM
+
+aws cloudformation deploy --region us-east-2 \
+  --stack-name cfdb-workers-prod \
+  --template-file cloudformation/workers.yml \
+  --parameter-overrides \
+    WorkerImageURI=605134458779.dkr.ecr.us-east-2.amazonaws.com/cfdb-wool:prod \
+  --capabilities CAPABILITY_IAM
+
+aws cloudformation deploy --region us-east-2 \
+  --stack-name cfdb-backend-prod \
+  --template-file cloudformation/backend.yml \
+  --parameter-overrides \
+    NetworkStackName=cfdb-network-prod \
+    DatabaseStackName=cfdb-db-prod \
+    WorkersStackName=cfdb-workers-prod \
+    ImageURI=605134458779.dkr.ecr.us-east-2.amazonaws.com/cfdb:prod \
+    DomainName=cfdb.visualizationhub.org \
+    HostedZoneName=visualizationhub.org \
+    HostedZoneId=Z02332581YW11QLMXBXY4 \
+    TargetGroupName=cfdb-prod-tg \
+  --capabilities CAPABILITY_IAM
+```
+
+Because both prod task definitions already reference `:prod`, this doubles as the prod bootstrap — but the `:prod` tags must exist in ECR *before* the stacks can pull them, so run one promotion (below) first, or seed `:prod` by re-tagging a known-good `:<sha>`.
+
+#### Promoting to prod
+
+Production never advances automatically. `.github/workflows/promote-to-prod.yml` is `workflow_dispatch`-only and gated on the `prod` GitHub Environment's required reviewers. Dispatch it with the 8-character `:<sha>` tag that the dev pipeline already built, scanned, and shipped; it verifies that tag exists in **both** `cfdb` and `cfdb-wool`, re-tags each onto `:prod` by copying the ECR manifest, rolls the prod API service, and waits for `services-stable`.
+
+Promotion re-tags rather than rebuilds, so prod runs bytes byte-identical to what dev validated. **Rollback is the same operation with an older SHA:** dispatch the workflow again naming the previous `:<sha>`. As on dev, the worker fleet needs no ECS step — the prod worker task def also references `:prod` and workers are ephemeral, so the next `EcsProvisioner` `RunTask` pulls the new image. That does mean the API rolls immediately while in-flight workers may still run the prior image until they drain, so keep the API↔worker dispatch contract compatible across adjacent promotions.
+
+Prod requires this one-time setup before the first promotion:
+
+- A `prod` **GitHub Environment** with required reviewers, carrying two environment variables: `PROD_BACKEND_CLUSTER` (`cfdb-backend-prod-cluster`) and `PROD_BACKEND_SERVICE` (`cfdb-backend-prod-service`). The workflow fails its pre-flight before touching ECR if either is unset.
+- The `cfdb-deploy` CI role's `ecs:UpdateService`/`DescribeServices`/`DescribeTasks`/`ListTasks` extended to `cfdb-backend-prod-cluster` — it is currently scoped to the dev cluster only. It already holds the `ecr:BatchGetImage`/`PutImage` the re-tag needs. This role is created out of band, not in this repo.
+- Both ECR repositories accepting the `:prod` moving tag (see the mutability note above).
+
+As with dev, confirm after the first promotion that the running prod tasks reference `:prod`. If the task definitions still pin a `:<sha>`, promotions will report success while the live code never advances.
+
+**CI auto-deploy to dev (moving-tag steady state).** This pipeline ships **dev only**; prod is promoted manually as described above. Every merge to `master` runs `.github/workflows/deploy-to-ecr.yml`, which builds the API (`cfdb`) and worker (`cfdb-wool`) images, trivy-scans the worker image, pushes both images, then rolls the API service — using only the permissions the `cfdb-deploy` CI role already holds (ECR push/pull on both repos, and `ecs:UpdateService`/`DescribeServices`/`DescribeTasks`/`ListTasks` on `cfdb-backend-dev-cluster`). Only the worker (`cfdb-wool`) image is trivy-scanned for HIGH/CRITICAL vulnerabilities — the worker shells out to `samtools`/`tabix`/`bigBedToBed` over untrusted upstream bytes — and that scan gates both pushes, so a scan failure leaves ECR fully on the prior images; the API image is not scanned. The role has **no** `cloudformation:*`, `ecs:RegisterTaskDefinition`, or `iam:PassRole`, so deploys no longer run `aws cloudformation deploy`; they use the **moving-tag** pattern instead. Each image is pushed to two tags: the immutable `:<sha>` (traceable to a commit, used for audit and rollback) and a moving, environment-scoped `:dev`. The ECS task definitions reference `:dev`. The workflow then runs `aws ecs update-service --force-new-deployment` on the backend service, which launches fresh Fargate tasks that re-pull `:dev` — shipping the new API code without registering a task definition — and waits for the rollout to stabilize with `aws ecs wait services-stable`. The worker fleet needs no ECS step: the worker task def also references `:dev`, and the workers are ephemeral, so the next `EcsProvisioner` `RunTask` (issued by the API role at workflow dispatch) pulls the freshly-pushed image. **Rollback is an ECR re-tag, not a redeploy:** re-tag the desired `:<sha>` onto `:dev` (`docker pull` the old `:<sha>`, re-tag it `:dev`, `docker push`; or `aws ecr batch-get-image` + `put-image`, both granted to the role), then `aws ecs update-service --force-new-deployment` to roll the API onto it (the workers re-pull on their next dispatch).
 
 A few operational caveats of the moving-tag pattern:
 

--- a/cloudformation/backend.yml
+++ b/cloudformation/backend.yml
@@ -46,15 +46,39 @@ Parameters:
       dispatches them as workers free up). This bounds WORKERS, not the
       queue — the queue/admission bound is CFDB_WORKFLOW_MAX_ACTIVE. 0
       disables the cap (rely on the Fargate vCPU quota).
+  # ---------- Per-environment DNS + naming ----------
+  # These four defaults are NOT the value any live environment uses — dev
+  # serves dev.cfdb.vis-api.link and prod serves cfdb.visualizationhub.org
+  # out of a different hosted zone. Every environment MUST pass its own
+  # overrides; the defaults exist only so a bare `cloudformation deploy`
+  # is not rejected for missing parameters.
   HostedZoneName:
     Type: String
     Default: vis-api.link
+    Description: >
+      Route 53 hosted zone the DNS record is created in, without a trailing
+      dot. Per-environment — prod uses a different zone from dev, so this
+      MUST be overridden.
   HostedZoneId:
     Type: String
     Default: Z09477406JQAR0KB7G87
+    Description: >
+      Hosted zone ID matching HostedZoneName, used for ACM DNS validation.
+      Per-environment — MUST be overridden alongside HostedZoneName.
   DomainName:
     Type: String
     Default: cfdb.vis-api.link
+    Description: >
+      Fully-qualified domain the ALB serves and the ACM certificate covers.
+      Per-environment — MUST be overridden.
+  TargetGroupName:
+    Type: String
+    Default: cfdb-tg
+    Description: >
+      ELB target group name. Target group names must be unique per account
+      and region, so each environment MUST pass its own value or the second
+      stack fails to create. The default preserves the original dev name so
+      that an existing stack is not forced to replace its target group.
   # ---------- Worker mTLS (optional, off by default) ----------
   # ARNs of Secrets Manager secrets holding the API's client-side PEM
   # material for mutual TLS on the API<->worker gRPC channel: the shared
@@ -124,7 +148,7 @@ Resources:
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub "cfdb-tg"
+      Name: !Ref TargetGroupName
       Port: 8000
       Protocol: HTTP
       TargetType: ip

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -1,0 +1,196 @@
+"""Tests for environment-scoping invariants in the CloudFormation templates.
+
+The four templates under ``cloudformation/`` are deployed once per
+environment (dev, prod) into the *same* AWS account and region, so any
+resource whose physical name is pinned to a literal collides on the second
+deploy. These tests pin the invariant that every such name is derived from
+``${AWS::StackName}``, supplied by a template parameter, or imported from
+another stack's (already stack-scoped) export.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "cloudformation"
+_TEMPLATES = ("network.yml", "database.yml", "workers.yml", "backend.yml")
+
+# Resource-type -> the property that sets an account/region-unique physical
+# name. Keyed by type rather than by property name so that same-named
+# properties which are NOT physical names are not swept up: the DocDB
+# parameter group's ``Family: docdb5.0`` is an engine family, and the VPC
+# endpoint's ``ServiceName: com.amazonaws...`` names an AWS service.
+_PHYSICAL_NAME_PROPERTIES: dict[str, str] = {
+    "AWS::ElasticLoadBalancingV2::TargetGroup": "Name",
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": "Name",
+    "AWS::ECS::Cluster": "ClusterName",
+    "AWS::ECS::Service": "ServiceName",
+    "AWS::ECS::TaskDefinition": "Family",
+    "AWS::Logs::LogGroup": "LogGroupName",
+    "AWS::SecretsManager::Secret": "Name",
+    "AWS::DocDB::DBCluster": "DBClusterIdentifier",
+    "AWS::DocDB::DBInstance": "DBInstanceIdentifier",
+    "AWS::DocDB::DBSubnetGroup": "DBSubnetGroupName",
+    "AWS::S3::Bucket": "BucketName",
+    "AWS::IAM::Role": "RoleName",
+    "AWS::ECR::Repository": "RepositoryName",
+}
+
+
+class _CfnLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates CloudFormation short-form intrinsic tags."""
+
+
+def _cfn_multi_constructor(loader: yaml.Loader, tag_suffix: str, node: yaml.Node) -> Any:
+    """Represent a ``!Tag`` node as its long-form ``{"Fn::Tag": value}`` dict.
+
+    ``!Ref`` is special-cased to the bare ``Ref`` key because that is its
+    real long form; every other intrinsic takes the ``Fn::`` prefix.
+    """
+    key = "Ref" if tag_suffix == "Ref" else f"Fn::{tag_suffix}"
+    if isinstance(node, yaml.ScalarNode):
+        return {key: loader.construct_scalar(node)}
+    if isinstance(node, yaml.SequenceNode):
+        return {key: loader.construct_sequence(node, deep=True)}
+    return {key: loader.construct_mapping(node, deep=True)}
+
+
+_CfnLoader.add_multi_constructor("!", _cfn_multi_constructor)
+
+
+def _load_template(name: str) -> dict[str, Any]:
+    """Parse the named template in ``cloudformation/`` into a plain dict."""
+    return yaml.load((_TEMPLATE_DIR / name).read_text(), Loader=_CfnLoader)
+
+
+def _is_environment_scoped(value: Any, parameters: set[str], resources: set[str]) -> bool:
+    """Report whether a physical-name value varies per environment.
+
+    A name qualifies when it resolves a declared template parameter, is
+    imported from another stack's export (itself stack-scoped by
+    construction), or interpolates ``${AWS::StackName}``, a parameter, or a
+    sibling resource. Interpolating a resource counts because CloudFormation
+    generates that resource's physical name per stack, so the derived name is
+    unique too. ``${AWS::Region}`` and ``${AWS::AccountId}`` deliberately do
+    not count: both are identical for two environments in the same account
+    and region, which is exactly the case under test.
+    """
+    if not isinstance(value, dict):
+        # A bare string literal is identical in every environment.
+        return False
+    if "Ref" in value:
+        return value["Ref"] in parameters
+    if "Fn::ImportValue" in value:
+        return True
+    if "Fn::Sub" in value:
+        body = value["Fn::Sub"]
+        # !Sub accepts either a bare string or [template, {vars}].
+        template = body[0] if isinstance(body, list) else body
+        varying = {"AWS::StackName", *parameters, *resources}
+        return any(f"${{{name}}}" in template for name in varying)
+    return False
+
+
+def _named_resources(template: dict[str, Any]) -> list[tuple[str, str, Any]]:
+    """Yield (logical_id, resource_type, name_value) for each pinned name.
+
+    Resources that leave their name property unset are skipped: CloudFormation
+    then generates a unique physical name, which cannot collide.
+    """
+    found = []
+    for logical_id, resource in (template.get("Resources") or {}).items():
+        resource_type = resource.get("Type")
+        prop = _PHYSICAL_NAME_PROPERTIES.get(resource_type)
+        if prop is None:
+            continue
+        properties = resource.get("Properties") or {}
+        if prop not in properties:
+            continue
+        found.append((logical_id, resource_type, properties[prop]))
+    return found
+
+
+@pytest.mark.parametrize("template_name", _TEMPLATES)
+def test_physical_names_should_be_environment_scoped(template_name: str):
+    """Test that no pinned physical name is a hard-coded literal.
+
+    Given:
+        A CloudFormation template that is deployed once per environment into
+        the same AWS account and region.
+    When:
+        Every resource that pins an account/region-unique physical name is
+        inspected.
+    Then:
+        Each such name should derive from ${AWS::StackName}, a template
+        parameter, or a cross-stack import, so a second environment does not
+        collide with the first.
+    """
+    # Arrange
+    template = _load_template(template_name)
+    parameters = set((template.get("Parameters") or {}).keys())
+    resources = set((template.get("Resources") or {}).keys())
+
+    # Act
+    offenders = [
+        (logical_id, resource_type, value)
+        for logical_id, resource_type, value in _named_resources(template)
+        if not _is_environment_scoped(value, parameters, resources)
+    ]
+
+    # Assert
+    assert offenders == [], (
+        f"{template_name} pins environment-invariant physical name(s): {offenders}. "
+        "Derive the name from ${AWS::StackName} or expose it as a parameter."
+    )
+
+
+def test_backend_target_group_name_should_be_parameterized():
+    """Test that the backend target group name comes from a parameter.
+
+    Given:
+        The backend template, whose target group name must be unique per
+        account and region.
+    When:
+        The TargetGroupName parameter and the target group resource are read.
+    Then:
+        The parameter should exist and the resource should reference it, so a
+        prod stack can supply its own name without disturbing dev's.
+    """
+    # Arrange
+    template = _load_template("backend.yml")
+
+    # Act
+    parameters = template.get("Parameters") or {}
+    target_group = template["Resources"]["TargetGroup"]["Properties"]
+
+    # Assert
+    assert "TargetGroupName" in parameters
+    assert target_group["Name"] == {"Ref": "TargetGroupName"}
+
+
+def test_backend_per_environment_parameters_should_be_documented():
+    """Test that environment-specific parameters carry a Description.
+
+    Given:
+        The backend template's DNS parameters, whose defaults match dev's
+        domain rather than any environment deployed today.
+    When:
+        Each per-environment parameter is inspected.
+    Then:
+        Each should document that it must be overridden per environment, so
+        the misleading default cannot be adopted silently.
+    """
+    # Arrange
+    template = _load_template("backend.yml")
+    parameters = template.get("Parameters") or {}
+
+    # Act & assert
+    for name in ("HostedZoneName", "HostedZoneId", "DomainName", "TargetGroupName"):
+        assert name in parameters, f"{name} is not a template parameter"
+        assert parameters[name].get("Description", "").strip(), (
+            f"{name} needs a Description marking it as a per-environment value"
+        )


### PR DESCRIPTION
## Summary

Add a production environment built from the existing four CloudFormation templates, deployed into the same AWS account and region as dev under new stack names, plus the manually-gated pipeline that ships it.

The templates needed almost no restructuring: cross-stack exports are already `${AWS::StackName}`-scoped and inter-stack wiring already flows through the `*StackName` parameters, so a second set of stacks coexists with dev. One exception surfaced during implementation — `backend.yml` pinned the ALB target group name to the literal `cfdb-tg`, which is not stack-scoped and would have failed the prod stack creation outright. A sweep of every explicit physical-name property across all four templates confirmed it was the only such case.

Production ships only when a human dispatches the new workflow and a reviewer approves. Promotion re-tags an image the dev pipeline already built, scanned, and shipped rather than rebuilding, so prod runs bytes identical to what dev validated, and rollback is the same dispatch naming an earlier commit tag. No AWS resources are created by this PR — deploying the stacks, widening the CI role, ECR mutability, and the GitHub Environment remain operator actions, documented as a runbook.

Closes #80

## Proposed changes

### Parameterize the target group name

Expose `TargetGroupName` in `backend.yml`, defaulting to the original `cfdb-tg` literal. The default matters: renaming a target group forces replacement, so defaulting to the existing value keeps dev's running service undisturbed while letting prod pass `cfdb-prod-tg`. Also document `HostedZoneName`, `HostedZoneId`, and `DomainName`, whose defaults match no live environment and exist only so a bare deploy is not rejected for missing parameters.

### Add the prod promotion workflow

`promote-to-prod.yml` runs on `workflow_dispatch` only and is gated on the `prod` environment's required reviewers. It verifies the requested tag exists in both `cfdb` and `cfdb-wool` before either tag moves — so a promotion cannot leave the API and worker split across different commits — then re-tags each onto `:prod` by copying the ECR manifest, rolls the prod service, and waits for `services-stable`. The manifest copy needs only `BatchGetImage` and `PutImage`, avoiding a pull-and-push cycle. The existing pipeline gains a header noting it ships dev only.

### Document the environments

Record how dev and prod differ across stack names, domain, hosted zone, moving tag, and VPC CIDR, along with the prod stack-deploy commands with explicit overrides, the promotion and rollback flow, and the one-time setup a promotion depends on — worth calling out because skipping the task-definition bootstrap leaves the pipeline reporting success while the live code never advances.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_cloudformation` | A template deployed once per environment into one account and region | Every resource pinning an account-unique physical name is inspected | Each name derives from the stack name, a parameter, or a cross-stack import | Environment scoping across all four templates |
| 2 | `test_cloudformation` | The backend template, whose target group name must be region-unique | The parameter and target group resource are read | `TargetGroupName` exists and the resource references it | Target group parameterization |
| 3 | `test_cloudformation` | The backend DNS parameters, whose defaults match no deployed environment | Each per-environment parameter is inspected | Each documents that it must be overridden | Parameter documentation |

Test 1 is parametrized across `network.yml`, `database.yml`, `workers.yml`, and `backend.yml`, and fails on the `cfdb-tg` literal before the fix. Names are matched by resource type rather than property name so that same-named properties which are not physical names — the DocumentDB parameter group family, the VPC endpoint service name — are not swept up.

## Deploying the prod stacks

These are operator steps — this PR creates no AWS resources. Run them once, with credentials for an **IAM-capable principal**: the `cfdb-deploy` CI role cannot do this, as it holds no `cloudformation:*` or `iam:PassRole`. Deploy in dependency order, since each stack imports the earlier ones' exports; tear down in reverse (`backend` → `workers` → `db` → `network`).

The CIDRs deliberately avoid overlapping dev's `10.2.0.0/21` so the two VPCs can be peered later if that is ever wanted.

```bash
# ---------------------------------------------------------------------------
# 1. NETWORK — the VPC, two public and two private subnets across two AZs, the
#    ALB / ECS / DocumentDB / worker security groups, and the S3 gateway
#    endpoint. Deploy first: every other stack imports its exports.
#    The CIDRs must not overlap dev's 10.2.0.0/21 or the two VPCs can never
#    be peered.
# ---------------------------------------------------------------------------
aws cloudformation deploy --region us-east-2 \
  --stack-name cfdb-network-prod \
  --template-file cloudformation/network.yml \
  --parameter-overrides \
    CidrBlock=10.3.0.0/21 \
    CidrPublicSubnetA=10.3.0.0/24 CidrPublicSubnetB=10.3.1.0/24 \
    CidrPrivateSubnetA=10.3.2.0/24 CidrPrivateSubnetB=10.3.3.0/24 \
  --capabilities CAPABILITY_IAM

# ---------------------------------------------------------------------------
# 2. DATABASE — the DocumentDB cluster (single instance; no failover, a
#    deliberate cost trade) plus the Secrets Manager secret holding the
#    connection URL the API reads at startup. Lands in the private subnets
#    imported from the network stack.
#    DBMasterUsername has no default and is NoEcho — choose one and store it
#    somewhere durable; it is not recoverable from the template.
# ---------------------------------------------------------------------------
aws cloudformation deploy --region us-east-2 \
  --stack-name cfdb-db-prod \
  --template-file cloudformation/database.yml \
  --parameter-overrides \
    NetworkStackName=cfdb-network-prod \
    DBMasterUsername=<username> \
  --capabilities CAPABILITY_IAM

# ---------------------------------------------------------------------------
# 3. WORKERS — the ephemeral wool worker task definition, the S3 artifact
#    cache bucket, and the worker IAM roles. No long-running service is
#    created here: the API launches workers on demand via RunTask, so this
#    stack only publishes what those launches reference.
#    WorkerImageURI pins the moving :prod tag, which is what makes the next
#    RunTask pick up a freshly promoted image without a redeploy.
# ---------------------------------------------------------------------------
aws cloudformation deploy --region us-east-2 \
  --stack-name cfdb-workers-prod \
  --template-file cloudformation/workers.yml \
  --parameter-overrides \
    WorkerImageURI=605134458779.dkr.ecr.us-east-2.amazonaws.com/cfdb-wool:prod \
  --capabilities CAPABILITY_IAM

# ---------------------------------------------------------------------------
# 4. BACKEND — the ECS Fargate API service, its ALB with an HTTPS listener and
#    HTTP redirect, a DNS-validated ACM certificate, the Route 53 alias
#    record, and the sync API key secret. Deploy last: it imports from all
#    three stacks above.
#    TargetGroupName is the parameter this PR adds. It MUST differ from dev's
#    cfdb-tg, since target group names are unique per account and region.
#    The ACM certificate validates via DNS, so this deploy blocks until the
#    validation record resolves in the visualizationhub.org zone.
# ---------------------------------------------------------------------------
aws cloudformation deploy --region us-east-2 \
  --stack-name cfdb-backend-prod \
  --template-file cloudformation/backend.yml \
  --parameter-overrides \
    NetworkStackName=cfdb-network-prod \
    DatabaseStackName=cfdb-db-prod \
    WorkersStackName=cfdb-workers-prod \
    ImageURI=605134458779.dkr.ecr.us-east-2.amazonaws.com/cfdb:prod \
    DomainName=cfdb.visualizationhub.org \
    HostedZoneName=visualizationhub.org \
    HostedZoneId=Z02332581YW11QLMXBXY4 \
    TargetGroupName=cfdb-prod-tg \
  --capabilities CAPABILITY_IAM
```

**Order of operations caveat.** Both prod task definitions reference `:prod`, which makes these deploys double as the prod bootstrap — but the `:prod` tags must already exist in ECR or the stacks cannot pull them. Seed `:prod` first by re-tagging a known-good `:<sha>` onto it in both `cfdb` and `cfdb-wool`, then deploy.

Before the first promotion, also complete the setup the workflow depends on:

- [ ] Both ECR repositories accept the `:prod` moving tag (`MUTABLE`, or `IMMUTABLE_WITH_EXCLUSION` covering `dev` and `prod`)
- [ ] `cfdb-deploy` role's `ecs:UpdateService`/`DescribeServices`/`DescribeTasks`/`ListTasks` extended to `cfdb-backend-prod-cluster` — currently scoped to the dev cluster only
- [ ] A `prod` GitHub Environment with required reviewers, carrying `PROD_BACKEND_CLUSTER=cfdb-backend-prod-cluster` and `PROD_BACKEND_SERVICE=cfdb-backend-prod-service`
- [ ] After the first promotion, confirm the running prod tasks reference `:prod` — if they still pin a `:<sha>`, promotions report success while the live code never advances

Run `cfn-lint cloudformation/*.yml` before deploying. It is not installed in the dev environment used here, so the templates have been validated structurally (YAML parse plus the tests above) rather than against the full CloudFormation schema.

