### PR TITLE
Enable identity-based worker mTLS on ECS Fargate — Closes #85

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Requires Python 3.11 or later.
 | `CFDB_WORKER_TLS_CA` | Path to the shared CA certificate for the wool worker gRPC channel. When this and the cert/key below are all set, the API↔worker dispatch channel uses mutual TLS (`mutual=True`); when all three are unset the channel stays plaintext. Partial config fails fast at startup. The API and every worker MUST use certs signed by the same CA. See [Worker mTLS](#worker-mtls). | - |
 | `CFDB_WORKER_TLS_CERT` | Path to this process's PEM certificate on the worker gRPC channel — the worker leaf cert on a worker (`worker_main`/`worker_lan`), the API client cert on the API. Must be signed by `CFDB_WORKER_TLS_CA`. | - |
 | `CFDB_WORKER_TLS_KEY` | Path to this process's PEM private key paired with `CFDB_WORKER_TLS_CERT`. | - |
-| `CFDB_WORKER_TLS_IDENTITY` | Logical name the **API** verifies worker certificates against, in place of the address it dialed. Workers answer on addresses assigned at launch — an awsvpc IP on Fargate, a bridge IP in local containers — that no certificate minted ahead of time can name, so without this the handshake cannot succeed. The worker leaf must carry this value as a SAN; `certs/generate-worker-certs.sh` mints the default. Set to the empty string to verify against the dialed address instead. Read by the API only — a worker is the TLS server and has no peer name to override. Ignored while mTLS is off. See [Worker mTLS](#worker-mtls). | `cfdb-worker` |
+| `CFDB_WORKER_TLS_IDENTITY` | Logical name the **API** verifies worker certificates against, in place of the address it dialed. Workers answer on addresses assigned at launch — an awsvpc IP on Fargate, a bridge IP in local containers — that no certificate minted ahead of time can name, so without this the handshake cannot succeed. The worker leaf must carry this value as a SAN; `certs/generate-worker-certs.sh` mints the default. Set to the empty string to verify against the dialed address instead. Read by every process that dials: the API on the dispatch channel, and each worker on the graceful-stop channel wool opens back to its own subprocess — so the API and the workers MUST agree on this value, or drain fails its name check and in-flight work is lost with no TLS error anywhere. Ignored while mTLS is off. See [Worker mTLS](#worker-mtls). | `cfdb-worker` |
 | `CFDB_API_URL` | Base URL for the cfdb API | `http://localhost:8000` |
 | `DATABASE_URL` | MongoDB connection string | `mongodb://127.0.0.1:27017` |
 | `DATABASE_NAME` | Name of the MongoDB database to use | `cfdb` |
@@ -143,6 +143,7 @@ aws cloudformation deploy --region us-east-2 \
   --template-file cloudformation/workers.yml \
   --parameter-overrides \
     WorkerImageURI=605134458779.dkr.ecr.us-east-2.amazonaws.com/cfdb-wool:prod \
+    BackendClusterName=cfdb-backend-prod-cluster \
   --capabilities CAPABILITY_IAM
 
 aws cloudformation deploy --region us-east-2 \
@@ -181,6 +182,7 @@ As with dev, confirm after the first promotion that the running prod tasks refer
 A few operational caveats of the moving-tag pattern:
 
 - **Version skew across a deploy.** The API service rolls immediately, but the worker fleet only advances when the next `EcsProvisioner` `RunTask` pulls the freshly-pushed `:dev`. Between the API roll and the next worker launch, a newly-rolled API can dispatch to in-flight workers still running the prior `:dev` image — so a deploy has a transient window where the API and worker code can be one commit apart. Keep the API↔worker dispatch contract backward-compatible across adjacent commits.
+- **A wool version bump is a deliberate exception to that.** wool admits a worker only when the proxy's version is `<=` the worker's within the same major (`is_version_compatible`), applied as a discovery filter, and `wool.protocol.__version__` is just the installed package version. Since the pipeline rolls the API first, a bump means the new API rejects **every** in-flight worker until the fleet turns over. It self-heals — jobs stay `pending` and the durable scheduler drains them once fresh workers spawn — but two second-order effects are worth knowing. Rejected-but-running workers still count toward `ECS_MAX_WORKERS` in the provisioner's pre-`RunTask` census, and nothing reaps them before `CFDB_WORKER_MAX_LIFETIME_SECONDS` (5 h, longer than the 4 h dispatch deadline), so a bump landing on a near-capped fleet can wedge spawning long enough to fail jobs `capacity:`. And the symptom is `NoWorkersAvailable`, indistinguishable from the TLS failures above. To make it a non-event, drain the fleet as part of the deploy that carries the bump — `aws ecs list-tasks --cluster <cluster> --family <worker-family>` then `stop-task` on each, or simply confirm it is empty before promoting. The rollback direction is safe: an older API against newer workers passes the gate.
 - **Single-environment moving tag.** `MOVING_TAG` is hard-coded to `dev` in the workflow, so this pipeline targets exactly one environment. A second environment (e.g. `prod`) would need its own moving tag, repo variables, and task-def wiring — not yet parameterized.
 - **Rollout wait ceiling.** `aws ecs wait services-stable` polls for up to ~10 minutes (40 attempts × 15 s) before timing out. A genuinely slow or wedged rollout will fail the workflow at that ceiling even though the `update-service` call itself succeeded; the deploy may still converge afterward, or the circuit breaker (below) may roll it back.
 - **Stale GitHub secrets.** The old `BACKEND_STACK_NAME` and `WORKERS_STACK_NAME` GitHub secrets are no longer used by this workflow (it no longer runs `cloudformation deploy`) and can be deleted.
@@ -197,7 +199,9 @@ aws cloudformation deploy \
   --region us-east-2 \
   --stack-name <workers-stack> \
   --template-file cloudformation/workers.yml \
-  --parameter-overrides WorkerImageURI=605134458779.dkr.ecr.us-east-2.amazonaws.com/cfdb-wool:dev \
+  --parameter-overrides \
+    WorkerImageURI=605134458779.dkr.ecr.us-east-2.amazonaws.com/cfdb-wool:dev \
+    BackendClusterName=<backend-stack>-cluster \
   --capabilities CAPABILITY_IAM
 aws cloudformation deploy \
   --region us-east-2 \
@@ -209,8 +213,23 @@ aws cloudformation deploy \
 
 The `cloudformation/backend.yml` `ImageURI` and `cloudformation/workers.yml` `WorkerImageURI` parameters now **default** to these `:dev` URIs. Note what that default does and does not do: on a stack **UPDATE**, CloudFormation reuses each parameter's **previous** value, not its default — so the `:dev` default only governs a fresh stack **CREATE**. The point is that a later infra `cloudformation deploy` (an update) keeps whatever value the bootstrap set — `:dev` — rather than reverting to a stale SHA, so the moving-tag CI deploy stays the source of truth for what code runs. Because the task defs pin `:dev` rather than a SHA, task-definition-level traceability to a commit is intentionally given up; it is recovered by the immutable `:<sha>` tag pushed alongside `:dev` and by SHA-based rollback via ECR re-tag.
 
+> **One-time privileged bootstrap #2 — the `ecs:TagResource` grant, ordered BEFORE the image.** Worker images that publish their own metadata (the `wool.version`/`wool.secure` task tags `EcsDiscovery` requires) **exit at startup** when their task role lacks `ecs:TagResource` — deliberately, because an unpublishable worker can never be discovered and would otherwise hold a Fargate slot while unable to receive work. That grant lives in `cloudformation/workers.yml`, and the CI pipeline **cannot deploy it**: the `cfdb-deploy` role holds no `cloudformation:*`, so merging ships the tag-or-die image while the deployed task role still lacks the permission. The failure mode is a fleet that empties itself — every `RunTask` launches a worker that logs `ecs:TagResource denied … exiting` and dies, jobs sit `pending` to the 4 h deadline, and the API-side symptom is the same `NoWorkersAvailable` as every other failure in this section — while CI reports green. **Before the first image carrying metadata publishing reaches an environment**, an IAM-capable principal must run, per environment:
+>
+> ```bash
+> aws cloudformation deploy --region us-east-2 \
+>   --stack-name cfdb-workers-<env> \
+>   --template-file cloudformation/workers.yml \
+>   --parameter-overrides BackendClusterName=cfdb-backend-<env>-cluster \
+>   --capabilities CAPABILITY_IAM
+> ```
+>
+> The forward order is harmless — an old image simply ignores the extra permission — so deploy the stack first, then merge. The same ordering applies to prod before the first promotion carrying this change (`promote-to-prod.yml` runs no CloudFormation either). Confirm with a worker log line `Published worker metadata to <arn>`; the denial, if you got the order wrong, is an `AccessDeniedException` in the worker's CloudWatch group and a rate-limited `none advertisable` warning in the API's.
+
 **Tearing down the cache.** CloudFormation cannot delete a non-empty S3 bucket, so empty the `CacheBucket` before deleting the workers stack or the delete will fail and roll back.
-**Worker mTLS on ECS (optional, off by default — and deliberately left off).** The same `CFDB_WORKER_TLS_*` gating that secures the local channel ([Worker mTLS](#worker-mtls)) is wired into the Fargate task definitions, but disabled unless you supply cert ARNs. Fargate cannot mount a Secrets Manager secret as a file, so the mechanism is: store each PEM as a Secrets Manager secret, inject them as env vars via the task definition's `Secrets:`, and let the image entrypoint (`scripts/cfdb-tls-entrypoint.sh`) write them to files and point `CFDB_WORKER_TLS_CA/CERT/KEY` at them before the app starts.
+
+#### Worker mTLS on ECS
+
+**Optional, off by default — and deliberately left off.** The same `CFDB_WORKER_TLS_*` gating that secures the local channel ([Worker mTLS](#worker-mtls)) is wired into the Fargate task definitions, but disabled unless you supply cert ARNs. Fargate cannot mount a Secrets Manager secret as a file, so the mechanism is: store each PEM as a Secrets Manager secret, inject them as env vars via the task definition's `Secrets:`, and let the image entrypoint (`scripts/cfdb-tls-entrypoint.sh`) write them to files and point `CFDB_WORKER_TLS_CA/CERT/KEY` at them before the app starts.
 
 **Why it stays off.** On AWS the marginal value is small and the operational cost is not. The worker security group already restricts inbound `50051` to the API's security group alone — there is no worker-to-worker rule, so a compromised worker cannot reach its peers — and only public data enters the pipeline, since `enforce_hubmap_access` rejects anything whose `data_access_level` is not `public` before dispatch. Fargate runs on Nitro, where intra-VPC traffic between tasks is already encrypted at the link layer, so this is not the difference between plaintext and encrypted. What mTLS would add is a backstop if the security group is ever widened, and authentication that does not depend on network position. What it costs is a CA to guard, a non-atomic rotation procedure, certificates that expire with nothing watching them, and a failure mode whose only symptom is a job that never moves. The capability is here so the decision can be revisited; the recommendation is to leave the cert ARNs empty.
 
@@ -219,7 +238,7 @@ Locally the calculation is different — there is no security group, developer m
 **If you do enable it**, three things have to be true together, and the middle one is the part that is easy to miss:
 
 1. Every PEM is in Secrets Manager and the ARNs are passed to both stacks — the workers stack (`WorkerTlsCaSecretArn`, `WorkerTlsCertSecretArn`, `WorkerTlsKeySecretArn`) and the backend stack (`ApiTlsCaSecretArn`, `ApiTlsCertSecretArn`, `ApiTlsKeySecretArn`, reusing the same CA secret). Supplying a CA ARN flips the per-stack condition that adds the `Secrets:` env and the least-privilege `secretsmanager:GetSecretValue` IAM.
-2. The worker leaf carries the backend stack's `WorkerTlsIdentity` (default `cfdb-worker`) as a SAN. `EcsDiscovery` reaches each worker at the awsvpc IP assigned at launch, so the API verifies the certificate against that logical name rather than the dialed address; a leaf without the SAN cannot be verified at all. There is no identity parameter on the workers stack — a worker is the TLS server on the dispatch channel, and its half of the arrangement is the certificate.
+2. The worker leaf carries the same `WorkerTlsIdentity` (default `cfdb-worker`) as a SAN, and **both stacks are given the same value** — the backend stack's parameter is what the API verifies dispatch against, and the workers stack's parameter is what each worker verifies on the graceful-stop channel wool dials back to its own subprocess. `EcsDiscovery` reaches each worker at the awsvpc IP assigned at launch, so verification uses that logical name rather than the dialed address; a leaf without the SAN cannot be verified at all. Letting the two stacks drift is the quiet failure: dispatch works, and every graceful drain fails its name check, force-reaping the subprocess and losing in-flight work.
 3. Both stacks are enabled together. wool's admission gate is symmetric: a proxy holding credentials admits only workers advertising `secure=true`, and a proxy without credentials admits only workers without. Turning mTLS on in one stack and not the other empties the pool.
 
 **Diagnosing a failed handshake.** wool logs it. `WorkerProxy` emits a rate-limited warning per worker under the `wool.runtime.worker.proxy` logger, carrying the gRPC status and detail, and the API's root logger is at `INFO` so it reaches CloudWatch:
@@ -854,6 +873,10 @@ When the API runs on ECS Fargate (or LocalStack-backed dev that mirrors prod end
 
 The worker container's `CMD` is `python -m cfdb.workflows.worker_main`. Worker-side knobs (gRPC port, health port, max lifetime, drain grace) are documented under `--help` on that command; their env vars are `CFDB_WORKER_GRPC_PORT`, `CFDB_WORKER_HEALTH_PORT`, `CFDB_WORKER_MAX_LIFETIME_SECONDS`, and `CFDB_WORKER_DRAIN_GRACE_SECONDS`. The worker task definition MUST declare a `healthCheck` against the gRPC port; without one ECS reports `healthStatus: UNKNOWN` indefinitely and the worker is never advertised to discovery.
 
+**Workers publish their own metadata.** ECS reports a task's address and health, but not what is running inside the container — and two fields of wool's `WorkerMetadata` are knowable only to the worker: the wool protocol version it runs, and whether it configured TLS. wool gates worker admission on both, so a value the API invented for them would be a value that silently rejects the entire fleet. After starting, each worker therefore tags its own ECS task (`wool.version`, `wool.secure`) with what wool authored for it, and `EcsDiscovery` reads those tags back via `DescribeTasks … --include TAGS`. ECS supplies liveness; the worker supplies identity.
+
+Two consequences worth knowing. The worker task role MUST hold `ecs:TagResource` — `workers.yml` grants it, but only a privileged `cloudformation deploy` can land that grant, and it MUST land **before** the image that publishes does (see the one-time bootstrap in [Deploying the CloudFormation stacks](#deploying-the-cloudformation-stacks) — the CI role cannot deploy templates, so merging without the bootstrap ships a fleet that exits at startup). A worker that cannot publish **exits** rather than serving, because it could never be discovered and would otherwise hold a Fargate slot and count against `ECS_MAX_WORKERS` while being unable to receive work. And a task that is `RUNNING`/`HEALTHY` but whose tags have not yet landed is deliberately not advertised: "has not published yet" is not "has default metadata", and treating them the same is what previously made every ECS worker unadmittable.
+
 #### Running a local worker pool
 
 For single-host development, start a wool worker pool in a separate process *before* launching the API, with `WORKFLOW_POOL_NAMESPACE` matching what the API uses:
@@ -865,7 +888,7 @@ python -m cfdb.workflows.worker_lan --namespace cfdb-workers --workers 2
 # or, with defaults: make worker-local
 ```
 
-This is the local-dev counterpart to the ECS entrypoint (`python -m cfdb.workflows.worker_main`): `worker_lan` spawns a `wool.WorkerPool` wired to `LanDiscovery` so the pool advertises its workers over zeroconf/mDNS, whereas `worker_main` boots a bare worker that `EcsDiscovery` finds by polling the ECS control plane. The API connects via LAN discovery and dispatches workflows to whatever workers are publishing under that namespace. With no worker pool running, `/data` and `/index` requests for processable formats will hang on the dispatch retry budget (60s by default) before failing with `NoWorkersAvailable`.
+This is the local-dev counterpart to the ECS entrypoint (`python -m cfdb.workflows.worker_main`): `worker_lan` spawns a `wool.WorkerPool` wired to `LanDiscovery` so the pool advertises its workers over zeroconf/mDNS, whereas `worker_main` boots a bare worker that `EcsDiscovery` finds by polling the ECS control plane and reading the metadata tags the worker published onto its own task. The API connects via LAN discovery and dispatches workflows to whatever workers are publishing under that namespace. With no worker pool running, `/data` and `/index` requests for processable formats will hang on the dispatch retry budget (60s by default) before failing with `NoWorkersAvailable`.
 
 #### Worker mTLS
 
@@ -873,7 +896,7 @@ By default the API↔worker gRPC dispatch channel is plaintext, gated only by ne
 
 The configuration is gating-by-presence: when all three of `CFDB_WORKER_TLS_CA`, `CFDB_WORKER_TLS_CERT`, and `CFDB_WORKER_TLS_KEY` are unset the plaintext path is used unchanged (local PoC dev needs no certs); when all three are set mTLS is enforced. A *partial* configuration (some set, some not) fails fast at startup rather than silently degrading to plaintext.
 
-**Identity.** TLS normally verifies a server's certificate against the address the client dialed, which is a problem here: workers answer wherever they happen to come up. `EcsDiscovery` reaches each Fargate worker at the awsvpc IP assigned at launch, and a containerized local worker answers on a bridge IP — neither is knowable when the certificate is minted. `CFDB_WORKER_TLS_IDENTITY` (default `cfdb-worker`) points the API at a fixed logical name instead, so the worker leaf carries one stable SAN rather than an enumeration of every address it might be reached at. Chain and SAN verification both still happen; only the name being matched changes. It is a client-side setting, so it belongs to the API alone — a worker's half of the arrangement is the SAN baked into its certificate. Setting it to the empty string restores address verification, which is only workable when workers are reached at a fixed, certified address.
+**Identity.** TLS normally verifies a server's certificate against the address the client dialed, which is a problem here: workers answer wherever they happen to come up. `EcsDiscovery` reaches each Fargate worker at the awsvpc IP assigned at launch, and a containerized local worker answers on a bridge IP — neither is knowable when the certificate is minted. `CFDB_WORKER_TLS_IDENTITY` (default `cfdb-worker`) points the API at a fixed logical name instead, so the worker leaf carries one stable SAN rather than an enumeration of every address it might be reached at. Chain and SAN verification both still happen; only the name being matched changes. It is a client-side setting — but "client" is a property of a connection, not of a process: the API is the client on the dispatch channel, and each worker is the client on the one channel wool opens back to its own subprocess to drain it, verifying the same SAN. Both sides therefore read the variable and MUST agree on it; a worker left at a different value drains by force-reap instead of gracefully, losing in-flight work with no TLS error anywhere. Setting it to the empty string restores address verification, which is only workable when workers are reached at a fixed, certified address.
 
 Generate a local CA and the worker + API leaf certs with:
 
@@ -904,7 +927,7 @@ export CFDB_WORKER_TLS_CERT=certs/api/api-cert.pem
 export CFDB_WORKER_TLS_KEY=certs/api/api-key.pem
 ```
 
-The same env vars configure the ECS worker entrypoint (`worker_main`) and the API on Fargate — see [Worker mTLS on ECS](#deploying-the-cloudformation-stacks) for distributing the material through Secrets Manager.
+The same env vars configure the ECS worker entrypoint (`worker_main`) and the API on Fargate — see [Worker mTLS on ECS](#worker-mtls-on-ecs) for distributing the material through Secrets Manager.
 
 > **Upgrading an existing mTLS deployment.** Worker certificates minted before identity support have no `cfdb-worker` SAN, so the API will now fail to verify them. Regenerate with `./certs/generate-worker-certs.sh --force` — plain `make worker-certs` passes no arguments and the script skips material that already exists, so it will report success and change nothing. Use `--force --identity NAME` to match a SAN your certificates already carry instead. Alternatively set `CFDB_WORKER_TLS_IDENTITY=""` to keep verifying against the dialed address. Deployments running the plaintext channel are unaffected.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Requires Python 3.11 or later.
 | `CFDB_WORKER_TLS_CA` | Path to the shared CA certificate for the wool worker gRPC channel. When this and the cert/key below are all set, the API↔worker dispatch channel uses mutual TLS (`mutual=True`); when all three are unset the channel stays plaintext. Partial config fails fast at startup. The API and every worker MUST use certs signed by the same CA. See [Worker mTLS](#worker-mtls). | - |
 | `CFDB_WORKER_TLS_CERT` | Path to this process's PEM certificate on the worker gRPC channel — the worker leaf cert on a worker (`worker_main`/`worker_lan`), the API client cert on the API. Must be signed by `CFDB_WORKER_TLS_CA`. | - |
 | `CFDB_WORKER_TLS_KEY` | Path to this process's PEM private key paired with `CFDB_WORKER_TLS_CERT`. | - |
+| `CFDB_WORKER_TLS_IDENTITY` | Logical name the **API** verifies worker certificates against, in place of the address it dialed. Workers answer on addresses assigned at launch — an awsvpc IP on Fargate, a bridge IP in local containers — that no certificate minted ahead of time can name, so without this the handshake cannot succeed. The worker leaf must carry this value as a SAN; `certs/generate-worker-certs.sh` mints the default. Set to the empty string to verify against the dialed address instead. Read by the API only — a worker is the TLS server and has no peer name to override. Ignored while mTLS is off. See [Worker mTLS](#worker-mtls). | `cfdb-worker` |
 | `CFDB_API_URL` | Base URL for the cfdb API | `http://localhost:8000` |
 | `DATABASE_URL` | MongoDB connection string | `mongodb://127.0.0.1:27017` |
 | `DATABASE_NAME` | Name of the MongoDB database to use | `cfdb` |
@@ -209,13 +210,71 @@ aws cloudformation deploy \
 The `cloudformation/backend.yml` `ImageURI` and `cloudformation/workers.yml` `WorkerImageURI` parameters now **default** to these `:dev` URIs. Note what that default does and does not do: on a stack **UPDATE**, CloudFormation reuses each parameter's **previous** value, not its default — so the `:dev` default only governs a fresh stack **CREATE**. The point is that a later infra `cloudformation deploy` (an update) keeps whatever value the bootstrap set — `:dev` — rather than reverting to a stale SHA, so the moving-tag CI deploy stays the source of truth for what code runs. Because the task defs pin `:dev` rather than a SHA, task-definition-level traceability to a commit is intentionally given up; it is recovered by the immutable `:<sha>` tag pushed alongside `:dev` and by SHA-based rollback via ECR re-tag.
 
 **Tearing down the cache.** CloudFormation cannot delete a non-empty S3 bucket, so empty the `CacheBucket` before deleting the workers stack or the delete will fail and roll back.
+**Worker mTLS on ECS (optional, off by default — and deliberately left off).** The same `CFDB_WORKER_TLS_*` gating that secures the local channel ([Worker mTLS](#worker-mtls)) is wired into the Fargate task definitions, but disabled unless you supply cert ARNs. Fargate cannot mount a Secrets Manager secret as a file, so the mechanism is: store each PEM as a Secrets Manager secret, inject them as env vars via the task definition's `Secrets:`, and let the image entrypoint (`scripts/cfdb-tls-entrypoint.sh`) write them to files and point `CFDB_WORKER_TLS_CA/CERT/KEY` at them before the app starts.
 
-**Worker mTLS on ECS (optional, off by default).** The same `CFDB_WORKER_TLS_*` gating that secures the local channel ([Worker mTLS](#worker-mtls)) is wired into the Fargate task definitions, but disabled unless you supply cert ARNs. Fargate cannot mount a Secrets Manager secret as a file, so the mechanism is: store each PEM as a Secrets Manager secret, inject them as env vars via the task definition's `Secrets:`, and let the image entrypoint (`scripts/cfdb-tls-entrypoint.sh`) write them to files and point `CFDB_WORKER_TLS_CA/CERT/KEY` at them before the app starts. To enable:
+**Why it stays off.** On AWS the marginal value is small and the operational cost is not. The worker security group already restricts inbound `50051` to the API's security group alone — there is no worker-to-worker rule, so a compromised worker cannot reach its peers — and only public data enters the pipeline, since `enforce_hubmap_access` rejects anything whose `data_access_level` is not `public` before dispatch. Fargate runs on Nitro, where intra-VPC traffic between tasks is already encrypted at the link layer, so this is not the difference between plaintext and encrypted. What mTLS would add is a backstop if the security group is ever widened, and authentication that does not depend on network position. What it costs is a CA to guard, a non-atomic rotation procedure, certificates that expire with nothing watching them, and a failure mode whose only symptom is a job that never moves. The capability is here so the decision can be revisited; the recommendation is to leave the cert ARNs empty.
 
-1. Generate certs (`make worker-certs`) and upload each PEM to Secrets Manager, e.g. `aws secretsmanager create-secret --name cfdb/worker-tls/ca --secret-string file://certs/worker-ca/ca.pem` (and the worker + API leaf cert/key).
-2. Pass the ARNs to the workers stack (`WorkerTlsCaSecretArn`, `WorkerTlsCertSecretArn`, `WorkerTlsKeySecretArn`) and the backend stack (`ApiTlsCaSecretArn`, `ApiTlsCertSecretArn`, `ApiTlsKeySecretArn` — reuse the same CA secret). Supplying a CA ARN flips the per-stack condition that adds the `Secrets:` env and the least-privilege `secretsmanager:GetSecretValue` IAM. Leave them empty to keep dispatch plaintext.
+Locally the calculation is different — there is no security group, developer machines share networks, and it is the configuration the tests exercise. See [Worker mTLS](#worker-mtls).
 
-> **Caveat — not yet functional on Fargate.** `EcsDiscovery` dials each worker at its *dynamic* awsvpc IP and wool does not override the gRPC authority, so a static worker cert's SAN cannot match the dialed address and the mTLS handshake will fail verification. The wiring above is in place, but **leave the cert ARNs empty** until wool gains a client-side target-name override (tracked separately). Until then, the worker security group is the access control on ECS.
+**If you do enable it**, three things have to be true together, and the middle one is the part that is easy to miss:
+
+1. Every PEM is in Secrets Manager and the ARNs are passed to both stacks — the workers stack (`WorkerTlsCaSecretArn`, `WorkerTlsCertSecretArn`, `WorkerTlsKeySecretArn`) and the backend stack (`ApiTlsCaSecretArn`, `ApiTlsCertSecretArn`, `ApiTlsKeySecretArn`, reusing the same CA secret). Supplying a CA ARN flips the per-stack condition that adds the `Secrets:` env and the least-privilege `secretsmanager:GetSecretValue` IAM.
+2. The worker leaf carries the backend stack's `WorkerTlsIdentity` (default `cfdb-worker`) as a SAN. `EcsDiscovery` reaches each worker at the awsvpc IP assigned at launch, so the API verifies the certificate against that logical name rather than the dialed address; a leaf without the SAN cannot be verified at all. There is no identity parameter on the workers stack — a worker is the TLS server on the dispatch channel, and its half of the arrangement is the certificate.
+3. Both stacks are enabled together. wool's admission gate is symmetric: a proxy holding credentials admits only workers advertising `secure=true`, and a proxy without credentials admits only workers without. Turning mTLS on in one stack and not the other empties the pool.
+
+**Diagnosing a failed handshake.** wool logs it. `WorkerProxy` emits a rate-limited warning per worker under the `wool.runtime.worker.proxy` logger, carrying the gRPC status and detail, and the API's root logger is at `INFO` so it reaches CloudWatch:
+
+```
+WARNING wool.runtime.worker.proxy Skipping worker 0b49fcd9-… at 10.3.2.7:50051 after handshake failure:
+UNAVAILABLE: … UNAUTHENTICATED: Hostname Verification Check failed.
+```
+
+Grep for `after handshake failure`. The detail distinguishes the cases — `Hostname Verification Check failed` is a SAN mismatch, a CA mismatch and an expired leaf read differently. The API also logs `worker_tls_identity=` at startup, which tells you what it expected to match; that is corroboration, not the diagnosis. One genuine blind spot remains: a *worker* rejecting the API's client certificate surfaces as a plain `UNAVAILABLE` with no TLS evidence, observable only on the worker.
+
+Note what a handshake failure looks like from outside: `HandshakeError` is transient in wool, so the worker is skipped rather than evicted, and dispatch reports `NoWorkersAvailable`. Nothing in the client-visible error names TLS.
+
+#### Operating the worker certificates
+
+The mechanics below are not recoverable from the code, and they are needed exactly when someone first enables mTLS. There is no tooling for any of it beyond `generate-worker-certs.sh`, which is local-dev tooling — it mints usable material, but its CA key is unencrypted and lands wherever you ran it, so treat production material as something you mint deliberately (CloudShell, or an offline host) rather than as a by-product of `make`.
+
+**Give each environment its own CA.** dev and prod share account `605134458779`. A CA is a trust root, so one CA across both environments means a leaked *dev* worker certificate authenticates to *prod* workers — the blast radius of the less-guarded environment becomes the blast radius of the guarded one. Mint and upload two independent sets, and never point a prod stack at a dev ARN.
+
+**Archive each CA key before minting the next.** The script writes the CA to the fixed path `certs/worker-ca/ca-key.pem` and regenerates it in place under `--force`, and the CA key is deliberately *not* uploaded to Secrets Manager. So minting a second environment overwrites the first environment's CA key, after which no replacement leaf can ever be issued for it and the only recovery is the full CA rotation below. Copy `ca-key.pem` somewhere durable first — a password manager, or its own Secrets Manager secret readable by neither task role nor the `cfdb-deploy` CI role.
+
+**Regenerating requires `--force`.** Both the CA block and `mint_leaf` skip when the files already exist, and `make worker-certs` passes no arguments, so `make worker-certs` on a machine that already has certs prints "already exists" and changes nothing. Call the script directly when you mean to replace material:
+
+```bash
+./certs/generate-worker-certs.sh --force                      # replace everything
+./certs/generate-worker-certs.sh --force --identity NAME      # …with a different SAN
+```
+
+**What a compromised task can reach.** The templates scope `secretsmanager:GetSecretValue` to the *execution* role — the one the ECS agent uses to inject the container's `Secrets:` — and to exactly the cert ARNs, so the **task** role holds no `GetSecretValue` at all. That bounds a task compromise to the material that task was already given: the entrypoint writes its own leaf and key to `/tmp/cfdb-tls/`, so a compromised task trivially holds those. What it cannot reach is the other side's leaf, the other environment's material, or the CA key.
+
+Related, and worth stating because an operator will otherwise assume otherwise: under a shared CA these certificates prove **fleet membership, not peer role**. The API verifies a worker by name, but a worker verifies its client by chain alone, so any CA-signed leaf can act as a client. A compromised worker — the component that shells out to `samtools`/`tabix`/`bigBedToBed` over untrusted upstream bytes — therefore holds a credential the API accepts. mTLS does not contain a worker compromise. The generator mitigates the reverse direction by giving the API leaf `clientAuth` only, so the API's certificate cannot terminate a server side.
+
+**Rotating a leaf** is two commands, because the entrypoint materializes the PEMs once at container start:
+
+```bash
+aws secretsmanager put-secret-value --secret-id <api-cert-secret> \
+  --secret-string file://certs/api/api-cert.pem
+aws ecs update-service --cluster cfdb-backend-prod-cluster \
+  --service cfdb-backend-prod-service --force-new-deployment
+```
+
+Workers need no step at all — they are ephemeral, so the next `EcsProvisioner` `RunTask` pulls the new secret. (wool 0.13 can adopt rotated material without a restart via a reloadable credential provider; cfdb has not adopted it, because on ECS the redeploy above is cheap.)
+
+**Rotating the CA is not atomic**, and the obvious approach breaks dispatch: a rolled API trusting only the new CA rejects every in-flight worker still holding a leaf signed by the old one. gRPC accepts a *bundle* of roots, so stage it instead — publish both CAs concatenated, roll everything onto it, then drop the old:
+
+```bash
+cat certs/worker-ca/ca.pem /path/to/new-ca.pem > /tmp/ca-bundle.pem
+aws secretsmanager put-secret-value --secret-id <ca-secret> \
+  --secret-string file:///tmp/ca-bundle.pem
+# Roll the API onto the bundle and let in-flight workers cycle out, then
+# reissue both leaves under the new CA, roll again, and only then publish
+# the new CA alone.
+```
+
+**Nothing watches expiry.** `generate-worker-certs.sh` mints 825-day leaves, and an expired certificate is skipped as a transient handshake failure like any other — wool's warning does name it, but only if someone is reading. Either put rotation on a schedule short enough that this runbook stays exercised, or record the expiry somewhere that will page you: `openssl x509 -enddate -noout -in certs/worker/worker-cert.pem`.
 
 ## GraphQL API
 
@@ -814,14 +873,16 @@ By default the API↔worker gRPC dispatch channel is plaintext, gated only by ne
 
 The configuration is gating-by-presence: when all three of `CFDB_WORKER_TLS_CA`, `CFDB_WORKER_TLS_CERT`, and `CFDB_WORKER_TLS_KEY` are unset the plaintext path is used unchanged (local PoC dev needs no certs); when all three are set mTLS is enforced. A *partial* configuration (some set, some not) fails fast at startup rather than silently degrading to plaintext.
 
+**Identity.** TLS normally verifies a server's certificate against the address the client dialed, which is a problem here: workers answer wherever they happen to come up. `EcsDiscovery` reaches each Fargate worker at the awsvpc IP assigned at launch, and a containerized local worker answers on a bridge IP — neither is knowable when the certificate is minted. `CFDB_WORKER_TLS_IDENTITY` (default `cfdb-worker`) points the API at a fixed logical name instead, so the worker leaf carries one stable SAN rather than an enumeration of every address it might be reached at. Chain and SAN verification both still happen; only the name being matched changes. It is a client-side setting, so it belongs to the API alone — a worker's half of the arrangement is the SAN baked into its certificate. Setting it to the empty string restores address verification, which is only workable when workers are reached at a fixed, certified address.
+
 Generate a local CA and the worker + API leaf certs with:
 
 ```bash
 make worker-certs
-# wraps ./certs/generate-worker-certs.sh — see --help for SAN options.
+# wraps ./certs/generate-worker-certs.sh — see --help for --identity and SAN options.
 # Writes (all git-ignored):
 #   certs/worker-ca/ca.pem            shared CA
-#   certs/worker/worker-cert.pem,-key.pem   worker leaf
+#   certs/worker/worker-cert.pem,-key.pem   worker leaf (SAN: cfdb-worker)
 #   certs/api/api-cert.pem,-key.pem         API client leaf
 ```
 
@@ -835,7 +896,7 @@ python -m cfdb.workflows.worker_lan
 # or, with these env vars baked in: make worker-local-tls
 ```
 
-…and the API process, with the **same** `CFDB_WORKER_TLS_CA` but the API leaf:
+…and the API process, with the **same** `CFDB_WORKER_TLS_CA` but the API leaf. `CFDB_WORKER_TLS_IDENTITY` already defaults to the SAN `make worker-certs` mints, so it only needs setting when you passed a different `--identity`:
 
 ```bash
 export CFDB_WORKER_TLS_CA=certs/worker-ca/ca.pem
@@ -843,7 +904,11 @@ export CFDB_WORKER_TLS_CERT=certs/api/api-cert.pem
 export CFDB_WORKER_TLS_KEY=certs/api/api-key.pem
 ```
 
-The same three env vars configure the ECS worker entrypoint (`worker_main`) and the API on Fargate; distributing the certs to the ECS task definitions is tracked as follow-up work and is not yet wired into the CloudFormation deploy.
+The same env vars configure the ECS worker entrypoint (`worker_main`) and the API on Fargate — see [Worker mTLS on ECS](#deploying-the-cloudformation-stacks) for distributing the material through Secrets Manager.
+
+> **Upgrading an existing mTLS deployment.** Worker certificates minted before identity support have no `cfdb-worker` SAN, so the API will now fail to verify them. Regenerate with `./certs/generate-worker-certs.sh --force` — plain `make worker-certs` passes no arguments and the script skips material that already exists, so it will report success and change nothing. Use `--force --identity NAME` to match a SAN your certificates already carry instead. Alternatively set `CFDB_WORKER_TLS_IDENTITY=""` to keep verifying against the dialed address. Deployments running the plaintext channel are unaffected.
+
+> **Rolling back past this change.** The reverse is also breaking, and less obvious. Once workers hold identity-carrying certificates, an API rolled back to a pre-identity image drops the target-name override and verifies against the dialed address again — which for a leaf whose only SAN is the identity fails every handshake. wool's version gate does not catch this, because an older API against newer workers passes `client <= server`: the workers are admitted and then fail at the handshake. Roll back with `CFDB_WORKER_TLS_IDENTITY=""` set, or revert to address-verifiable certificates first.
 
 **URL:** `GET /jobs/{job_id}`
 

--- a/certs/generate-worker-certs.sh
+++ b/certs/generate-worker-certs.sh
@@ -20,15 +20,29 @@
 # (see certs/.gitignore) and MUST NOT be committed or used in
 # production; ECS distributes its own material out of band.
 #
+# The *worker* leaf carries a logical *identity* SAN (default
+# ``cfdb-worker``). The API verifies worker certs against that name
+# rather than the address it dialed — see CFDB_WORKER_TLS_IDENTITY —
+# which is what lets one cert serve a worker no matter which address it
+# comes up on. Without it the SAN list has to enumerate every address a
+# worker might answer at, which is impossible on ECS and tedious for
+# containerized local dev. The API leaf deliberately carries no SAN at
+# all (and clientAuth only): a worker verifies its client by chain, not
+# by name, and an identity SAN on the API leaf would make the API's own
+# certificate a valid worker certificate.
+#
 # Usage:
-#   ./certs/generate-worker-certs.sh [--force] [extra-SAN ...]
+#   ./certs/generate-worker-certs.sh [--force] [--identity NAME] [extra-SAN ...]
 #
-#   --force        Overwrite existing certificates instead of skipping.
-#   extra-SAN ...  Additional subjectAltName entries to embed in the
-#                  leaf certs (e.g. a worker's LAN hostname/IP). Each is
-#                  auto-classified as IP:<x> or DNS:<x>.
+#   --force          Overwrite existing certificates instead of skipping.
+#   --identity NAME  Logical identity SAN to embed (default cfdb-worker).
+#                    Must match CFDB_WORKER_TLS_IDENTITY on the API.
+#   extra-SAN ...    Additional subjectAltName entries to embed in the
+#                    leaf certs (e.g. a worker's LAN hostname/IP). Each
+#                    is auto-classified as IP:<x> or DNS:<x>. Rarely
+#                    needed now that the identity covers addressing.
 #
-#   -h, --help     Show this help and exit.
+#   -h, --help       Show this help and exit.
 
 set -euo pipefail
 
@@ -37,9 +51,10 @@ usage() {
 }
 
 FORCE=0
+IDENTITY="cfdb-worker"   # keep in step with credentials.DEFAULT_TLS_IDENTITY
 EXTRA_SANS=()
-for arg in "$@"; do
-    case "$arg" in
+while [ "$#" -gt 0 ]; do
+    case "$1" in
         -h|--help)
             usage
             exit 0
@@ -47,11 +62,41 @@ for arg in "$@"; do
         --force)
             FORCE=1
             ;;
+        --identity)
+            # Consumes the next argument, so guard against it being
+            # absent — otherwise the identity would silently become
+            # empty and every leaf would ship without its stable SAN.
+            [ "$#" -ge 2 ] || { echo "error: --identity requires a name" >&2; exit 2; }
+            IDENTITY="$2"
+            shift
+            ;;
+        --identity=*)
+            IDENTITY="${1#--identity=}"
+            ;;
         *)
-            EXTRA_SANS+=("$arg")
+            EXTRA_SANS+=("$1")
             ;;
     esac
+    shift
 done
+
+# The identity is interpolated straight into a subjectAltName list and
+# matched by gRPC as a DNS name, so constrain it to what can survive
+# both. A comma would silently inject a second SAN entry; a space would
+# fail openssl's extension parser; a leading dash means the caller wrote
+# "--identity --force" and lost their value to the flag that followed.
+# An IP literal is rejected too: it would be minted as DNS:1.2.3.4,
+# which gRPC never matches against an address.
+if [ -z "$IDENTITY" ]; then
+    echo "error: --identity must not be empty" >&2
+    exit 2
+elif [[ ! "$IDENTITY" =~ ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$ ]]; then
+    echo "error: --identity must be a DNS-safe name (got '$IDENTITY')" >&2
+    exit 2
+elif [[ "$IDENTITY" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: --identity must be a name, not an IP address" >&2
+    exit 2
+fi
 
 # Resolve directories relative to this script so it works from any CWD.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -72,11 +117,22 @@ if ! command -v openssl >/dev/null 2>&1; then
     exit 1
 fi
 
-# Build the subjectAltName list. localhost / loopback / 0.0.0.0 cover
-# the single-host LAN-dev case; callers can append the worker's actual
-# advertised hostname/IP as extra args.
-build_san() {
-    local sans="DNS:localhost,IP:127.0.0.1,IP:0.0.0.0"
+# Build the subjectAltName list. The identity comes first because it is
+# the entry the API actually matches on when CFDB_WORKER_TLS_IDENTITY is
+# set; the rest are a convenience for address-based verification, which
+# is what you fall back to with an empty identity. localhost / loopback
+# / 0.0.0.0 cover the single-host LAN-dev case; callers can append the
+# worker's actual advertised hostname/IP as extra args.
+#
+# These belong to the WORKER leaf alone. The API is only ever a client on
+# this channel, and a worker authenticates its client by chain with no
+# name check — so the API leaf needs no SAN at all. Giving it one, and in
+# particular giving it the identity, would make the API's own certificate
+# a valid worker server certificate: after this change the API's test of
+# a worker is "CA-signed and bears the identity SAN", which its own leaf
+# would then satisfy.
+build_worker_san() {
+    local sans="DNS:$IDENTITY,DNS:localhost,IP:127.0.0.1,IP:0.0.0.0"
     local host
     host="$(hostname 2>/dev/null || true)"
     if [ -n "$host" ]; then
@@ -94,7 +150,7 @@ build_san() {
     printf '%s' "$sans"
 }
 
-SAN="$(build_san)"
+WORKER_SAN="$(build_worker_san)"
 
 # --- Certificate authority -------------------------------------------
 if [ "$FORCE" -eq 0 ] && [ -f "$CA_CERT" ] && [ -f "$CA_KEY" ]; then
@@ -108,9 +164,17 @@ else
 fi
 
 # --- Leaf certificate helper -----------------------------------------
-# $1 = output dir, $2 = file stem, $3 = CN
+# $1 = output dir, $2 = file stem, $3 = CN, $4 = extendedKeyUsage,
+# $5 = subjectAltName list (empty for a leaf that needs none)
+#
+# The two leaves are deliberately NOT symmetric. The worker terminates
+# the dispatch connection, so it needs serverAuth and a SAN the API can
+# match. The API only ever dials, so it needs clientAuth and no SAN —
+# and withholding serverAuth means the TLS stack itself refuses to let
+# the API's certificate terminate a server side, which is a stronger
+# guarantee than merely omitting the name.
 mint_leaf() {
-    local dir="$1" stem="$2" cn="$3"
+    local dir="$1" stem="$2" cn="$3" eku="$4" san="${5:-}"
     local key="$dir/${stem}-key.pem"
     local cert="$dir/${stem}-cert.pem"
     local csr="$dir/${stem}.csr"
@@ -120,19 +184,31 @@ mint_leaf() {
         return
     fi
 
-    echo "Generating ${stem} cert -> $cert (CN=$cn, SAN=$SAN)"
+    # openssl rejects an empty subjectAltName, so the extension is
+    # omitted entirely rather than emitted blank.
+    local ext="extendedKeyUsage=$eku"
+    if [ -n "$san" ]; then
+        ext="subjectAltName=$san"$'\n'"$ext"
+    fi
+
+    echo "Generating ${stem} cert -> $cert (CN=$cn, EKU=$eku, SAN=${san:-<none>})"
     openssl req -newkey "rsa:$KEY_BITS" -nodes \
         -keyout "$key" -out "$csr" \
         -subj "/CN=$cn"
     openssl x509 -req -in "$csr" \
         -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
         -out "$cert" -days "$DAYS" -sha256 \
-        -extfile <(printf 'subjectAltName=%s\nextendedKeyUsage=serverAuth,clientAuth\n' "$SAN")
+        -extfile <(printf '%s\n' "$ext")
     rm -f "$csr"
 }
 
-mint_leaf "$WORKER_DIR" "worker" "cfdb-worker"
-mint_leaf "$API_DIR" "api" "cfdb-api"
+# The worker also dials one connection of its own — wool's graceful-stop
+# RPC to its subprocess — so its leaf keeps clientAuth alongside
+# serverAuth.
+# CN follows the identity so `openssl x509 -text` reads consistently
+# during a debugging session; verification itself uses only the SAN.
+mint_leaf "$WORKER_DIR" "worker" "$IDENTITY" "serverAuth,clientAuth" "$WORKER_SAN"
+mint_leaf "$API_DIR" "api" "cfdb-api" "clientAuth"
 
 echo
 echo "Done. Worker mTLS material written under $SCRIPT_DIR/"

--- a/cloudformation/backend.yml
+++ b/cloudformation/backend.yml
@@ -84,9 +84,6 @@ Parameters:
   # material for mutual TLS on the API<->worker gRPC channel: the shared
   # CA cert (same secret the workers stack uses), the API leaf cert, and
   # its key. Leave all three empty (default) to dispatch over plaintext.
-  # See the workers stack for the upstream-blocker caveat (wool does not
-  # override the gRPC authority, so enforced mTLS over the ECS path does
-  # not validate yet) — keep empty until that lands.
   ApiTlsCaSecretArn:
     Type: String
     Default: ""
@@ -99,6 +96,37 @@ Parameters:
     Type: String
     Default: ""
     Description: Secrets Manager ARN of the API client private-key PEM.
+  # The API verifies each worker's certificate against this logical name
+  # instead of the address it dialed. That indirection is what makes the
+  # ECS path work at all: EcsDiscovery reaches every worker at the
+  # awsvpc IP assigned at launch, which no certificate minted ahead of
+  # time can name. The worker leaf must carry this as a SAN — see
+  # certs/generate-worker-certs.sh --identity, whose default matches.
+  # Empty falls back to address verification, which on Fargate means the
+  # handshake fails; only set it empty if workers are reached at a fixed
+  # name. Ignored entirely while mTLS is off.
+  WorkerTlsIdentity:
+    Type: String
+    Default: cfdb-worker
+    # Constrained to what can survive being both a certificate SAN and a
+    # gRPC target name. A value with a space or comma yields an override
+    # that matches no SAN, and the only symptom is NoWorkersAvailable —
+    # so reject it at deploy time instead. An IP literal is rejected for
+    # the same reason (the generator would mint it as DNS:<ip>, which
+    # gRPC never matches against an address), by requiring at least one
+    # letter. The empty string is allowed because it is the documented
+    # opt-out.
+    AllowedPattern: "^$|^([0-9][A-Za-z0-9._-]*)?[A-Za-z]([A-Za-z0-9._-]*[A-Za-z0-9])?$"
+    ConstraintDescription: >
+      Must be empty or a DNS-safe name (letters, digits, dot, hyphen,
+      underscore; not starting or ending with a separator) containing
+      at least one letter. IP literals are rejected — they cannot be
+      minted as a matchable SAN.
+    Description: >
+      Logical identity the API verifies worker certificates against,
+      matching the SAN in the worker leaf certificate. MUST equal the
+      workers stack's WorkerTlsIdentity — the worker verifies the same
+      SAN on its own graceful-stop channel.
 
 Conditions:
   # mTLS is wired only when a CA secret ARN is supplied; otherwise the
@@ -277,6 +305,16 @@ Resources:
             # rather than spawning past this. Bounds workers, not the queue.
             - Name: ECS_MAX_WORKERS
               Value: !Ref EcsMaxWorkers
+            # Only meaningful alongside the cert Secrets below, so it is
+            # rendered away when mTLS is off rather than advertising a
+            # setting that does nothing. The workers stack has no
+            # counterpart: a worker is the TLS server here, and its half
+            # of the identity is the SAN in its certificate.
+            - !If
+              - ApiMtlsEnabled
+              - Name: CFDB_WORKER_TLS_IDENTITY
+                Value: !Ref WorkerTlsIdentity
+              - !Ref AWS::NoValue
           # The cert PEMs (when mTLS is enabled) are injected as env vars
           # and written to files by the image entrypoint
           # (cfdb-tls-entrypoint.sh), which points CFDB_WORKER_TLS_CA/CERT/KEY

--- a/cloudformation/workers.yml
+++ b/cloudformation/workers.yml
@@ -74,12 +74,13 @@ Parameters:
   # PEM). Leave all three empty (default) to run the channel plaintext —
   # the worker SG is the only access control in that case.
   #
-  # NOTE: enforced mTLS over the ECS path is currently blocked upstream:
-  # EcsDiscovery dials the worker at its dynamic awsvpc IP and wool does
-  # not override the gRPC authority, so a static worker cert's SAN cannot
-  # match the dialed IP. Populating these turns the channel on but the
-  # handshake will not validate until wool gains a target-name override.
-  # Keep empty until then.
+  # The worker leaf cert MUST carry the backend stack's
+  # WorkerTlsIdentity as a SAN. EcsDiscovery reaches each worker at the
+  # awsvpc IP assigned at launch, so the API verifies against that
+  # logical name rather than the dialed address; a cert without the SAN
+  # fails the handshake. certs/generate-worker-certs.sh mints it by
+  # default. There is no identity parameter on this stack — the worker
+  # is the TLS server, and its half of the arrangement is the SAN.
   WorkerTlsCaSecretArn:
     Type: String
     Default: ""

--- a/cloudformation/workers.yml
+++ b/cloudformation/workers.yml
@@ -67,6 +67,20 @@ Parameters:
     Description: >
       Seconds /health returns 503 after SIGTERM before the gRPC port is
       torn down (CFDB_WORKER_DRAIN_GRACE_SECONDS).
+  BackendClusterName:
+    Type: String
+    # NOTE: like every default in these templates, this matches neither
+    # live environment — pass <backend-stack>-cluster explicitly
+    # (cfdb-backend-dev-cluster / cfdb-backend-prod-cluster).
+    Default: cfdb-backend-cluster
+    Description: >
+      Name of the ECS cluster the backend stack creates
+      (${BackendStackName}-cluster). Used only to scope the worker task
+      role's ecs:TagResource grant to this environment's own tasks. A
+      plain name rather than an import because this stack deploys
+      before the backend stack exists; the cluster name is
+      deterministic, and IAM resource ARNs need not name an existing
+      resource.
   # ---------- Worker mTLS (optional, off by default) ----------
   # ARNs of Secrets Manager secrets holding the PEM material for mutual
   # TLS on the API<->worker gRPC channel. Supply the shared CA cert, the
@@ -74,13 +88,11 @@ Parameters:
   # PEM). Leave all three empty (default) to run the channel plaintext —
   # the worker SG is the only access control in that case.
   #
-  # The worker leaf cert MUST carry the backend stack's
-  # WorkerTlsIdentity as a SAN. EcsDiscovery reaches each worker at the
-  # awsvpc IP assigned at launch, so the API verifies against that
-  # logical name rather than the dialed address; a cert without the SAN
-  # fails the handshake. certs/generate-worker-certs.sh mints it by
-  # default. There is no identity parameter on this stack — the worker
-  # is the TLS server, and its half of the arrangement is the SAN.
+  # The worker leaf cert MUST carry WorkerTlsIdentity as a SAN.
+  # EcsDiscovery reaches each worker at the awsvpc IP assigned at
+  # launch, so the API verifies against that logical name rather than
+  # the dialed address; a cert without the SAN fails the handshake.
+  # certs/generate-worker-certs.sh mints it by default.
   WorkerTlsCaSecretArn:
     Type: String
     Default: ""
@@ -93,6 +105,30 @@ Parameters:
     Type: String
     Default: ""
     Description: Secrets Manager ARN of the worker leaf private-key PEM.
+  WorkerTlsIdentity:
+    Type: String
+    Default: cfdb-worker
+    # Same pattern as backend.yml's WorkerTlsIdentity: empty, or a
+    # DNS-safe name that contains at least one letter. An IP literal is
+    # rejected because it would be minted as DNS:<ip>, which gRPC never
+    # matches against an address — a value that deploys cleanly but can
+    # never handshake, whose only symptom is NoWorkersAvailable.
+    AllowedPattern: "^$|^([0-9][A-Za-z0-9._-]*)?[A-Za-z]([A-Za-z0-9._-]*[A-Za-z0-9])?$"
+    ConstraintDescription: >
+      Must be empty or a DNS-safe name (letters, digits, dot, hyphen,
+      underscore; not starting or ending with a separator) containing
+      at least one letter. IP literals are rejected — they cannot be
+      minted as a matchable SAN.
+    Description: >
+      Logical TLS identity (CFDB_WORKER_TLS_IDENTITY) for the worker
+      process. A worker is the TLS *server* on the dispatch channel,
+      but wool's graceful-stop RPC dials the worker's own subprocess —
+      on that one connection the worker is a client verifying a
+      certificate whose only SAN may be this logical name. MUST match
+      the backend stack's WorkerTlsIdentity and the SAN minted into the
+      worker leaf, or graceful drain fails its name check and wool
+      force-reaps the subprocess, losing in-flight work. Rendered only
+      when mTLS is enabled; empty opts back into address verification.
 
 Conditions:
   # mTLS is wired only when a CA secret ARN is supplied; otherwise every
@@ -246,6 +282,36 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource: !GetAtt CacheBucket.Arn
+        # The worker publishes its own wool metadata (protocol version,
+        # TLS flag) by tagging its ECS task; EcsDiscovery reads the tags
+        # back. Only the worker knows those values, and wool rejects any
+        # worker whose advertised metadata it cannot verify, so without
+        # this grant the worker exits at startup and the pool stays
+        # empty. See cfdb.workflows.worker_main.
+        #
+        # Scoped tight, because these tags are load-bearing: discovery
+        # trusts them to build the metadata wool gates admission on, so
+        # an unscoped grant would let a compromised worker — the
+        # component that shells out over untrusted upstream bytes —
+        # rewrite wool.version/wool.secure on every task in the account,
+        # including the *other environment's* (dev and prod share the
+        # account and region), silently emptying its pool. The Resource
+        # confines the grant to this environment's own cluster (the name
+        # is a parameter, not an import — see BackendClusterName), and
+        # the aws:TagKeys condition confines it to the two wool.* keys
+        # so cost-allocation and ownership tags stay out of reach.
+        - PolicyName: worker-metadata
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: ecs:TagResource
+                Resource: !Sub "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:task/${BackendClusterName}/*"
+                Condition:
+                  ForAllValues:StringEquals:
+                    aws:TagKeys:
+                      - wool.version
+                      - wool.secure
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-worker-task-role"
@@ -289,6 +355,22 @@ Resources:
               Value: !Ref WorkerMaxLifetimeSeconds
             - Name: CFDB_WORKER_DRAIN_GRACE_SECONDS
               Value: !Ref WorkerDrainGraceSeconds
+            # The worker tags its own task at startup (worker-metadata
+            # policy above); boto3 needs a region and Fargate does not
+            # inject one. The code also falls back to the task ARN's
+            # region segment, but the explicit variable mirrors
+            # backend.yml and keeps the two containers configured alike.
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
+            # The worker's half of identity verification on wool's
+            # graceful-stop channel (see the WorkerTlsIdentity
+            # parameter). Rendered only under mTLS so the plaintext
+            # template stays byte-identical to the pre-mTLS one.
+            - !If
+              - WorkerMtlsEnabled
+              - Name: CFDB_WORKER_TLS_IDENTITY
+                Value: !Ref WorkerTlsIdentity
+              - !Ref AWS::NoValue
           # mTLS PEMs (optional). ECS injects each secret as an env var;
           # the image entrypoint (cfdb-tls-entrypoint.sh) writes them to
           # files and points CFDB_WORKER_TLS_CA/CERT/KEY at them. Absent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "requests",
     "strawberry-graphql",
     "uvicorn",
-    "wool==0.12.0",
+    "wool~=0.13.0",
 ]
 description = "A Python utility for parsing and normalizing various DCC datapackages."
 dynamic = ["version"]
@@ -32,7 +32,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-dev = ["allpairspy", "cloudpickle", "debugpy", "httpx", "hypothesis", "mongomock-motor", "moto[ecs,s3]", "pytest-asyncio", "pytest-mock", "ruff"]
+dev = ["allpairspy", "cloudpickle", "cryptography", "debugpy", "httpx", "hypothesis", "mongomock-motor", "moto[ecs,s3]", "pytest-asyncio", "pytest-mock", "ruff"]
 
 [project.scripts]
 cfdb = "cfdb.cli:cli"

--- a/src/cfdb/api/__init__.py
+++ b/src/cfdb/api/__init__.py
@@ -4,6 +4,11 @@ from typing import TYPE_CHECKING, Final
 
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
+# A leaf module with no third-party imports of its own, so this stays
+# clear of the runtime workflow (and wool) dependency the rest of
+# ``cfdb.workflows`` carries — see the TYPE_CHECKING block below.
+from cfdb.workflows.constants import DEFAULT_TLS_IDENTITY, TLS_IDENTITY_ENV
+
 if TYPE_CHECKING:
     from cfdb.workflows.cache import CacheBackend
     from cfdb.workflows.executor import JobExecutor
@@ -83,7 +88,12 @@ WORKFLOW_POOL_NAMESPACE: Final = os.getenv("WORKFLOW_POOL_NAMESPACE", "cfdb-work
 # ``cfdb.workflows.credentials.build_worker_credentials``. The
 # ``CFDB_WORKER_TLS_*`` names are shared with the worker entrypoints
 # (``worker_main`` / ``worker_lan``); each process points CERT/KEY at
-# its own leaf material while the CA is common.
+# its own leaf material while the CA is common. The fourth setting,
+# ``CFDB_WORKER_TLS_IDENTITY``, is shared too: it names the peer a
+# *dialing* process expects to be talking to, which is the API on the
+# dispatch channel — and also each worker on the one channel wool opens
+# back to its own subprocess to drain it (roles are per-connection, not
+# per-process; see ``cfdb.workflows.credentials``).
 
 #: Path to the shared CA certificate the API verifies workers against
 #: (and that signed the API's own client certificate). Unset disables
@@ -97,6 +107,17 @@ CFDB_WORKER_TLS_CERT: Final = os.getenv("CFDB_WORKER_TLS_CERT")
 #: Path to the API's PEM client private key paired with
 #: ``CFDB_WORKER_TLS_CERT``.
 CFDB_WORKER_TLS_KEY: Final = os.getenv("CFDB_WORKER_TLS_KEY")
+
+#: Logical name the API verifies worker certificates against, in place
+#: of the address it dialed — workers answer on dynamic addresses (an
+#: awsvpc IP on ECS, a bridge IP in local containers) that no static SAN
+#: can enumerate. Defaults to the SAN ``certs/generate-worker-certs.sh``
+#: mints, so a freshly generated cert set needs no extra configuration.
+#: Set it to the empty string to verify against the dialed address
+#: instead. Ignored entirely while mTLS is off.
+CFDB_WORKER_TLS_IDENTITY: Final = os.getenv(
+    TLS_IDENTITY_ENV, DEFAULT_TLS_IDENTITY
+)
 
 # AWS / ECS profile. These knobs are optional — when none of them are
 # set the API runs the PoC profile (``LocalFsCache`` + ``LanDiscovery``

--- a/src/cfdb/api/main.py
+++ b/src/cfdb/api/main.py
@@ -315,10 +315,16 @@ async def lifespan(_: FastAPI):
             # the three cert-path env vars. None (all unset) keeps the
             # plaintext PoC path; a partial config raises here so a
             # half-wired channel can't silently fall back to plaintext.
+            #
+            # The identity makes the worker cert verifiable at all: every
+            # profile dials workers at addresses assigned at launch, so
+            # without it the handshake would check the cert against an
+            # awsvpc or bridge IP no static SAN can name.
             worker_credentials = build_worker_credentials(
                 api.CFDB_WORKER_TLS_CA,
                 api.CFDB_WORKER_TLS_CERT,
                 api.CFDB_WORKER_TLS_KEY,
+                identity=api.CFDB_WORKER_TLS_IDENTITY,
             )
 
             async with _build_discovery(profile) as discovery:
@@ -375,13 +381,26 @@ async def lifespan(_: FastAPI):
                     log.info(
                         "Workflow subsystem enabled: profile=%s cache=%s "
                         "workdir=%s discovery=%s provisioner=%s "
-                        "worker_mtls=%s",
+                        "worker_mtls=%s worker_tls_identity=%s",
                         profile.kind,
                         type(api.cache).__name__,
                         profile.workdir_root,
                         type(discovery).__name__,
                         "EcsProvisioner" if provisioner is not None else "none",
                         "enabled" if worker_credentials is not None else "disabled",
+                        # Records what the API will match a worker
+                        # certificate against, so a handshake rejected
+                        # for the wrong expected name is diagnosable
+                        # without shelling into a Fargate task. wool
+                        # itself logs the failure and its gRPC cause at
+                        # WARNING under ``wool.runtime.worker.proxy``;
+                        # this line says what was expected, not what
+                        # went wrong. Reported as n/a rather than as a
+                        # name when mTLS is off, since the setting has
+                        # no effect without credentials.
+                        (api.CFDB_WORKER_TLS_IDENTITY or "<address>")
+                        if worker_credentials is not None
+                        else "n/a",
                     )
                     # Stack each teardown step as an async callback so a
                     # failure earlier in the chain (e.g. ``drain`` raises

--- a/src/cfdb/workflows/constants.py
+++ b/src/cfdb/workflows/constants.py
@@ -16,6 +16,33 @@ from __future__ import annotations
 #: MUST match.
 DEFAULT_WORKER_PORT = 50051
 
+# ECS task tags through which a worker publishes the parts of its
+# ``wool.WorkerMetadata`` that only it can know. ``worker_main`` writes
+# them onto its own task; ``EcsDiscovery`` reads them back off the
+# ``DescribeTasks`` response. Both MUST agree on these keys — a
+# mismatch means every worker looks unpublished and none are ever
+# advertised (issue #90).
+#
+# Keys stay within the ECS tag charset (``[\p{L}\p{Z}\p{N}_.:/=+\-@]``)
+# and are namespaced under ``wool.`` so they do not collide with
+# cost-allocation or ownership tags applied to the same tasks.
+
+#: Wool protocol version the worker runs, from ``WorkerMetadata.version``.
+#: wool admits a worker only when the proxy's version is ``<=`` this and
+#: shares its major, so an absent or invented value rejects the worker.
+WORKER_TAG_VERSION = "wool.version"
+
+#: Whether the worker requires TLS, from ``WorkerMetadata.secure``,
+#: serialized as :data:`WORKER_TAG_TRUE` / ``"false"``. A proxy holding
+#: credentials admits only secure workers, and one without credentials
+#: admits only insecure ones — so this must reflect the worker's actual
+#: configuration rather than a default.
+WORKER_TAG_SECURE = "wool.secure"
+
+#: Canonical serialization of a true ``secure`` flag. Compared
+#: case-insensitively on read so a hand-applied tag still works.
+WORKER_TAG_TRUE = "true"
+
 # Worker mutual-TLS identity. These live here, rather than beside the
 # rest of the TLS configuration in ``cfdb.workflows.credentials``,
 # because ``cfdb.api`` needs the default too and importing

--- a/src/cfdb/workflows/constants.py
+++ b/src/cfdb/workflows/constants.py
@@ -15,3 +15,23 @@ from __future__ import annotations
 #: the ECS task definition's ``portMappings`` / ``healthCheck`` target
 #: MUST match.
 DEFAULT_WORKER_PORT = 50051
+
+# Worker mutual-TLS identity. These live here, rather than beside the
+# rest of the TLS configuration in ``cfdb.workflows.credentials``,
+# because ``cfdb.api`` needs the default too and importing
+# ``credentials`` would drag wool into the API's config module. Holding
+# one definition in a leaf module both sides can import is the whole
+# reason this module exists — a second hand-copied literal is exactly
+# the drift that produces an unexplainable NoWorkersAvailable.
+
+#: Env var naming the logical identity a client verifies a worker's
+#: certificate against, in place of the address it dialed.
+TLS_IDENTITY_ENV = "CFDB_WORKER_TLS_IDENTITY"
+
+#: Identity used when :data:`TLS_IDENTITY_ENV` is unset. Matches the SAN
+#: ``certs/generate-worker-certs.sh`` mints into the worker leaf, so a
+#: freshly generated cert set works with no further configuration. Set
+#: the env var to the empty string to fall back to address verification.
+#: ``cloudformation/backend.yml``'s ``WorkerTlsIdentity`` parameter
+#: defaults to the same value, and a test asserts they agree.
+DEFAULT_TLS_IDENTITY = "cfdb-worker"

--- a/src/cfdb/workflows/credentials.py
+++ b/src/cfdb/workflows/credentials.py
@@ -18,6 +18,34 @@ wool's mTLS is peer-to-peer: each process holds *its own* leaf cert and
 key (the worker's on workers, the API client's on the API) signed by a
 *shared* CA. So ``CFDB_WORKER_TLS_CERT`` / ``CFDB_WORKER_TLS_KEY`` name
 different files per process while ``CFDB_WORKER_TLS_CA`` is common.
+
+**Identity.** By default TLS verifies a server's certificate against the
+address the client dialed, which no static cert can satisfy here: on ECS
+``EcsDiscovery`` dials each worker at its dynamic awsvpc IP, and locally
+a containerized worker answers on whatever bridge address it was given.
+Setting an *identity* points the client at a fixed logical name instead
+(wool passes it as gRPC's ``ssl_target_name_override``), so the worker
+leaf carries one stable SAN rather than an enumeration of every address
+it might be reached at. Chain and SAN verification still both happen —
+only the name being matched changes.
+
+Identity is a property of the *dialing* side. That is not the same as
+saying it belongs to the API: the roles are properties of a connection,
+not of a process. The API is the client on the dispatch channel, and the
+worker is the server there — but ``wool.LocalWorker.stop`` opens one
+outbound channel of its own, to the worker's subprocess, to ask it to
+drain. On that connection the worker is the client, and it verifies its
+subprocess's certificate exactly the way the API verifies the worker's.
+
+So every process that holds credentials gets the identity, and it is
+simply inert wherever the credentials are used to serve rather than to
+dial. Withholding it from workers looks harmless — the shipped cert
+carries loopback SANs, so the stop RPC verifies by address and succeeds
+— but it breaks precisely the certificate this feature exists to enable:
+mint a leaf whose only SAN is the logical identity, as the runbook says
+to, and graceful drain fails its name check while dispatch keeps working.
+The failure is a killed worker instead of a drained one, which surfaces
+as lost in-flight work rather than as a TLS error.
 """
 
 from __future__ import annotations
@@ -25,15 +53,24 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Optional
+from typing import Union
 
 import wool
 
+# Re-exported so callers can keep importing the whole TLS vocabulary
+# from this module; they live in the wool-free constants module because
+# ``cfdb.api`` needs the default without importing wool.
+from cfdb.workflows.constants import DEFAULT_TLS_IDENTITY, TLS_IDENTITY_ENV
+
 __all__ = [
+    "DEFAULT_TLS_IDENTITY",
     "TLS_CA_ENV",
     "TLS_CERT_ENV",
+    "TLS_IDENTITY_ENV",
     "TLS_KEY_ENV",
+    "WorkerCredentialsLike",
     "build_worker_credentials",
-    "worker_credentials_from_env",
+    "identity_from_env",
 ]
 
 #: Env var naming the shared CA certificate every peer verifies against.
@@ -46,19 +83,40 @@ TLS_CERT_ENV = "CFDB_WORKER_TLS_CERT"
 #: Env var naming this process's PEM private key.
 TLS_KEY_ENV = "CFDB_WORKER_TLS_KEY"
 
+#: What :func:`build_worker_credentials` hands back: a provider when an
+#: identity applies, plain credentials otherwise, ``None`` for plaintext.
+WorkerCredentialsLike = Union[
+    wool.WorkerCredentials, wool.WorkerCredentialsProvider
+]
+
+
+def identity_from_env() -> Optional[str]:
+    """Resolve the configured identity, or ``None`` to verify by address.
+
+    Reads :data:`TLS_IDENTITY_ENV`, defaulting to
+    :data:`DEFAULT_TLS_IDENTITY`. An exported-but-empty value is the
+    documented opt-out and normalizes to ``None``, which
+    :func:`build_worker_credentials` treats as "verify against the
+    dialed address" — the pre-identity behaviour.
+    """
+    return os.getenv(TLS_IDENTITY_ENV, DEFAULT_TLS_IDENTITY) or None
+
 
 def build_worker_credentials(
     ca_path: Optional[str],
     cert_path: Optional[str],
     key_path: Optional[str],
     *,
+    identity: Optional[str] = None,
     mutual: bool = True,
-) -> Optional[wool.WorkerCredentials]:
-    """Build :class:`wool.WorkerCredentials` from cert paths, or ``None``.
+) -> Optional[WorkerCredentialsLike]:
+    """Build wool credentials from cert paths, or ``None``.
 
     Returns ``None`` when all three paths are unset (empty string is
     treated as unset) — the caller stays on the plaintext gRPC path so
-    local PoC dev without certs keeps working.
+    local PoC dev without certs keeps working. That holds regardless of
+    ``identity``: an identity alone never turns mTLS on, because there is
+    no certificate for it to constrain.
 
     Raises :class:`ValueError` when the configuration is *partial* (some
     paths set, some not): a half-configured channel is never intentional
@@ -72,6 +130,14 @@ def build_worker_credentials(
     When all three exist, returns the credentials from
     :meth:`wool.WorkerCredentials.from_files` with ``mutual`` (default
     ``True`` — both server and client authenticate, i.e. mTLS enforced).
+
+    When ``identity`` is also given, those credentials are adapted with
+    :meth:`wool.WorkerCredentials.as_provider` so the peer certificate is
+    verified against that logical name rather than the dialed address —
+    see the module docstring. ``identity`` is deliberately outside the
+    all-or-none check above: it refines a complete mTLS configuration
+    rather than forming a fourth required part of one, and omitting it
+    leaves verification exactly as it was.
     """
     # Normalize empty strings to None so an exported-but-empty env var
     # reads as "unset" rather than a path that fails the existence check.
@@ -103,27 +169,21 @@ def build_worker_credentials(
                 "not a file."
             )
 
-    return wool.WorkerCredentials.from_files(
+    credentials = wool.WorkerCredentials.from_files(
         ca_path=paths[TLS_CA_ENV],
         key_path=paths[TLS_KEY_ENV],
         cert_path=paths[TLS_CERT_ENV],
         mutual=mutual,
     )
+    if not identity:
+        return credentials
+    return credentials.as_provider(identity=identity)
 
 
-def worker_credentials_from_env(
-    *, mutual: bool = True
-) -> Optional[wool.WorkerCredentials]:
-    """Build credentials from the ``CFDB_WORKER_TLS_*`` env vars.
-
-    Convenience wrapper over :func:`build_worker_credentials` that reads
-    :data:`TLS_CA_ENV`, :data:`TLS_CERT_ENV`, and :data:`TLS_KEY_ENV`
-    from the process environment. Used by the worker entrypoints; the
-    API passes its own ``cfdb.api`` config constants in directly.
-    """
-    return build_worker_credentials(
-        os.getenv(TLS_CA_ENV),
-        os.getenv(TLS_CERT_ENV),
-        os.getenv(TLS_KEY_ENV),
-        mutual=mutual,
-    )
+# NOTE: there is deliberately no env-reading convenience wrapper here.
+# The entrypoints resolve their cert paths through click options (where
+# a CLI flag can override the env var) and call
+# ``build_worker_credentials(..., identity=identity_from_env())``
+# directly; a wrapper reading ``os.getenv`` would silently drop the
+# CLI override and duplicate a three-line composition. Tests pin the
+# ``identity=`` kwarg at each call site instead.

--- a/src/cfdb/workflows/discovery.py
+++ b/src/cfdb/workflows/discovery.py
@@ -7,23 +7,35 @@ than maintaining a parallel registry. ``EcsDiscovery`` implements Wool's
 
 1. ``ecs.list_tasks`` enumerates every task in the cluster matching the
    worker task family with ``desiredStatus="RUNNING"``.
-2. ``ecs.describe_tasks`` (batched 100 ARNs at a time) hydrates each
-   into its full state, including ``healthStatus`` and ``attachments``.
-3. We filter for ``lastStatus == "RUNNING"`` and (where reported)
-   ``healthStatus == "HEALTHY"`` — tasks whose container definition
-   omits a ``healthCheck`` are accepted as healthy so a deployment that
-   hasn't yet wired up health checks still surfaces workers.
+2. ``ecs.describe_tasks`` (batched 100 ARNs at a time, with
+   ``include=["TAGS"]``) hydrates each into its full state, including
+   ``healthStatus``, ``attachments``, and the tags the worker published.
+3. We filter for ``lastStatus == "RUNNING"``, ``healthStatus ==
+   "HEALTHY"``, and the presence of the worker's own published metadata.
 4. The poller diffs the resolved set against the previous one and
    publishes ``worker-added`` / ``worker-dropped`` events to a Wool
    ``DiscoveryPublisherLike``.
 
-The worker side does nothing for discovery — no heartbeat thread, no
-Mongo write, no registration RPC. ECS reports ``healthStatus: HEALTHY``
-once the container's health check passes, which is the "ready to
-dispatch" signal the discovery filters on. The worker task definition
-MUST declare a ``healthCheck`` against the gRPC port; without one
-ECS reports ``healthStatus: UNKNOWN`` indefinitely and the worker is
-never advertised.
+**Where the metadata comes from.** ECS can report an address and a
+health status; it cannot report what is running inside the container.
+Two fields of :class:`wool.WorkerMetadata` are knowable only to the
+worker process — the wool protocol version it runs and whether it
+configured TLS — and wool gates worker admission on both, so a value
+this module invented for them would be a value that silently rejects
+the whole fleet (issue #90). The worker therefore publishes what it
+knows: it tags its own ECS task with the metadata wool authored for it
+(see :mod:`cfdb.workflows.worker_main`), and this poller reads those
+tags back off the task it is already describing. ECS supplies liveness;
+the worker supplies identity.
+
+A consequence worth stating: a task can be ``RUNNING`` and ``HEALTHY``
+for a moment before its tags land. Such a task is deliberately **not**
+advertised — "hasn't published yet" is not the same as "has default
+metadata", and conflating them is the bug this arrangement fixes.
+
+The worker task definition MUST declare a ``healthCheck`` against the
+gRPC port; without one ECS reports ``healthStatus: UNKNOWN``
+indefinitely and the worker is never advertised.
 """
 
 from __future__ import annotations
@@ -44,7 +56,13 @@ from wool.runtime.discovery.base import (
     WorkerMetadata,
 )
 
-from cfdb.workflows.constants import DEFAULT_WORKER_PORT
+from cfdb.workflows.constants import (
+    DEFAULT_WORKER_PORT,
+    WORKER_TAG_SECURE,
+    WORKER_TAG_TRUE,
+    WORKER_TAG_VERSION,
+)
+from cfdb.workflows.grpc_options import worker_grpc_options
 from cfdb.workflows.provisioner import build_ecs_client
 
 logger = logging.getLogger(__name__)
@@ -57,6 +75,11 @@ _DESCRIBE_BATCH_SIZE = 100
 #: page "Rate of cluster resource read API calls"). 5s leaves ample
 #: headroom for many concurrent clusters.
 DEFAULT_POLL_INTERVAL_SECONDS = 5.0
+
+#: Minimum spacing between "tasks exist but none advertisable"
+#: warnings, so a persistently unpublished fleet logs once a minute
+#: rather than once per 5 s poll.
+_UNRESOLVED_WARNING_INTERVAL_S = 60.0
 
 
 class EcsDiscovery(Discovery):
@@ -77,8 +100,12 @@ class EcsDiscovery(Discovery):
         worker_port: gRPC port the worker binds — used to construct
             the address string passed to Wool. Shares the worker_main
             default so a deployment that changes one changes both.
-        version: Wool worker version string passed through into
-            ``WorkerMetadata``. Free-form; useful for filtering.
+
+    There is deliberately no ``version`` parameter. It existed, defaulted
+    to ``"0"``, and was passed straight into ``WorkerMetadata`` — where
+    wool reads it as the protocol version and rejects any worker failing
+    ``client <= server``, which ``"0"`` always does. The version now comes
+    from the task tag the worker publishes; see the module docstring.
 
     Lifecycle: enter ``async with EcsDiscovery(...)`` to start the
     background poller. Exiting the context cancels the poller and
@@ -95,7 +122,6 @@ class EcsDiscovery(Discovery):
         region_name: Optional[str] = None,
         poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
         worker_port: int = DEFAULT_WORKER_PORT,
-        version: str = "0",
     ) -> None:
         if not cluster:
             raise ValueError("EcsDiscovery requires a cluster name")
@@ -123,10 +149,26 @@ class EcsDiscovery(Discovery):
         )
         self._poll_interval = poll_interval
         self._worker_port = worker_port
-        self._version = version
 
         self._subscribers: list[_EcsSubscriber] = []
         self._known: dict[str, WorkerMetadata] = {}
+        #: Last successfully-read metadata tags per worker uid (hex),
+        #: as ``(version, secure)``. ECS resource tags are read through
+        #: a secondary ``include=["TAGS"]`` lookup that is not
+        #: documented as strongly consistent, so a single describe
+        #: response can transiently omit tags a task has already
+        #: published. Falling back to the last-known values keeps an
+        #: already-advertised worker in the pool — mirroring this
+        #: module's retain-on-transient-failure posture for the
+        #: list/describe calls themselves — while "never seen
+        #: published" remains unadvertised (see ``_task_to_metadata``).
+        #: Pruned alongside ``_known`` so entries age out with the task.
+        self._published: dict[str, tuple[str, bool]] = {}
+        #: Monotonic timestamp of the last none-resolved warning, so a
+        #: persistently unpublished fleet logs once a minute rather
+        #: than once per poll. ``-inf`` fires the first warning
+        #: immediately.
+        self._last_unresolved_warning = float("-inf")
         self._poll_task: Optional[asyncio.Task[None]] = None
         #: Guards ``_subscribers`` / ``_known`` / ``_closed`` and the
         #: sentinel-push fan-out during ``__aexit__``. Held only
@@ -180,6 +222,7 @@ class EcsDiscovery(Discovery):
             "_poll_task",
             "_subscribers",
             "_known",
+            "_published",
             "_closed",
         ):
             state.pop(transient, None)
@@ -212,6 +255,7 @@ class EcsDiscovery(Discovery):
             )
         self._subscribers = []
         self._known = {}
+        self._published = {}
         self._poll_task = None
         self._closed = False
         self._state_lock = asyncio.Lock()
@@ -350,6 +394,32 @@ class EcsDiscovery(Discovery):
                     metadata = self._task_to_metadata(task)
                     if metadata is not None:
                         resolved[str(metadata.uid)] = metadata
+                if tasks and not resolved:
+                    # Tasks exist but none is advertisable. Individually
+                    # each cause is deliberate silence (unhealthy tasks
+                    # are visible in the ECS console, unpublished ones
+                    # are a startup window) — but a *fleet-wide* zero is
+                    # the signature of a systemic failure the console
+                    # does not show: an old worker image, a missing
+                    # ecs:TagResource grant, a tag-key rename on one
+                    # side. Warn (rate-limited) so the incident is a
+                    # grep instead of a bisect; the API-side symptom is
+                    # otherwise just NoWorkersAvailable.
+                    now = asyncio.get_running_loop().time()
+                    if (
+                        now - self._last_unresolved_warning
+                        >= _UNRESOLVED_WARNING_INTERVAL_S
+                    ):
+                        self._last_unresolved_warning = now
+                        logger.warning(
+                            "EcsDiscovery: %d task(s) in cluster=%s but none "
+                            "advertisable (not RUNNING+HEALTHY, or metadata "
+                            "tags never published). If this persists, check "
+                            "the worker task logs and the ecs:TagResource "
+                            "grant.",
+                            len(tasks),
+                            self._cluster,
+                        )
 
             # Diff, mutate, and dispatch under ``self._state_lock`` so a
             # concurrent ``_register_subscriber`` cannot replay a
@@ -363,6 +433,16 @@ class EcsDiscovery(Discovery):
             async with self._state_lock:
                 events = list(_diff(self._known, resolved))
                 self._known = resolved
+                # Age the sticky metadata cache out with the fleet: a
+                # uid absent from this cycle's resolved set is a task
+                # that is gone (or fell unhealthy), not one suffering a
+                # transient tag miss — those were just resolved *via*
+                # the cache and so appear in ``resolved``.
+                self._published = {
+                    uid: published
+                    for uid, published in self._published.items()
+                    if uid in resolved
+                }
                 if events:
                     for sub in self._subscribers:
                         for event in events:
@@ -416,13 +496,19 @@ class EcsDiscovery(Discovery):
         return arns
 
     def _describe_tasks_batched(self, arns: list[str]) -> list[dict[str, Any]]:
-        """Call ``DescribeTasks`` in batches of ``_DESCRIBE_BATCH_SIZE``."""
+        """Call ``DescribeTasks`` in batches of ``_DESCRIBE_BATCH_SIZE``.
+
+        ``include=["TAGS"]`` is required: without it ECS omits ``tags``
+        from the response entirely, every task reads as unpublished, and
+        no worker is ever advertised.
+        """
         out: list[dict[str, Any]] = []
         for i in range(0, len(arns), _DESCRIBE_BATCH_SIZE):
             batch = arns[i : i + _DESCRIBE_BATCH_SIZE]
             response = self._client.describe_tasks(
                 cluster=self._cluster,
                 tasks=batch,
+                include=["TAGS"],
             )
             out.extend(response.get("tasks") or [])
         return out
@@ -430,13 +516,18 @@ class EcsDiscovery(Discovery):
     def _task_to_metadata(self, task: dict[str, Any]) -> Optional[WorkerMetadata]:
         """Convert an ECS task description to a Wool ``WorkerMetadata``.
 
-        Returns None when the task is not RUNNING + HEALTHY or we
-        cannot extract a usable IP address. Worker task definitions
-        MUST declare a ``healthCheck``; tasks without one surface as
+        Returns None when the task is not RUNNING + HEALTHY, when we
+        cannot extract a usable IP address, or when the worker has not
+        yet published its metadata tags. Worker task definitions MUST
+        declare a ``healthCheck``; tasks without one surface as
         ``healthStatus: UNKNOWN`` and are filtered out, since their
         gRPC readiness is unknowable. Tasks whose ``healthStatus`` is
         absent from the describe-tasks response are also filtered —
         same reason.
+
+        The version and secure flag come from the task's tags rather
+        than from anything this module knows, because only the worker
+        process knows them; see the module docstring.
         """
         if task.get("lastStatus") != "RUNNING":
             return None
@@ -461,12 +552,49 @@ class EcsDiscovery(Discovery):
             uid = uuid.UUID(task_id)
         except (ValueError, AttributeError):
             uid = uuid.uuid5(uuid.NAMESPACE_URL, task_arn)
+        uid_key = str(uid)
+
+        tags = _extract_tags(task)
+        version = tags.get(WORKER_TAG_VERSION)
+        if version:
+            secure = (
+                tags.get(WORKER_TAG_SECURE, "").strip().lower() == WORKER_TAG_TRUE
+            )
+            self._published[uid_key] = (version, secure)
+        elif uid_key in self._published:
+            # This task has published before, so an absent tag here is a
+            # transient of the ``include=["TAGS"]`` secondary lookup —
+            # not the pre-publish window. Fall back to the last-read
+            # values instead of flapping an already-advertised worker
+            # out of the pool (metadata is written once at startup and
+            # never changes, so the cache cannot go stale).
+            version, secure = self._published[uid_key]
+        else:
+            # Healthy but not yet published — the window between the
+            # container passing its health check and its TagResource
+            # call landing. Advertising it now would mean advertising
+            # metadata we invented, which is precisely what wool's
+            # admission gate then rejects.
+            return None
 
         return WorkerMetadata(
             uid=uid,
             address=f"{ip}:{self._worker_port}",
+            # The worker's real pid is meaningless to the API — it names
+            # a process in another container — and nothing reads it, so
+            # it is left at 0 rather than published. ``version`` and
+            # ``secure`` are different: wool gates admission on both.
             pid=0,
-            version=self._version,
+            version=version,
+            secure=secure,
+            # Channel options are the third worker-authored field, but
+            # unlike version/secure they need no tag: the API and the
+            # worker ship from the same image tag and import the same
+            # module, so one shared definition keeps the dispatch
+            # channel's keepalive cadence (see grpc_options) in
+            # lockstep without serializing a rich object into a
+            # 256-char tag value.
+            options=worker_grpc_options().channel,
         )
 
     async def _register_subscriber(self, sub: "_EcsSubscriber") -> None:
@@ -668,6 +796,25 @@ class _RaisingPublisher:
         raise RuntimeError(
             "EcsDiscovery is read-only — workers register implicitly via ECS"
         )
+
+
+def _extract_tags(task: dict[str, Any]) -> dict[str, str]:
+    """Flatten a task's ``tags`` list into a ``{key: value}`` mapping.
+
+    ECS returns tags as ``[{"key": ..., "value": ...}, ...]``, and omits
+    the field entirely both when the task has no tags and when
+    ``DescribeTasks`` was called without ``include=["TAGS"]``. Entries
+    missing a key are skipped rather than raising — a malformed tag
+    should cost one worker, not the whole poll cycle.
+    """
+    tags: dict[str, str] = {}
+    for tag in task.get("tags") or ():
+        if not isinstance(tag, dict):
+            continue
+        key = tag.get("key")
+        if key:
+            tags[key] = tag.get("value") or ""
+    return tags
 
 
 def _extract_eni_ip(task: dict[str, Any]) -> Optional[str]:

--- a/src/cfdb/workflows/worker_lan.py
+++ b/src/cfdb/workflows/worker_lan.py
@@ -47,7 +47,7 @@ from wool.runtime.discovery.lan import LanDiscovery
 
 from cfdb.workflows import WORKER_MAX_CONCURRENT_TASKS
 from cfdb.workflows.backpressure import backpressure_for
-from cfdb.workflows.credentials import build_worker_credentials
+from cfdb.workflows.credentials import build_worker_credentials, identity_from_env
 from cfdb.workflows.grpc_options import worker_grpc_options
 
 logger = logging.getLogger(__name__)
@@ -85,8 +85,14 @@ async def serve(
     plaintext. The API leasing these workers must hold a certificate
     signed by the same CA. Partial cert config raises before the pool
     starts (see :func:`build_worker_credentials`).
+
+    The identity comes from the environment rather than a flag because
+    it is inert on the serving side — it applies only to the channels
+    wool opens back to the pool's own workers to drain them.
     """
-    credentials = build_worker_credentials(tls_ca, tls_cert, tls_key)
+    credentials = build_worker_credentials(
+        tls_ca, tls_cert, tls_key, identity=identity_from_env()
+    )
     stop_event = asyncio.Event()
     loop = asyncio.get_running_loop()
 

--- a/src/cfdb/workflows/worker_main.py
+++ b/src/cfdb/workflows/worker_main.py
@@ -6,9 +6,21 @@ the ECS health check probes, handles SIGTERM cleanly so ``ecs.stop_task``
 cycles drain in-flight work, and self-terminates after a configurable
 maximum lifetime so workers don't accumulate when the dispatch rate falls.
 
-No discovery registration code lives here. ``EcsDiscovery`` polls ECS's
-own task state to surface running workers; the worker only needs to
-bind its gRPC port and respond ``200 OK`` to the health probe.
+ECS owns the worker *lifecycle* — registration, IP, status, health — and
+``EcsDiscovery`` polls it for all of that. But two fields of the wool
+``WorkerMetadata`` the API needs are knowable only in here: the wool
+protocol version this process runs, and whether it configured TLS. wool
+gates worker admission on both, so a value the API invented for them is
+a value that silently rejects the whole fleet (issue #90). After the
+worker starts, this module therefore publishes what wool authored for it
+(``LocalWorker.metadata``) onto its own ECS task as tags, which
+``EcsDiscovery`` reads back. ECS supplies liveness; the worker supplies
+identity.
+
+Publishing is skipped outside ECS — ``ECS_CONTAINER_METADATA_URI_V4``
+is injected only into Fargate tasks — so running this module locally is
+unaffected, and the LAN path (:mod:`cfdb.workflows.worker_lan`) uses
+wool's own publisher instead.
 
 Environment variables (single source of truth; CLI flags mirror them):
 
@@ -22,12 +34,17 @@ Environment variables (single source of truth; CLI flags mirror them):
 * ``CFDB_WORKER_DRAIN_GRACE_SECONDS`` — how long ``/health`` returns
   503 after SIGTERM before tearing down the gRPC port. A second
   SIGTERM short-circuits.
+* ``CFDB_WORKER_PUBLISH_ATTEMPTS`` — attempts to publish metadata
+  before giving up and exiting (default 5).
+* ``CFDB_WORKER_PUBLISH_BACKOFF_SECONDS`` — base of the exponential
+  backoff between publish attempts (default 0.5).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import signal
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Optional
@@ -37,9 +54,15 @@ import wool
 
 from cfdb.workflows import WORKER_MAX_CONCURRENT_TASKS
 from cfdb.workflows.backpressure import backpressure_for
-from cfdb.workflows.constants import DEFAULT_WORKER_PORT
-from cfdb.workflows.credentials import build_worker_credentials
+from cfdb.workflows.constants import (
+    DEFAULT_WORKER_PORT,
+    WORKER_TAG_SECURE,
+    WORKER_TAG_TRUE,
+    WORKER_TAG_VERSION,
+)
+from cfdb.workflows.credentials import build_worker_credentials, identity_from_env
 from cfdb.workflows.grpc_options import worker_grpc_options
+from cfdb.workflows.provisioner import _is_retryable_error, build_ecs_client
 
 if TYPE_CHECKING:
     from aiohttp import web
@@ -81,6 +104,229 @@ DEFAULT_DRAIN_GRACE_SECONDS = 120.0
 #: (SIGTERM-on-stop_task, ~hours-scale max-lifetime) don't need it.
 _STOP_POLL_INTERVAL_SECONDS = 1.0
 
+#: Env var ECS injects into every Fargate task (platform 1.4.0+). Its
+#: absence is how this module tells "running on ECS" from "running on a
+#: laptop", and it is the only signal needed — no profile flag.
+_ECS_METADATA_URI_ENV = "ECS_CONTAINER_METADATA_URI_V4"
+
+#: Default attempts to publish metadata before giving up. ``TagResource``
+#: shares the ECS API's account-wide rate limit, and the task metadata
+#: endpoint is busiest during exactly the cold-start burst that spawns
+#: workers — so a burst of simultaneous starts can throttle a few;
+#: retrying costs a few seconds and saves a task that would otherwise be
+#: discarded. Overridable via ``CFDB_WORKER_PUBLISH_ATTEMPTS``.
+DEFAULT_PUBLISH_ATTEMPTS = 5
+
+#: Default base of the exponential backoff between publish attempts, in
+#: seconds. Overridable via ``CFDB_WORKER_PUBLISH_BACKOFF_SECONDS``.
+DEFAULT_PUBLISH_BACKOFF_SECONDS = 0.5
+
+#: How long to wait on the task metadata endpoint. It is a link-local
+#: HTTP server in the same task, so a slow response means something is
+#: wrong rather than merely busy.
+_METADATA_TIMEOUT_SECONDS = 5.0
+
+
+async def _task_arn() -> Optional[str]:
+    """Return this task's ARN from the ECS metadata endpoint, or None.
+
+    None means the worker is not running on ECS, which is the normal
+    case for local development. A malformed or unreachable endpoint
+    while the env var *is* set raises instead — that is a broken task,
+    not a laptop.
+    """
+    base = os.getenv(_ECS_METADATA_URI_ENV)
+    if not base:
+        return None
+
+    from aiohttp import ClientSession, ClientTimeout
+
+    timeout = ClientTimeout(total=_METADATA_TIMEOUT_SECONDS)
+    async with ClientSession(timeout=timeout) as session:
+        async with session.get(f"{base.rstrip('/')}/task") as response:
+            response.raise_for_status()
+            # The endpoint serves application/json but has historically
+            # been served with a text content type; don't let aiohttp's
+            # content-type check reject a valid body.
+            payload = await response.json(content_type=None)
+
+    arn = payload.get("TaskARN")
+    if not arn:
+        raise RuntimeError(
+            "ECS task metadata endpoint returned no TaskARN; cannot "
+            "publish worker metadata"
+        )
+    return arn
+
+
+def _region_from_arn(arn: str) -> Optional[str]:
+    """Return the region segment of an ECS task ARN, or None.
+
+    ``arn:aws:ecs:us-east-2:...:task/<cluster>/<id>`` — the fourth
+    colon-delimited field. Used as the region fallback when
+    ``AWS_REGION`` is unset in the environment: the ARN names the
+    region the task actually runs in, so it cannot drift from the
+    resource being tagged, and it makes publishing independent of the
+    task definition's env block (see the readiness discussion in
+    ``_publish_worker_metadata``).
+    """
+    parts = arn.split(":")
+    if len(parts) > 4 and parts[3]:
+        return parts[3]
+    return None
+
+
+def _is_access_denied(exc: BaseException) -> bool:
+    """Return True when an ECS error is an authorization failure."""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = (response.get("Error") or {}).get("Code")
+        return code in ("AccessDeniedException", "AccessDenied")
+    return False
+
+
+def _is_retryable_publish_error(exc: BaseException) -> bool:
+    """Return True when a publish failure is worth another attempt.
+
+    The publish path crosses two boundaries with distinct failure
+    vocabularies: the link-local task metadata endpoint (aiohttp
+    errors, timeouts — throttled or busy during a cold-start burst)
+    and the ECS control plane (botocore errors, classified by the
+    provisioner's shared :func:`_is_retryable_error`). Authorization
+    failures are permanent by definition and are excluded so a missing
+    ``ecs:TagResource`` grant fails in one attempt with a message
+    naming the fix, rather than after the full backoff budget.
+    """
+    if _is_access_denied(exc):
+        return False
+    from aiohttp import ClientError
+
+    if isinstance(exc, (ClientError, asyncio.TimeoutError)):
+        return True
+    return _is_retryable_error(exc)
+
+
+async def _publish_worker_metadata(
+    worker: "wool.LocalWorker",
+    *,
+    stop_event: Optional[asyncio.Event] = None,
+    attempts: int = DEFAULT_PUBLISH_ATTEMPTS,
+    backoff_seconds: float = DEFAULT_PUBLISH_BACKOFF_SECONDS,
+) -> None:
+    """Publish this worker's wool metadata onto its own ECS task tags.
+
+    ``EcsDiscovery`` reads these back to build the ``WorkerMetadata`` it
+    advertises. Only the fields it cannot otherwise know are published:
+    the wool protocol version and the TLS flag, both of which wool's
+    admission gate tests (see the module docstring).
+
+    Returns without doing anything when not running on ECS, and returns
+    early (without publishing) when ``stop_event`` is set mid-retry —
+    the worker is exiting anyway, so becoming discoverable would only
+    invite a dispatch it cannot honor.
+
+    Every step that can fail transiently — the task-metadata fetch, the
+    client construction, and the ``TagResource`` call — sits inside the
+    retry loop, because all three share the same burst profile: a fleet
+    cold start is exactly when the metadata endpoint and the ECS API
+    are busiest. The region falls back to the task ARN's own region
+    segment when ``AWS_REGION`` is unset, so publishing works even if
+    the task definition's env block loses the variable.
+
+    Raises when the metadata cannot be published within ``attempts``
+    tries, or immediately on a permanent error (an ``AccessDenied``
+    from a missing ``ecs:TagResource`` grant). That is deliberate: a
+    worker whose metadata never lands is invisible to the API forever,
+    so it would hold a Fargate slot and count against
+    ``ECS_MAX_WORKERS`` while being incapable of receiving work.
+    Exiting frees both immediately and the provisioner launches a
+    replacement on the next dispatch; standalone ``RunTask`` tasks are
+    not restarted, so there is no crash-loop.
+    """
+    if not os.getenv(_ECS_METADATA_URI_ENV):
+        logger.debug(
+            "%s unset — not running on ECS, skipping metadata publish",
+            _ECS_METADATA_URI_ENV,
+        )
+        return
+
+    metadata = worker.metadata
+    if metadata is None:  # pragma: no cover — start() precedes this call
+        raise RuntimeError("Worker has no metadata; publish called before start")
+
+    tags = [
+        {"key": WORKER_TAG_VERSION, "value": metadata.version},
+        {
+            "key": WORKER_TAG_SECURE,
+            "value": WORKER_TAG_TRUE if metadata.secure else "false",
+        },
+    ]
+
+    arn: Optional[str] = None
+    for attempt in range(1, attempts + 1):
+        try:
+            arn = await _task_arn()
+            assert arn is not None  # env var is set, so _task_arn cannot skip
+            client = build_ecs_client(
+                endpoint_url=os.getenv("AWS_ENDPOINT_URL"),
+                region_name=os.getenv("AWS_REGION") or _region_from_arn(arn),
+            )
+            # boto3 is synchronous; keep it off the event loop so the
+            # health server stays responsive while we retry.
+            await asyncio.to_thread(client.tag_resource, resourceArn=arn, tags=tags)
+        except Exception as exc:
+            if _is_access_denied(exc):
+                logger.error(
+                    "ecs:TagResource denied while publishing worker metadata "
+                    "to %s — the worker task role is missing the grant the "
+                    "workers stack (cloudformation/workers.yml) provides. "
+                    "Deploy the workers stack before shipping this image; "
+                    "this worker can never be discovered, exiting: %s",
+                    arn,
+                    exc,
+                )
+                raise
+            if attempt == attempts or not _is_retryable_publish_error(exc):
+                logger.error(
+                    "Failed to publish worker metadata to %s after %d attempt(s); "
+                    "this worker can never be discovered, exiting: %s",
+                    arn,
+                    attempt,
+                    exc,
+                )
+                raise
+            delay = backoff_seconds * (2 ** (attempt - 1))
+            logger.warning(
+                "Publishing worker metadata to %s failed (attempt %d/%d), "
+                "retrying in %.1fs: %s",
+                arn,
+                attempt,
+                attempts,
+                delay,
+                exc,
+            )
+            if stop_event is not None:
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=delay)
+                except asyncio.TimeoutError:
+                    pass
+                if stop_event.is_set():
+                    logger.info(
+                        "Stop requested during metadata publish — abandoning "
+                        "publish and shutting down"
+                    )
+                    return
+            else:
+                await asyncio.sleep(delay)
+        else:
+            logger.info(
+                "Published worker metadata to %s (version %s, secure %s)",
+                arn,
+                metadata.version,
+                metadata.secure,
+            )
+            return
+
 
 async def serve(
     *,
@@ -91,6 +337,8 @@ async def serve(
     tls_ca: Optional[str] = None,
     tls_cert: Optional[str] = None,
     tls_key: Optional[str] = None,
+    publish_attempts: int = DEFAULT_PUBLISH_ATTEMPTS,
+    publish_backoff_seconds: float = DEFAULT_PUBLISH_BACKOFF_SECONDS,
 ) -> int:
     """Run the worker until SIGTERM or maximum lifetime elapses.
 
@@ -108,8 +356,20 @@ async def serve(
     worker requires mutual TLS (a CA-signed client certificate);
     unset leaves the gRPC channel plaintext. Partial cert config raises
     before the worker binds (see :func:`build_worker_credentials`).
+
+    The identity comes from the environment rather than a flag because
+    it is inert on the serving side — it applies only to the one channel
+    wool opens back to this worker's subprocess to drain it.
+
+    ``publish_attempts`` and ``publish_backoff_seconds`` bound the
+    metadata-publish retry loop (see ``_publish_worker_metadata``);
+    they are exposed here — like every other operational knob in this
+    module — so tests and operators configure the budget through the
+    public surface rather than by patching module state.
     """
-    credentials = build_worker_credentials(tls_ca, tls_cert, tls_key)
+    credentials = build_worker_credentials(
+        tls_ca, tls_cert, tls_key, identity=identity_from_env()
+    )
     stop_event = asyncio.Event()
     force_stop_event = asyncio.Event()
     loop = asyncio.get_running_loop()
@@ -157,6 +417,18 @@ async def serve(
     )
     await worker.start()
     try:
+        # Publish before entering the serve loop. The worker is already
+        # accepting gRPC by now, but until its tags land EcsDiscovery
+        # deliberately will not advertise it, so there is no window in
+        # which the API dispatches to a worker whose metadata is unknown.
+        # stop_event lets a SIGTERM landing mid-retry short-circuit the
+        # backoff and proceed straight to drain.
+        await _publish_worker_metadata(
+            worker,
+            stop_event=stop_event,
+            attempts=publish_attempts,
+            backoff_seconds=publish_backoff_seconds,
+        )
         logger.info(
             "Wool worker listening on port %d (health on %d, mTLS %s, "
             "max concurrent tasks %s)",
@@ -328,6 +600,22 @@ async def _shutdown_health_server(runner: Optional["web.AppRunner"]) -> None:
     default=None,
     help="Path to this worker's PEM private key.",
 )
+@click.option(
+    "--publish-attempts",
+    type=click.IntRange(min=1),
+    envvar="CFDB_WORKER_PUBLISH_ATTEMPTS",
+    default=DEFAULT_PUBLISH_ATTEMPTS,
+    show_default=True,
+    help="Attempts to publish worker metadata before exiting.",
+)
+@click.option(
+    "--publish-backoff-seconds",
+    type=click.FloatRange(min=0),
+    envvar="CFDB_WORKER_PUBLISH_BACKOFF_SECONDS",
+    default=DEFAULT_PUBLISH_BACKOFF_SECONDS,
+    show_default=True,
+    help="Base of the exponential backoff between publish attempts.",
+)
 def main(
     worker_port: int,
     health_port: int,
@@ -336,6 +624,8 @@ def main(
     tls_ca: Optional[str],
     tls_cert: Optional[str],
     tls_key: Optional[str],
+    publish_attempts: int,
+    publish_backoff_seconds: float,
 ) -> None:
     """ECS Fargate worker entrypoint — invoked by the container CMD.
 
@@ -355,6 +645,8 @@ def main(
                 tls_ca=tls_ca,
                 tls_cert=tls_cert,
                 tls_key=tls_key,
+                publish_attempts=publish_attempts,
+                publish_backoff_seconds=publish_backoff_seconds,
             )
         )
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,13 @@ Function scope:
     real ``LocalFsCache`` and the real BAM / tabix processors, keyed on
     a tmp cache root per test so state does not leak between tests.
 
+  - ``worker_certs`` — a CA plus the worker and API leaves the wool
+    mutual-TLS tests mint. Shared here rather than per-module because
+    the *shape* of that material is load-bearing (the worker leaf's
+    sole SAN is the logical identity; the API leaf has none), and two
+    hand-copied minters are how two tests start disagreeing about what
+    a worker certificate is.
+
 Scenario model:
   - The ``Scenario`` dataclass + ``Format``/``Endpoint``/``Method``/...
     enums encode the cross-dimension axes that integration tests sweep
@@ -28,6 +35,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import datetime
 import http.server
 import os
 import shutil
@@ -42,6 +50,10 @@ from typing import Any
 import pytest
 import pytest_asyncio
 import wool
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
 # Permit ``http://127.0.0.1`` access from workers — the integration
 # suite serves sample fixtures over an in-process HTTP server because
@@ -623,3 +635,128 @@ def make_file_meta(
     if extra_files is not None:
         meta["extra"] = {"extra_files": list(extra_files)}
     return meta
+
+
+# ---------------------------------------------------------------------------
+# Worker mutual-TLS material.
+#
+# Shared across the mTLS integration modules because the *shape* of this
+# material is what those tests assert on: the worker leaf's only SAN is
+# the logical identity (so it is unverifiable by address, which is what
+# makes an identity-carried handshake provable), and the API leaf has no
+# SAN at all and clientAuth only (so a worker authenticating its client
+# by chain alone is exercised, and the API's certificate cannot
+# terminate a server side). A second hand-copied minter is how two test
+# modules start disagreeing about what a worker certificate is.
+# ---------------------------------------------------------------------------
+
+
+def _generate_key() -> rsa.RSAPrivateKey:
+    # 2048 rather than the 4096 the shipped script uses: these certs live
+    # for one test, and key generation dominates its runtime.
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _common_name(value: str) -> x509.Name:
+    return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, value)])
+
+
+def _sign(subject, subject_key, issuer, issuer_key, *, sans=None, eku=None, ca=False):
+    """Mint a certificate, self-signed when issuer and subject coincide."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(subject_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=ca, path_length=None), critical=True)
+    )
+    if sans is not None:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(sans), critical=False
+        )
+    if eku is not None:
+        builder = builder.add_extension(x509.ExtendedKeyUsage(eku), critical=False)
+    return builder.sign(issuer_key, hashes.SHA256())
+
+
+def _write(path, data: bytes) -> str:
+    path.write_bytes(data)
+    return str(path)
+
+
+def _write_leaf(tmp_path, stem, ca_name, ca_key, *, common_name, sans, eku):
+    """Mint a CA-signed leaf and return its ``(cert_path, key_path)``."""
+    key = _generate_key()
+    cert = _sign(_common_name(common_name), key, ca_name, ca_key, sans=sans, eku=eku)
+    return (
+        _write(
+            tmp_path / f"{stem}-cert.pem",
+            cert.public_bytes(serialization.Encoding.PEM),
+        ),
+        _write(
+            tmp_path / f"{stem}-key.pem",
+            key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def worker_certs(tmp_path):
+    """Mint a CA plus the separate worker and API leaves it signs.
+
+    Returns ``(ca_path, worker_cert, worker_key, api_cert, api_key)``,
+    mirroring the deployed arrangement where each process holds its own
+    leaf and only the CA is shared.
+
+    The worker leaf's sole SAN is the logical identity — no
+    ``localhost``, no ``127.0.0.1`` — so it is unverifiable by address.
+    The API leaf gets none at all, which is the point: a worker
+    authenticates its client by chain, with no name check.
+
+    The extended key usages mirror what ``certs/generate-worker-certs.sh``
+    mints, so these tests fail if a ``clientAuth``-only API leaf turns
+    out not to work as a client. Withholding ``serverAuth`` from the API
+    is what stops its certificate doubling as a worker's.
+    """
+    from cfdb.workflows.credentials import DEFAULT_TLS_IDENTITY
+
+    ca_key = _generate_key()
+    ca_name = _common_name("cfdb-worker-ca")
+    ca_cert = _sign(ca_name, ca_key, ca_name, ca_key, ca=True)
+
+    worker_cert, worker_key = _write_leaf(
+        tmp_path,
+        "worker",
+        ca_name,
+        ca_key,
+        common_name="cfdb-worker",
+        sans=[x509.DNSName(DEFAULT_TLS_IDENTITY)],
+        # serverAuth to terminate dispatch; clientAuth because wool's
+        # graceful-stop RPC dials the worker's own subprocess.
+        eku=[ExtendedKeyUsageOID.SERVER_AUTH, ExtendedKeyUsageOID.CLIENT_AUTH],
+    )
+    api_cert, api_key = _write_leaf(
+        tmp_path,
+        "api",
+        ca_name,
+        ca_key,
+        common_name="cfdb-api",
+        sans=None,
+        eku=[ExtendedKeyUsageOID.CLIENT_AUTH],
+    )
+
+    return (
+        _write(tmp_path / "ca.pem", ca_cert.public_bytes(serialization.Encoding.PEM)),
+        worker_cert,
+        worker_key,
+        api_cert,
+        api_key,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,8 @@ Function scope:
     sole SAN is the logical identity; the API leaf has none), and two
     hand-copied minters are how two tests start disagreeing about what
     a worker certificate is.
+  - ``offline_aws_env`` — environment that lets a wool worker
+    subprocess construct a boto3 client without reaching AWS.
 
 Scenario model:
   - The ``Scenario`` dataclass + ``Format``/``Endpoint``/``Method``/...
@@ -759,4 +761,32 @@ def worker_certs(tmp_path):
         worker_key,
         api_cert,
         api_key,
+    )
+
+
+@pytest.fixture
+def offline_aws_env(monkeypatch, tmp_path):
+    """Let a wool worker subprocess build a boto3 client without AWS.
+
+    Dispatch cloudpickles the proxy into the worker, so an
+    ``EcsDiscovery`` riding along has its ``__setstate__`` rebuild a
+    real boto3 ECS client *inside the worker* — even though nothing
+    there ever calls it. Without resolvable credentials botocore's
+    chain falls through to the login provider and raises
+    ``MissingDependencyException`` (this venv carries no
+    ``botocore[crt]``); with a developer's ``AWS_PROFILE`` exported it
+    raises ``ProfileNotFound``. Both surface as a failed dispatch,
+    indistinguishable from an mTLS fault — hence the belt-and-braces.
+
+    MUST be set before the worker spawns: the subprocess inherits
+    ``os.environ`` at spawn time.
+    """
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "absent-aws-config"))
+    monkeypatch.setenv(
+        "AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "absent-aws-credentials")
     )

--- a/tests/integration/routines.py
+++ b/tests/integration/routines.py
@@ -20,6 +20,8 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, Final
 
+import wool
+
 from cfdb.workflows.cache import CacheBackend
 from cfdb.workflows.events import Complete, StageComplete, WorkflowEvent
 from cfdb.workflows.models import ArtifactKind
@@ -100,6 +102,17 @@ class StubProcessor(Processor):
             if self.sleep_between_yields > 0:
                 await asyncio.sleep(self.sleep_between_yields)
         yield Complete(artifacts=dict(self.artifacts))
+
+
+@wool.routine
+async def echo(value: str) -> str:
+    """Return ``value`` from inside the worker process.
+
+    The smallest thing that can cross the dispatch channel. Used by the
+    mTLS tests, where the payload is irrelevant and the only question is
+    whether the gRPC handshake succeeded at all.
+    """
+    return value
 
 
 def stub_file_meta() -> dict[str, Any]:

--- a/tests/integration/test_ecs_discovery_dispatch.py
+++ b/tests/integration/test_ecs_discovery_dispatch.py
@@ -1,0 +1,271 @@
+"""Integration test for dispatch over discovery-supplied worker metadata.
+
+This is the composition that shipped broken as issue #90, and the one
+no other test reaches. ``tests/integration/test_identity_mtls.py``
+proves the identity dial, but over ``WorkerPool(spawn=…)`` — a
+different construction, where wool builds the worker itself and the
+metadata is authored in-process. The unit suite proves
+``EcsDiscovery.poll_once`` reads the right values out of ECS task tags,
+but stops at the dict it produces.
+
+What neither covers is the join: a real ``WorkerProxy`` **holding
+credentials** consuming metadata that arrived through a **discovery
+stream**, and dispatching over a real mTLS channel to a real worker.
+wool decides admission on that metadata before attempting a connection
+(``_create_security_filter`` / ``_create_version_filter``), so a wrong
+``secure`` flag or version empties the pool with no connection error to
+diagnose — which is exactly how the original defect hid.
+
+The only fake here is the boto3 wire. Everything else is real:
+``_task_to_metadata`` parses the tags, ``_EcsSubscriber`` carries the
+events, the proxy is cloudpickled into the worker on every dispatch,
+and the handshake is verified against a certificate whose only SAN is
+the logical identity. That makes this the closest reachable
+approximation of the ECS profile without AWS — the awsvpc IP a Fargate
+worker answers on is, for TLS purposes, just another address absent
+from the certificate, exactly like the loopback address used here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+import wool
+
+from cfdb.workflows.constants import (
+    WORKER_TAG_SECURE,
+    WORKER_TAG_TRUE,
+    WORKER_TAG_VERSION,
+)
+from cfdb.workflows.credentials import DEFAULT_TLS_IDENTITY, build_worker_credentials
+from cfdb.workflows.discovery import EcsDiscovery
+from cfdb.workflows.loadbalancer import PriorityLoadBalancer
+
+from tests.integration.routines import echo
+
+
+pytestmark = pytest.mark.integration
+
+#: Bounds every dispatch so a stalled handshake cannot hang the suite.
+_DISPATCH_TIMEOUT_S = 30.0
+
+#: Admission budget for the passing case. The worker is already
+#: listening before the pool is built, so admission is an in-memory
+#: queue drain after discovery's first poll — measured at ~0.1 s. This
+#: is pure headroom for a loaded CI box.
+_QUORUM_TIMEOUT_S = 15.0
+
+#: Admission budget for the rejecting case, where no worker will ever
+#: be admitted and the wait is therefore spent in full. Kept tight
+#: because it is the test's entire runtime.
+_REJECTED_QUORUM_TIMEOUT_S = 3.0
+
+#: Teardown grace. A clean drain takes about two seconds.
+_SHUTDOWN_TIMEOUT_S = 15.0
+
+
+class _FakeEcsClient:
+    """ECS client double serving one hand-seeded task description.
+
+    Only ``list_tasks`` and ``describe_tasks`` are implemented — the
+    two calls ``EcsDiscovery`` makes. Their kwarg shape against real
+    boto3 is pinned separately by the moto-backed tests in
+    ``tests/test_workflows/test_discovery.py``; here the wire is
+    deliberately stubbed so the *metadata* is the only variable.
+
+    This never crosses the cloudpickle boundary into the worker:
+    ``EcsDiscovery.__getstate__`` nulls ``_client``.
+    """
+
+    def __init__(self, tasks: list[dict[str, Any]]) -> None:
+        self._tasks = tasks
+
+    def list_tasks(self, **_kwargs: Any) -> dict[str, Any]:
+        return {"taskArns": [task["taskArn"] for task in self._tasks]}
+
+    def describe_tasks(
+        self, *, cluster: str, tasks: list[str], include: list[str] | None = None
+    ) -> dict[str, Any]:
+        wanted = set(tasks)
+        return {"tasks": [t for t in self._tasks if t["taskArn"] in wanted]}
+
+
+def _task_advertising(metadata, *, secure: bool) -> dict[str, Any]:
+    """Build the ECS task description a worker with ``metadata`` produces.
+
+    The tag payload mirrors ``worker_main._publish_worker_metadata``
+    exactly, down to the shared key constants — so a rename on either
+    side fails this test rather than silently emptying a real fleet.
+    The version is whatever the running worker actually authored, so it
+    travels the same path ``worker_main`` publishes it on.
+    """
+    ip, _port = metadata.address.rsplit(":", 1)
+    return {
+        "taskArn": f"arn:aws:ecs:us-east-1:123:task/cfdb/{uuid.uuid4().hex}",
+        "lastStatus": "RUNNING",
+        "healthStatus": "HEALTHY",
+        "attachments": [
+            {
+                "type": "ElasticNetworkInterface",
+                "details": [{"name": "privateIPv4Address", "value": ip}],
+            }
+        ],
+        "tags": [
+            {"key": WORKER_TAG_VERSION, "value": metadata.version},
+            {
+                "key": WORKER_TAG_SECURE,
+                "value": WORKER_TAG_TRUE if secure else "false",
+            },
+        ],
+    }
+
+
+@asynccontextmanager
+async def _mtls_worker(worker_certs):
+    """Run a real worker holding the worker leaf, on an ephemeral port."""
+    ca, worker_cert, worker_key, _, _ = worker_certs
+    worker = wool.LocalWorker(
+        host="127.0.0.1",
+        port=0,
+        credentials=build_worker_credentials(
+            ca, worker_cert, worker_key, identity=DEFAULT_TLS_IDENTITY
+        ),
+    )
+    await worker.start()
+    try:
+        yield worker
+    finally:
+        await worker.stop()
+
+
+def _discovery_resolving(worker, *, secure: bool) -> EcsDiscovery:
+    """Build an EcsDiscovery that resolves to ``worker``'s real address.
+
+    ``LocalWorker(port=0)`` binds an ephemeral port and reports the
+    resolved address, so the IP seeds the fake task's ENI detail and
+    the port becomes ``worker_port`` — which is how
+    ``_task_to_metadata`` reassembles it. No fixed ports, no collisions.
+    """
+    _ip, port = worker.metadata.address.rsplit(":", 1)
+    return EcsDiscovery(
+        cluster="cfdb-test",
+        task_definition_family="cfdb-test-worker",
+        client=_FakeEcsClient([_task_advertising(worker.metadata, secure=secure)]),
+        worker_port=int(port),
+    )
+
+
+def _pool(discovery, worker_certs, *, quorum_timeout: float):
+    """Build the pool the API lifespan builds, bar the quorum.
+
+    Production runs ``quorum=0`` because a Fargate cold start outlasts
+    any readiness gate. Here the worker is already listening, so a
+    quorum of 1 removes the race between the first dispatch and
+    discovery's first poll.
+
+    ``lazy`` is deliberately left at wool's default of True. Dispatch
+    cloudpickles this proxy into the worker, and a non-lazy copy enters
+    eagerly there — blocking on its own quorum against an
+    ``_EcsSubscriber`` that ``__setstate__`` deliberately restores
+    inert. Passing ``lazy=False`` turns every dispatch into a timeout.
+    """
+    ca, _, _, api_cert, api_key = worker_certs
+    return wool.WorkerPool(
+        discovery=discovery,
+        credentials=build_worker_credentials(
+            ca, api_cert, api_key, identity=DEFAULT_TLS_IDENTITY
+        ),
+        loadbalancer=PriorityLoadBalancer(),
+        quorum=1,
+        quorum_timeout=quorum_timeout,
+        shutdown_timeout=_SHUTDOWN_TIMEOUT_S,
+    )
+
+
+class TestEcsDiscoveryDispatch:
+    @pytest.mark.asyncio
+    async def test_dispatch_should_succeed_when_tags_advertise_a_secure_worker(
+        self, worker_certs, offline_aws_env
+    ):
+        """Test that tag-published metadata carries a real mTLS dispatch.
+
+        Given:
+            A real mTLS worker whose certificate's only SAN is the
+            logical identity, and an EcsDiscovery resolving it from ECS
+            task tags carrying the version and TLS flag that worker
+            itself authored.
+        When:
+            A credentialed pool dispatches a routine through that
+            discovery.
+        Then:
+            It should return the routine's result, because both halves
+            of wool's admission gate passed on worker-published metadata
+            and the handshake was verified against the identity rather
+            than the address discovery composed.
+        """
+        # Arrange
+        async with _mtls_worker(worker_certs) as worker:
+            discovery = _discovery_resolving(worker, secure=True)
+
+            # Act
+            async with _pool(
+                discovery, worker_certs, quorum_timeout=_QUORUM_TIMEOUT_S
+            ):
+                result = await asyncio.wait_for(
+                    echo("hello"), timeout=_DISPATCH_TIMEOUT_S
+                )
+
+        # Assert
+        assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_fail_when_tags_advertise_an_insecure_worker(
+        self, worker_certs, offline_aws_env, caplog
+    ):
+        """Test that a credentialed proxy refuses an insecure worker.
+
+        Given:
+            The same reachable mTLS worker, differing in one tag: its
+            published ``wool.secure`` reads false — which is what
+            discovery reported for every ECS worker before it read the
+            tags at all.
+        When:
+            The same credentialed pool dispatches a routine.
+        Then:
+            It should never admit the worker, timing out on the
+            readiness gate instead, because wool admits only secure
+            workers to a proxy holding credentials — so a wrong flag
+            empties the pool however healthy the fleet is.
+        """
+        # Arrange
+        async with _mtls_worker(worker_certs) as worker:
+            discovery = _discovery_resolving(worker, secure=False)
+
+            # Act & assert
+            with caplog.at_level(
+                logging.DEBUG, logger="wool.runtime.worker.proxy"
+            ):
+                async with _pool(
+                    discovery,
+                    worker_certs,
+                    quorum_timeout=_REJECTED_QUORUM_TIMEOUT_S,
+                ):
+                    with pytest.raises(asyncio.TimeoutError):
+                        await asyncio.wait_for(
+                            echo("hello"), timeout=_DISPATCH_TIMEOUT_S
+                        )
+
+        # A timeout alone would also follow from a worker that never
+        # started; the gate's own diagnostic is what ties the refusal to
+        # the security half. Matched loosely because wool builds the
+        # message from a parameterized format string and emits it at
+        # DEBUG — the exception carries the contract, this corroborates.
+        assert re.search(
+            r"(?i)admission gate rejected.*incompatible", caplog.text
+        )

--- a/tests/integration/test_identity_mtls.py
+++ b/tests/integration/test_identity_mtls.py
@@ -5,11 +5,12 @@ certificates, because the thing under test *is* the TLS handshake — a
 mocked ``as_provider`` proves cfdb calls wool correctly but says nothing
 about whether the resulting channel actually comes up.
 
-The worker leaf minted here carries exactly one SAN, the logical
-identity — no ``localhost``, no ``127.0.0.1``. That is what makes the
-pair of tests meaningful: the certificate is unverifiable by address, so
-the dispatch that succeeds can only have succeeded through the identity
-override, and the one without an identity can only fail.
+The worker leaf (from the shared ``worker_certs`` fixture in
+``conftest``) carries exactly one SAN, the logical identity — no
+``localhost``, no ``127.0.0.1``. That is what makes the pair of tests
+meaningful: the certificate is unverifiable by address, so the dispatch
+that succeeds can only have succeeded through the identity override,
+and the one without an identity can only fail.
 
 The two ends hold separate leaves signed by a shared CA, as they do in
 deployment, which takes a little arranging: a spawning pool passes its
@@ -24,16 +25,11 @@ case where a mistake stays invisible.
 from __future__ import annotations
 
 import asyncio
-import datetime
 import logging
 import re
 
 import pytest
 import wool
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
 from cfdb.workflows.credentials import DEFAULT_TLS_IDENTITY, build_worker_credentials
 
@@ -64,116 +60,7 @@ _SHUTDOWN_TIMEOUT_S = 15.0
 _FAILED_SHUTDOWN_TIMEOUT_S = 5.0
 
 
-def _generate_key() -> rsa.RSAPrivateKey:
-    # 2048 rather than the 4096 the shipped script uses: these certs live
-    # for one test, and key generation dominates its runtime.
-    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
-
-
-def _common_name(value: str) -> x509.Name:
-    return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, value)])
-
-
-def _sign(subject, subject_key, issuer, issuer_key, *, sans=None, eku=None, ca=False):
-    """Mint a certificate, self-signed when issuer and subject coincide."""
-    now = datetime.datetime.now(datetime.timezone.utc)
-    builder = (
-        x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer)
-        .public_key(subject_key.public_key())
-        .serial_number(x509.random_serial_number())
-        .not_valid_before(now - datetime.timedelta(minutes=5))
-        .not_valid_after(now + datetime.timedelta(days=1))
-        .add_extension(x509.BasicConstraints(ca=ca, path_length=None), critical=True)
-    )
-    if sans is not None:
-        builder = builder.add_extension(
-            x509.SubjectAlternativeName(sans), critical=False
-        )
-    if eku is not None:
-        builder = builder.add_extension(x509.ExtendedKeyUsage(eku), critical=False)
-    return builder.sign(issuer_key, hashes.SHA256())
-
-
-def _write(path, data: bytes) -> str:
-    path.write_bytes(data)
-    return str(path)
-
-
-def _write_leaf(tmp_path, stem, ca_name, ca_key, *, common_name, sans, eku):
-    """Mint a CA-signed leaf and return its ``(cert_path, key_path)``."""
-    key = _generate_key()
-    cert = _sign(_common_name(common_name), key, ca_name, ca_key, sans=sans, eku=eku)
-    return (
-        _write(
-            tmp_path / f"{stem}-cert.pem",
-            cert.public_bytes(serialization.Encoding.PEM),
-        ),
-        _write(
-            tmp_path / f"{stem}-key.pem",
-            key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption(),
-            ),
-        ),
-    )
-
-
-@pytest.fixture
-def certs(tmp_path):
-    """Mint a CA plus the separate worker and API leaves it signs.
-
-    Returns ``(ca_path, worker_cert, worker_key, api_cert, api_key)``,
-    mirroring the deployed arrangement where each process holds its own
-    leaf and only the CA is shared.
-
-    The worker leaf's sole SAN is the logical identity — no
-    ``localhost``, no ``127.0.0.1`` — so it is unverifiable by address.
-    The API leaf gets none at all, which is the point: a worker
-    authenticates its client by chain, with no name check.
-
-    The extended key usages mirror what ``certs/generate-worker-certs.sh``
-    now mints, so these tests fail if a ``clientAuth``-only API leaf turns
-    out not to work as a client. Withholding ``serverAuth`` from the API
-    is what stops its certificate doubling as a worker's.
-    """
-    ca_key = _generate_key()
-    ca_name = _common_name("cfdb-worker-ca")
-    ca_cert = _sign(ca_name, ca_key, ca_name, ca_key, ca=True)
-
-    worker_cert, worker_key = _write_leaf(
-        tmp_path,
-        "worker",
-        ca_name,
-        ca_key,
-        common_name="cfdb-worker",
-        sans=[x509.DNSName(DEFAULT_TLS_IDENTITY)],
-        # serverAuth to terminate dispatch; clientAuth because wool's
-        # graceful-stop RPC dials the worker's own subprocess.
-        eku=[ExtendedKeyUsageOID.SERVER_AUTH, ExtendedKeyUsageOID.CLIENT_AUTH],
-    )
-    api_cert, api_key = _write_leaf(
-        tmp_path,
-        "api",
-        ca_name,
-        ca_key,
-        common_name="cfdb-api",
-        sans=None,
-        eku=[ExtendedKeyUsageOID.CLIENT_AUTH],
-    )
-
-    return (
-        _write(tmp_path / "ca.pem", ca_cert.public_bytes(serialization.Encoding.PEM)),
-        worker_cert,
-        worker_key,
-        api_cert,
-        api_key,
-    )
-
-
-def _worker_factory(certs):
+def _worker_factory(worker_certs):
     """Build a worker factory that keeps the worker's own credentials.
 
     A spawning pool hands its single ``credentials=`` to both the proxy
@@ -192,7 +79,7 @@ def _worker_factory(certs):
     losing in-flight work — visible here as the pool warning that it
     "stopped waiting for 1 worker(s) that did not stop gracefully".
     """
-    ca, worker_cert, worker_key, _, _ = certs
+    ca, worker_cert, worker_key, _, _ = worker_certs
 
     def factory(*tags, credentials=None, host=None):
         return wool.LocalWorker(
@@ -206,12 +93,12 @@ def _worker_factory(certs):
     return factory
 
 
-def _pool(certs, *, identity, shutdown_timeout=_SHUTDOWN_TIMEOUT_S):
+def _pool(worker_certs, *, identity, shutdown_timeout=_SHUTDOWN_TIMEOUT_S):
     """Build a one-worker pool over the minted material."""
-    ca, _, _, api_cert, api_key = certs
+    ca, _, _, api_cert, api_key = worker_certs
     return wool.WorkerPool(
         spawn=1,
-        worker=_worker_factory(certs),
+        worker=_worker_factory(worker_certs),
         credentials=build_worker_credentials(
             ca, api_cert, api_key, identity=identity
         ),
@@ -234,7 +121,7 @@ def _pool(certs, *, identity, shutdown_timeout=_SHUTDOWN_TIMEOUT_S):
 class TestIdentityMutualTls:
     @pytest.mark.asyncio
     async def test_dispatch_should_succeed_when_identity_matches_the_certificate(
-        self, certs
+        self, worker_certs
     ):
         """Test that an identity makes an address-unverifiable cert usable.
 
@@ -249,7 +136,7 @@ class TestIdentityMutualTls:
             the address the pool dialed.
         """
         # Arrange
-        pool = _pool(certs, identity=DEFAULT_TLS_IDENTITY)
+        pool = _pool(worker_certs, identity=DEFAULT_TLS_IDENTITY)
 
         # Act
         async with pool:
@@ -262,7 +149,7 @@ class TestIdentityMutualTls:
 
     @pytest.mark.asyncio
     async def test_dispatch_should_fail_when_identity_is_not_configured(
-        self, certs, caplog
+        self, worker_certs, caplog
     ):
         """Test that the same certificate is unusable without an identity.
 
@@ -279,7 +166,7 @@ class TestIdentityMutualTls:
         """
         # Arrange
         pool = _pool(
-            certs, identity=None, shutdown_timeout=_FAILED_SHUTDOWN_TIMEOUT_S
+            worker_certs, identity=None, shutdown_timeout=_FAILED_SHUTDOWN_TIMEOUT_S
         )
 
         # Act & assert

--- a/tests/integration/test_identity_mtls.py
+++ b/tests/integration/test_identity_mtls.py
@@ -1,0 +1,308 @@
+"""Integration test for identity-based mutual TLS on the dispatch channel.
+
+Exercises a real ``wool.WorkerPool`` over a real gRPC channel with real
+certificates, because the thing under test *is* the TLS handshake — a
+mocked ``as_provider`` proves cfdb calls wool correctly but says nothing
+about whether the resulting channel actually comes up.
+
+The worker leaf minted here carries exactly one SAN, the logical
+identity — no ``localhost``, no ``127.0.0.1``. That is what makes the
+pair of tests meaningful: the certificate is unverifiable by address, so
+the dispatch that succeeds can only have succeeded through the identity
+override, and the one without an identity can only fail.
+
+The two ends hold separate leaves signed by a shared CA, as they do in
+deployment, which takes a little arranging: a spawning pool passes its
+single ``credentials=`` to both the proxy and every worker it starts, so
+the worker factory has to supply the worker's own (see
+``_worker_factory``). Worth the arranging, because collapsing them into
+one leaf would leave the API's client certificate untested — and a
+client certificate that happens to also be the server's is exactly the
+case where a mistake stays invisible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import re
+
+import pytest
+import wool
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from cfdb.workflows.credentials import DEFAULT_TLS_IDENTITY, build_worker_credentials
+
+from tests.integration.routines import echo
+
+
+pytestmark = pytest.mark.integration
+
+#: Bounds every dispatch so a handshake that stalls rather than failing
+#: cannot hang the suite.
+_DISPATCH_TIMEOUT_S = 30.0
+
+#: How long to wait for the worker to be admitted to the pool. Long
+#: enough for a subprocess spawn plus a TLS handshake on a loaded CI box,
+#: short enough that the failing case does not dominate the suite.
+_QUORUM_TIMEOUT_S = 20.0
+
+#: Teardown grace for the passing case. A clean drain takes about two
+#: seconds, so this has real headroom while still failing the test rather
+#: than hanging it if graceful stop ever breaks again. Keeping it tight
+#: is deliberate: an over-generous budget hides a broken stop path behind
+#: a force-reap that still reports success.
+_SHUTDOWN_TIMEOUT_S = 15.0
+
+#: Teardown grace for the failing case only. The pool cannot reach a
+#: worker it could never verify, so the stop RPC is doomed and the wait
+#: is pure latency; the full budget above would be spent on it.
+_FAILED_SHUTDOWN_TIMEOUT_S = 5.0
+
+
+def _generate_key() -> rsa.RSAPrivateKey:
+    # 2048 rather than the 4096 the shipped script uses: these certs live
+    # for one test, and key generation dominates its runtime.
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _common_name(value: str) -> x509.Name:
+    return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, value)])
+
+
+def _sign(subject, subject_key, issuer, issuer_key, *, sans=None, eku=None, ca=False):
+    """Mint a certificate, self-signed when issuer and subject coincide."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(subject_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=ca, path_length=None), critical=True)
+    )
+    if sans is not None:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(sans), critical=False
+        )
+    if eku is not None:
+        builder = builder.add_extension(x509.ExtendedKeyUsage(eku), critical=False)
+    return builder.sign(issuer_key, hashes.SHA256())
+
+
+def _write(path, data: bytes) -> str:
+    path.write_bytes(data)
+    return str(path)
+
+
+def _write_leaf(tmp_path, stem, ca_name, ca_key, *, common_name, sans, eku):
+    """Mint a CA-signed leaf and return its ``(cert_path, key_path)``."""
+    key = _generate_key()
+    cert = _sign(_common_name(common_name), key, ca_name, ca_key, sans=sans, eku=eku)
+    return (
+        _write(
+            tmp_path / f"{stem}-cert.pem",
+            cert.public_bytes(serialization.Encoding.PEM),
+        ),
+        _write(
+            tmp_path / f"{stem}-key.pem",
+            key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def certs(tmp_path):
+    """Mint a CA plus the separate worker and API leaves it signs.
+
+    Returns ``(ca_path, worker_cert, worker_key, api_cert, api_key)``,
+    mirroring the deployed arrangement where each process holds its own
+    leaf and only the CA is shared.
+
+    The worker leaf's sole SAN is the logical identity — no
+    ``localhost``, no ``127.0.0.1`` — so it is unverifiable by address.
+    The API leaf gets none at all, which is the point: a worker
+    authenticates its client by chain, with no name check.
+
+    The extended key usages mirror what ``certs/generate-worker-certs.sh``
+    now mints, so these tests fail if a ``clientAuth``-only API leaf turns
+    out not to work as a client. Withholding ``serverAuth`` from the API
+    is what stops its certificate doubling as a worker's.
+    """
+    ca_key = _generate_key()
+    ca_name = _common_name("cfdb-worker-ca")
+    ca_cert = _sign(ca_name, ca_key, ca_name, ca_key, ca=True)
+
+    worker_cert, worker_key = _write_leaf(
+        tmp_path,
+        "worker",
+        ca_name,
+        ca_key,
+        common_name="cfdb-worker",
+        sans=[x509.DNSName(DEFAULT_TLS_IDENTITY)],
+        # serverAuth to terminate dispatch; clientAuth because wool's
+        # graceful-stop RPC dials the worker's own subprocess.
+        eku=[ExtendedKeyUsageOID.SERVER_AUTH, ExtendedKeyUsageOID.CLIENT_AUTH],
+    )
+    api_cert, api_key = _write_leaf(
+        tmp_path,
+        "api",
+        ca_name,
+        ca_key,
+        common_name="cfdb-api",
+        sans=None,
+        eku=[ExtendedKeyUsageOID.CLIENT_AUTH],
+    )
+
+    return (
+        _write(tmp_path / "ca.pem", ca_cert.public_bytes(serialization.Encoding.PEM)),
+        worker_cert,
+        worker_key,
+        api_cert,
+        api_key,
+    )
+
+
+def _worker_factory(certs):
+    """Build a worker factory that keeps the worker's own credentials.
+
+    A spawning pool hands its single ``credentials=`` to both the proxy
+    it dials with and every worker it starts, which would collapse the
+    two leaves into one. Declaring ``credentials`` and discarding it —
+    while declaring keyword-only ``host`` so wool still prescribes the
+    bind address — restores the split each process has in deployment,
+    where it builds credentials from its own environment.
+
+    The worker's own credentials carry the identity, matching what the
+    entrypoints do via ``identity_from_env``. That is not redundant with
+    the pool's: ``LocalWorker.stop`` dials this worker's subprocess to
+    drain it, so the worker is a client on that one connection and
+    verifies a certificate whose only SAN is the identity. Without it the
+    stop RPC fails its name check and wool force-reaps the subprocess,
+    losing in-flight work — visible here as the pool warning that it
+    "stopped waiting for 1 worker(s) that did not stop gracefully".
+    """
+    ca, worker_cert, worker_key, _, _ = certs
+
+    def factory(*tags, credentials=None, host=None):
+        return wool.LocalWorker(
+            *tags,
+            credentials=build_worker_credentials(
+                ca, worker_cert, worker_key, identity=DEFAULT_TLS_IDENTITY
+            ),
+            host=host,
+        )
+
+    return factory
+
+
+def _pool(certs, *, identity, shutdown_timeout=_SHUTDOWN_TIMEOUT_S):
+    """Build a one-worker pool over the minted material."""
+    ca, _, _, api_cert, api_key = certs
+    return wool.WorkerPool(
+        spawn=1,
+        worker=_worker_factory(certs),
+        credentials=build_worker_credentials(
+            ca, api_cert, api_key, identity=identity
+        ),
+        # Wait for the worker to register before returning from
+        # __aenter__, so a dispatch is not racing its startup — without
+        # this both tests fail with NoWorkersAvailable for reasons that
+        # have nothing to do with TLS. Admission does not itself require
+        # a completed handshake, so the gate removes the race and leaves
+        # the dispatch to be decided by the certificate. (The API runs
+        # quorum=0 instead, because a Fargate cold start outlasts any
+        # sensible gate — a difference in startup policy, not in how the
+        # channel is secured.)
+        quorum=1,
+        quorum_timeout=_QUORUM_TIMEOUT_S,
+        lazy=False,
+        shutdown_timeout=shutdown_timeout,
+    )
+
+
+class TestIdentityMutualTls:
+    @pytest.mark.asyncio
+    async def test_dispatch_should_succeed_when_identity_matches_the_certificate(
+        self, certs
+    ):
+        """Test that an identity makes an address-unverifiable cert usable.
+
+        Given:
+            A real worker whose certificate's only SAN is the logical
+            identity, and credentials carrying that same identity.
+        When:
+            A routine is dispatched to it.
+        Then:
+            It should return its result over the mTLS channel, since the
+            peer is verified against the identity rather than against
+            the address the pool dialed.
+        """
+        # Arrange
+        pool = _pool(certs, identity=DEFAULT_TLS_IDENTITY)
+
+        # Act
+        async with pool:
+            result = await asyncio.wait_for(
+                echo("hello"), timeout=_DISPATCH_TIMEOUT_S
+            )
+
+        # Assert
+        assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_fail_when_identity_is_not_configured(
+        self, certs, caplog
+    ):
+        """Test that the same certificate is unusable without an identity.
+
+        Given:
+            The same certificate, but credentials built with no
+            identity, so verification falls back to the dialed address.
+        When:
+            A routine is dispatched to it.
+        Then:
+            It should fail on the certificate's name check, because the
+            address the pool dialed appears in no SAN. This is what
+            establishes that the passing case above is carried by the
+            identity and not by some incidental match.
+        """
+        # Arrange
+        pool = _pool(
+            certs, identity=None, shutdown_timeout=_FAILED_SHUTDOWN_TIMEOUT_S
+        )
+
+        # Act & assert
+        # The worker registers, but its handshake fails; wool classifies
+        # that as transient and skips the worker rather than evicting it,
+        # so the balancer runs out of candidates and the proxy reports no
+        # healthy worker. NoWorkersAvailable alone would also be raised by
+        # a worker that never started or one rejected on version, so the
+        # log assertion below is what ties the failure to verification.
+        with caplog.at_level(logging.WARNING, logger="wool.runtime.worker.proxy"):
+            async with pool:
+                with pytest.raises(wool.NoWorkersAvailable):
+                    await asyncio.wait_for(
+                        echo("hello"), timeout=_DISPATCH_TIMEOUT_S
+                    )
+
+        assert "handshake failure" in caplog.text
+        # The verification detail is authored by BoringSSL and surfaced
+        # through grpcio ("Hostname Verification Check failed" today),
+        # neither of which cfdb pins with an upper bound — so match the
+        # concept, not the exact wording, or a grpcio bump turns this
+        # into a red test that names nothing under test. The wool-owned
+        # "handshake failure" assertion above is the stable contract.
+        assert re.search(
+            r"(?i)hostname verification|certificate verify", caplog.text
+        )

--- a/tests/integration/test_worker_metadata.py
+++ b/tests/integration/test_worker_metadata.py
@@ -1,0 +1,58 @@
+"""Integration test for the worker-metadata admission contract.
+
+The ECS metadata-publishing pipeline (worker tags its task →
+``EcsDiscovery`` reads the tags back) carries one value end to end:
+whatever ``wool.LocalWorker`` authors as its metadata. Every unit test
+on that pipeline mocks the worker, so none of them would notice if a
+wool upgrade renamed the field, stopped populating it, or started
+returning something wool's own admission gate cannot parse — which
+would reproduce the original fleet-wide rejection (issue #90) with a
+green suite. This test starts a real worker and closes the loop against
+wool's actual predicates.
+"""
+
+from __future__ import annotations
+
+import pytest
+import wool
+import wool.protocol
+from wool.runtime.worker.proxy import is_version_compatible, parse_version
+
+
+pytestmark = pytest.mark.integration
+
+
+class TestLocalWorkerMetadata:
+    @pytest.mark.asyncio
+    async def test_metadata_should_be_admissible_by_wools_version_gate(self):
+        """Test that a real worker authors an admissible version.
+
+        Given:
+            A started ``wool.LocalWorker`` — the same object whose
+            ``metadata.version`` the ECS entrypoint publishes as the
+            ``wool.version`` task tag.
+        When:
+            Its authored version is checked against wool's own
+            version-compatibility predicate, as a same-version proxy
+            would at admission.
+        Then:
+            It should parse and be compatible, pinning the contract the
+            tag pipeline round-trips: what a real worker publishes is
+            what a real proxy admits.
+        """
+        # Arrange
+        worker = wool.LocalWorker(host="127.0.0.1", port=0)
+        await worker.start()
+
+        # Act
+        try:
+            metadata = worker.metadata
+        finally:
+            await worker.stop()
+
+        # Assert
+        assert metadata is not None
+        published = parse_version(metadata.version)
+        proxy_side = parse_version(wool.protocol.__version__)
+        assert published is not None
+        assert is_version_compatible(proxy_side, published)

--- a/tests/test_api/test_lifespan_workerpool.py
+++ b/tests/test_api/test_lifespan_workerpool.py
@@ -19,6 +19,7 @@ import inspect
 import pytest
 import wool
 
+from cfdb import api
 from cfdb.api import main
 from cfdb.api import profile as profile_mod
 
@@ -81,7 +82,7 @@ async def test_lifespan_should_construct_worker_pool_with_quorum_zero(
     mocker.patch.object(main, "_build_provisioner", return_value=None)
     mocker.patch.object(main, "_build_discovery", new=_fake_build_discovery)
     mocker.patch.object(main, "default_registry", return_value=mocker.MagicMock())
-    mocker.patch.object(
+    build_credentials = mocker.patch.object(
         main, "build_worker_credentials", return_value="CREDS-SENTINEL"
     )
     mocker.patch.object(main, "WoolExecutor", return_value=fake_executor)
@@ -97,6 +98,17 @@ async def test_lifespan_should_construct_worker_pool_with_quorum_zero(
     assert kwargs["quorum"] == 0
     assert kwargs["discovery"] is sentinel_discovery
     assert kwargs["credentials"] == "CREDS-SENTINEL"
+    # Pin the credential call itself, not just its result. The identity
+    # kwarg is the only thing connecting CFDB_WORKER_TLS_IDENTITY to the
+    # wire, and dropping it reverts every mTLS deployment to address
+    # verification — which on ECS can never succeed, and surfaces only
+    # as NoWorkersAvailable with nothing naming TLS.
+    build_credentials.assert_called_once_with(
+        api.CFDB_WORKER_TLS_CA,
+        api.CFDB_WORKER_TLS_CERT,
+        api.CFDB_WORKER_TLS_KEY,
+        identity=api.CFDB_WORKER_TLS_IDENTITY,
+    )
     # The priority/leaky-bucket balancer must be wired in (issue #45). This
     # file exists to pin pool kwargs against silent regressions, so the
     # load balancer belongs here alongside quorum/discovery/credentials.

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -194,3 +194,288 @@ def test_backend_per_environment_parameters_should_be_documented():
         assert parameters[name].get("Description", "").strip(), (
             f"{name} needs a Description marking it as a per-environment value"
         )
+
+
+def test_worker_task_role_should_allow_the_worker_to_tag_its_own_task():
+    """Test that the worker task role can publish its metadata.
+
+    Given:
+        The workers template, whose container publishes its wool version
+        and TLS flag by tagging its own ECS task.
+    When:
+        The worker task role's policies are read.
+    Then:
+        They should grant ``ecs:TagResource``, without which the worker
+        exits at startup and EcsDiscovery never advertises a worker.
+    """
+    # Arrange
+    template = _load_template("workers.yml")
+
+    # Act
+    policies = template["Resources"]["WorkerTaskRole"]["Properties"]["Policies"]
+    actions = [
+        statement.get("Action")
+        for policy in policies
+        for statement in policy["PolicyDocument"]["Statement"]
+    ]
+
+    # Assert
+    assert "ecs:TagResource" in actions
+
+
+def test_worker_tag_grant_should_be_scoped_to_the_cluster_and_wool_keys():
+    """Test that the tagging grant cannot reach the other environment.
+
+    Given:
+        The workers template's ecs:TagResource statement. These tags are
+        load-bearing — discovery trusts them to build the metadata wool
+        gates admission on — and dev and prod share the account and
+        region, so an account-wide grant would let a compromised dev
+        worker rewrite prod's tags and silently empty its pool.
+    When:
+        The statement's Resource and Condition are read.
+    Then:
+        The Resource should be confined to the parameterized cluster
+        (not a bare ``task/*``) and the Condition should confine the
+        writable keys to exactly the two ``wool.*`` tags.
+    """
+    # Arrange
+    template = _load_template("workers.yml")
+    policies = template["Resources"]["WorkerTaskRole"]["Properties"]["Policies"]
+
+    # Act
+    statement = next(
+        statement
+        for policy in policies
+        for statement in policy["PolicyDocument"]["Statement"]
+        if statement.get("Action") == "ecs:TagResource"
+    )
+    resource_template = statement["Resource"]["Fn::Sub"]
+    tag_keys = statement["Condition"]["ForAllValues:StringEquals"]["aws:TagKeys"]
+
+    # Assert
+    assert "task/${BackendClusterName}/*" in resource_template
+    assert "task/*" not in resource_template.replace(
+        "task/${BackendClusterName}/*", ""
+    )
+    assert sorted(tag_keys) == ["wool.secure", "wool.version"]
+    assert "BackendClusterName" in (template.get("Parameters") or {})
+
+
+def test_worker_container_should_declare_aws_region():
+    """Test that the worker container is told its region.
+
+    Given:
+        The workers template's container definition. The worker's
+        metadata publish builds a boto3 client, and Fargate injects no
+        region — without this variable (or the code-side ARN fallback)
+        every worker exits at startup with NoRegionError and the fleet
+        stays empty.
+    When:
+        The container's Environment entries are read.
+    Then:
+        ``AWS_REGION`` should be present and derive from the stack's
+        own region, mirroring the backend container.
+    """
+    # Arrange
+    template = _load_template("workers.yml")
+    container = template["Resources"]["WorkerTaskDefinition"]["Properties"][
+        "ContainerDefinitions"
+    ][0]
+
+    # Act
+    plain_env = {
+        entry["Name"]: entry.get("Value")
+        for entry in container["Environment"]
+        if isinstance(entry, dict) and "Name" in entry
+    }
+
+    # Assert
+    assert plain_env.get("AWS_REGION") == {"Ref": "AWS::Region"}
+
+
+def test_worker_tls_identity_should_only_render_when_mtls_is_enabled():
+    """Test that the worker identity env var is gated on mTLS.
+
+    Given:
+        The workers template's container definition and its
+        WorkerTlsIdentity parameter — the worker's half of identity
+        verification on wool's graceful-stop channel.
+    When:
+        The conditional Environment entry is read.
+    Then:
+        ``CFDB_WORKER_TLS_IDENTITY`` should render under the
+        WorkerMtlsEnabled condition and reference the parameter, so the
+        plaintext template stays unchanged while an mTLS deployment can
+        align the worker with the backend stack's identity.
+    """
+    # Arrange
+    template = _load_template("workers.yml")
+    container = template["Resources"]["WorkerTaskDefinition"]["Properties"][
+        "ContainerDefinitions"
+    ][0]
+
+    # Act
+    conditional = next(
+        entry["Fn::If"]
+        for entry in container["Environment"]
+        if isinstance(entry, dict) and "Fn::If" in entry
+    )
+    condition_name, enabled_value, disabled_value = conditional
+
+    # Assert
+    assert condition_name == "WorkerMtlsEnabled"
+    assert enabled_value == {
+        "Name": "CFDB_WORKER_TLS_IDENTITY",
+        "Value": {"Ref": "WorkerTlsIdentity"},
+    }
+    assert disabled_value == {"Ref": "AWS::NoValue"}
+
+
+def test_worker_tls_identity_defaults_should_agree_across_both_stacks():
+    """Test that the two templates cannot drift on the identity default.
+
+    Given:
+        The WorkerTlsIdentity parameters of the backend and workers
+        templates. The API verifies the worker leaf's SAN against the
+        backend value; the worker verifies the same SAN on its own
+        graceful-stop channel via the workers value.
+    When:
+        Both defaults are compared to the application constant.
+    Then:
+        All three should be equal — a drift between them fails only at
+        runtime, as a force-reaped worker losing in-flight work, with
+        no TLS error anywhere client-side.
+    """
+    # Arrange
+    from cfdb.workflows.constants import DEFAULT_TLS_IDENTITY
+
+    backend = _load_template("backend.yml")["Parameters"]["WorkerTlsIdentity"]
+    workers = _load_template("workers.yml")["Parameters"]["WorkerTlsIdentity"]
+
+    # Act & assert
+    assert backend["Default"] == DEFAULT_TLS_IDENTITY
+    assert workers["Default"] == DEFAULT_TLS_IDENTITY
+
+
+def test_worker_tls_identity_pattern_should_reject_ip_literals():
+    """Test that the identity patterns reject what cannot be a SAN.
+
+    Given:
+        The identical AllowedPattern on both templates' WorkerTlsIdentity
+        parameters. The cert generator refuses an IP-literal identity
+        because it would mint DNS:<ip>, which gRPC never matches against
+        an address — so the deploy boundary must refuse it too, or the
+        one symptom is NoWorkersAvailable.
+    When:
+        The pattern is evaluated against representative values.
+    Then:
+        It should accept DNS-safe names (with at least one letter, in
+        any position) and the empty opt-out, and reject IP literals,
+        all-numeric names, and separator-edged names.
+    """
+    # Arrange
+    import re
+
+    backend = _load_template("backend.yml")["Parameters"]["WorkerTlsIdentity"]
+    workers = _load_template("workers.yml")["Parameters"]["WorkerTlsIdentity"]
+    pattern = re.compile(backend["AllowedPattern"])
+
+    # Act & assert
+    assert backend["AllowedPattern"] == workers["AllowedPattern"]
+    for accepted in ("", "cfdb-worker", "a.b-c", "9lives", "cfdb-worker-prod"):
+        assert pattern.fullmatch(accepted), f"{accepted!r} should be accepted"
+    for rejected in ("10.0.0.5", "1.2.3.4", "1234", ".abc", "abc.", "-a", "a b"):
+        assert not pattern.fullmatch(rejected), f"{rejected!r} should be rejected"
+
+
+def test_cert_generator_default_identity_should_match_the_application_default():
+    """Test that the cert script and the code agree on the default identity.
+
+    Given:
+        The ``IDENTITY=`` default in certs/generate-worker-certs.sh —
+        the value that decides what SAN locally-minted worker leaves
+        actually carry.
+    When:
+        The default is extracted from the script source.
+    Then:
+        It should equal DEFAULT_TLS_IDENTITY, because a drift means the
+        API verifies against a name the certificates do not carry, and
+        the only symptom is NoWorkersAvailable.
+    """
+    # Arrange
+    import re
+
+    from cfdb.workflows.constants import DEFAULT_TLS_IDENTITY
+
+    script = (
+        Path(__file__).resolve().parents[1] / "certs" / "generate-worker-certs.sh"
+    ).read_text()
+
+    # Act
+    match = re.search(r'^IDENTITY="([^"]*)"', script, flags=re.MULTILINE)
+
+    # Assert
+    assert match is not None, "IDENTITY= default not found in the script"
+    assert match.group(1) == DEFAULT_TLS_IDENTITY
+
+
+def test_backend_worker_tls_identity_should_match_the_application_default():
+    """Test that the template and the code agree on the default identity.
+
+    Given:
+        The backend template's WorkerTlsIdentity parameter and the
+        application constant the API reads.
+    When:
+        The parameter's default is compared to DEFAULT_TLS_IDENTITY.
+    Then:
+        They should be equal — a drift means the API expects a name the
+        deployed certificates do not carry, and every handshake fails
+        with nothing in the error naming TLS.
+    """
+    # Arrange
+    from cfdb.workflows.constants import DEFAULT_TLS_IDENTITY
+
+    template = _load_template("backend.yml")
+
+    # Act
+    parameter = template["Parameters"]["WorkerTlsIdentity"]
+
+    # Assert
+    assert parameter["Default"] == DEFAULT_TLS_IDENTITY
+
+
+def test_backend_worker_tls_identity_should_only_render_when_mtls_is_enabled():
+    """Test that the identity env var is gated on the mTLS condition.
+
+    Given:
+        The backend template's API container definition.
+    When:
+        Its Environment entries are searched for the identity variable.
+    Then:
+        It should appear inside an Fn::If over ApiMtlsEnabled, so a
+        plaintext deployment does not advertise a setting that has no
+        effect.
+    """
+    # Arrange
+    template = _load_template("backend.yml")
+    container = template["Resources"]["TaskDefinition"]["Properties"][
+        "ContainerDefinitions"
+    ][0]
+
+    # Act
+    conditional = [
+        entry
+        for entry in container["Environment"]
+        if isinstance(entry, dict) and "Fn::If" in entry
+    ]
+
+    # Assert
+    identity_entries = [
+        entry
+        for entry in conditional
+        if entry["Fn::If"][0] == "ApiMtlsEnabled"
+        and entry["Fn::If"][1].get("Name") == "CFDB_WORKER_TLS_IDENTITY"
+    ]
+    assert len(identity_entries) == 1
+    assert identity_entries[0]["Fn::If"][1]["Value"] == {"Ref": "WorkerTlsIdentity"}

--- a/tests/test_workflows/test_credentials.py
+++ b/tests/test_workflows/test_credentials.py
@@ -10,7 +10,6 @@ from cfdb.workflows.credentials import (
     TLS_CERT_ENV,
     TLS_KEY_ENV,
     build_worker_credentials,
-    worker_credentials_from_env,
 )
 
 
@@ -167,59 +166,114 @@ class TestBuildWorkerCredentials:
         # Assert
         assert from_files.call_args.kwargs["mutual"] is False
 
-
-class TestWorkerCredentialsFromEnv:
-    def test_worker_credentials_from_env_should_return_none_when_unset(
-        self, monkeypatch
+    def test_build_worker_credentials_should_return_plain_credentials_when_identity_unset(
+        self, tmp_path, mocker
     ):
-        """Test that an unconfigured environment yields plaintext.
+        """Test that omitting an identity leaves verification untouched.
 
         Given:
-            None of the ``CFDB_WORKER_TLS_*`` env vars are set.
+            Complete cert config and no identity.
         When:
-            ``worker_credentials_from_env`` is called.
+            ``build_worker_credentials`` is called.
         Then:
-            It should return None.
-        """
-        # Arrange
-        for var in (TLS_CA_ENV, TLS_CERT_ENV, TLS_KEY_ENV):
-            monkeypatch.delenv(var, raising=False)
-
-        # Act
-        result = worker_credentials_from_env()
-
-        # Assert
-        assert result is None
-
-    def test_worker_credentials_from_env_should_read_the_env_vars(
-        self, tmp_path, monkeypatch, mocker
-    ):
-        """Test that the builder reads cert paths from the environment.
-
-        Given:
-            The three ``CFDB_WORKER_TLS_*`` env vars point at existing
-            files.
-        When:
-            ``worker_credentials_from_env`` is called.
-        Then:
-            It should delegate to ``wool.WorkerCredentials.from_files``
-            with the env-supplied paths.
+            It should return wool's credentials unadapted, so the peer
+            is verified against the dialed address as it was before
+            identities existed.
         """
         # Arrange
         ca = _write_pem(tmp_path, "ca.pem")
         cert = _write_pem(tmp_path, "cert.pem")
         key = _write_pem(tmp_path, "key.pem")
-        monkeypatch.setenv(TLS_CA_ENV, ca)
-        monkeypatch.setenv(TLS_CERT_ENV, cert)
-        monkeypatch.setenv(TLS_KEY_ENV, key)
-        from_files = mocker.patch.object(
-            wool.WorkerCredentials, "from_files", return_value=object()
+        credentials = mocker.Mock(spec=wool.WorkerCredentials)
+        mocker.patch.object(
+            wool.WorkerCredentials, "from_files", return_value=credentials
         )
 
         # Act
-        worker_credentials_from_env()
+        result = build_worker_credentials(ca, cert, key)
 
         # Assert
-        from_files.assert_called_once_with(
-            ca_path=ca, key_path=key, cert_path=cert, mutual=True
+        assert result is credentials
+        credentials.as_provider.assert_not_called()
+
+    def test_build_worker_credentials_should_adapt_to_a_provider_when_identity_set(
+        self, tmp_path, mocker
+    ):
+        """Test that an identity produces a provider carrying it.
+
+        Given:
+            Complete cert config and a logical identity.
+        When:
+            ``build_worker_credentials`` is called with that identity.
+        Then:
+            It should return the provider from ``as_provider``, which is
+            what makes wool verify the peer against the name rather than
+            the address it dialed.
+        """
+        # Arrange
+        ca = _write_pem(tmp_path, "ca.pem")
+        cert = _write_pem(tmp_path, "cert.pem")
+        key = _write_pem(tmp_path, "key.pem")
+        provider = mocker.Mock(spec=wool.WorkerCredentialsProvider)
+        credentials = mocker.Mock(spec=wool.WorkerCredentials)
+        credentials.as_provider.return_value = provider
+        mocker.patch.object(
+            wool.WorkerCredentials, "from_files", return_value=credentials
         )
+
+        # Act
+        result = build_worker_credentials(ca, cert, key, identity="cfdb-worker")
+
+        # Assert
+        assert result is provider
+        credentials.as_provider.assert_called_once_with(identity="cfdb-worker")
+
+    def test_build_worker_credentials_should_return_plain_credentials_when_identity_empty(
+        self, tmp_path, mocker
+    ):
+        """Test that an empty identity is the documented opt-out.
+
+        Given:
+            Complete cert config and an empty-string identity, as an
+            operator sets to fall back to address verification.
+        When:
+            ``build_worker_credentials`` is called.
+        Then:
+            It should return the plain credentials rather than a
+            provider bearing a meaningless empty name.
+        """
+        # Arrange
+        ca = _write_pem(tmp_path, "ca.pem")
+        cert = _write_pem(tmp_path, "cert.pem")
+        key = _write_pem(tmp_path, "key.pem")
+        credentials = mocker.Mock(spec=wool.WorkerCredentials)
+        mocker.patch.object(
+            wool.WorkerCredentials, "from_files", return_value=credentials
+        )
+
+        # Act
+        result = build_worker_credentials(ca, cert, key, identity="")
+
+        # Assert
+        assert result is credentials
+        credentials.as_provider.assert_not_called()
+
+    def test_build_worker_credentials_should_return_none_when_identity_set_without_certs(
+        self,
+    ):
+        """Test that an identity alone never enables mTLS.
+
+        Given:
+            No cert paths at all, but an identity.
+        When:
+            ``build_worker_credentials`` is called.
+        Then:
+            It should return None for the plaintext path — an identity
+            constrains a certificate, so on its own it has nothing to
+            act on and must not be mistaken for partial cert config.
+        """
+        # Act
+        result = build_worker_credentials(None, None, None, identity="cfdb-worker")
+
+        # Assert
+        assert result is None

--- a/tests/test_workflows/test_discovery.py
+++ b/tests/test_workflows/test_discovery.py
@@ -20,15 +20,33 @@ def _task_arn(task_id: str | None = None) -> str:
     return f"arn:aws:ecs:us-east-1:123:task/cluster/{task_id or uuid.uuid4().hex}"
 
 
+#: Stand-in for the wool version a worker publishes. Any parsable
+#: version works; the poller passes it through verbatim.
+_PUBLISHED_VERSION = "1.2.3"
+
+
 def _running_task(
     task_id: str,
     *,
     ip: str = "10.0.0.5",
     health: str = "HEALTHY",
     status: str = "RUNNING",
+    version: str | None = _PUBLISHED_VERSION,
+    secure: bool | None = None,
 ) -> dict[str, Any]:
-    """Construct a fake ECS DescribeTasks entry."""
-    return {
+    """Construct a fake ECS DescribeTasks entry.
+
+    Tags carry the metadata the worker publishes about itself. Pass
+    ``version=None`` to model a task that is healthy but has not yet
+    published — the poller treats that as not-ready.
+    """
+    tags: list[dict[str, str]] = []
+    if version is not None:
+        tags.append({"key": "wool.version", "value": version})
+    if secure is not None:
+        tags.append({"key": "wool.secure", "value": "true" if secure else "false"})
+
+    task: dict[str, Any] = {
         "taskArn": _task_arn(task_id),
         "lastStatus": status,
         "healthStatus": health,
@@ -42,6 +60,9 @@ def _running_task(
             }
         ],
     }
+    if tags:
+        task["tags"] = tags
+    return task
 
 
 class _FakeEcsClient:
@@ -50,11 +71,17 @@ class _FakeEcsClient:
     def __init__(self) -> None:
         self.task_arns: list[str] = []
         self.tasks: list[dict[str, Any]] = []
+        #: ``include`` values seen by ``describe_tasks``, so a test can
+        #: assert tags were actually requested.
+        self.describe_includes: list[list[str] | None] = []
 
     def list_tasks(self, **_kwargs):
         return {"taskArns": list(self.task_arns)}
 
-    def describe_tasks(self, *, cluster: str, tasks: list[str]):
+    def describe_tasks(
+        self, *, cluster: str, tasks: list[str], include: list[str] | None = None
+    ):
+        self.describe_includes.append(include)
         wanted = set(tasks)
         return {
             "tasks": [t for t in self.tasks if t["taskArn"] in wanted],
@@ -158,6 +185,289 @@ class TestEcsDiscovery:
         assert events[0].type == "worker-added"
         assert events[0].metadata.address == "10.0.0.5:4242"
         assert len(resolved) == 1
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_surface_the_metadata_the_worker_published(self):
+        """Test that version and secure come from the task's tags.
+
+        Given:
+            A healthy task tagged with the wool version and TLS flag its
+            worker published.
+        When:
+            poll_once is awaited.
+        Then:
+            It should advertise exactly those values rather than a
+            default — wool admits a worker only when its version and
+            secure flag match the proxy, so anything synthesized here
+            silently rejects the whole fleet.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id, version="9.9.9", secure=True)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+
+        # Act
+        _events, resolved = await discovery.poll_once()
+
+        # Assert
+        metadata = next(iter(resolved.values()))
+        assert metadata.version == "9.9.9"
+        assert metadata.secure is True
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_treat_a_task_without_a_secure_tag_as_insecure(
+        self,
+    ):
+        """Test that an absent secure tag means an insecure worker.
+
+        Given:
+            A healthy task that published its version but no TLS flag.
+        When:
+            poll_once is awaited.
+        Then:
+            It should advertise ``secure=False``, matching a worker that
+            configured no credentials, so a plaintext proxy still admits
+            it.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id, secure=None)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+
+        # Act
+        _events, resolved = await discovery.poll_once()
+
+        # Assert
+        assert next(iter(resolved.values())).secure is False
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_not_surface_a_task_that_has_not_published(self):
+        """Test that a healthy but unpublished task is not advertised.
+
+        Given:
+            A RUNNING and HEALTHY task carrying no metadata tags, as in
+            the window between its health check passing and its own
+            TagResource call landing.
+        When:
+            poll_once is awaited.
+        Then:
+            It should advertise nothing — "has not published yet" is not
+            "has default metadata", and conflating them is what made
+            every worker unadmittable.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id, version=None)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+
+        # Act
+        events, resolved = await discovery.poll_once()
+
+        # Assert
+        assert events == []
+        assert resolved == {}
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_request_tags_from_describe_tasks(self):
+        """Test that DescribeTasks is asked for tags.
+
+        Given:
+            A discovery with one running task.
+        When:
+            poll_once is awaited.
+        Then:
+            It should call describe_tasks with ``include=["TAGS"]`` —
+            without it ECS omits tags entirely, every task reads as
+            unpublished, and no worker is ever advertised.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+
+        # Act
+        await discovery.poll_once()
+
+        # Assert
+        assert client.describe_includes == [["TAGS"]]
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_advertise_the_workers_channel_options(self):
+        """Test that advertised metadata carries the shared channel options.
+
+        Given:
+            A healthy, published task. The worker serves under
+            ``worker_grpc_options()`` — a 60s keepalive cadence chosen
+            to clear the server's ping floor — and wool builds the
+            dispatch channel from ``metadata.options``.
+        When:
+            poll_once is awaited.
+        Then:
+            The advertised options should carry the same cadence, so the
+            client actually pings at the rate the worker was configured
+            for rather than wool's default that sits on the floor.
+        """
+        # Arrange
+        from cfdb.workflows.grpc_options import KEEPALIVE_TIME_MS
+
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+
+        # Act
+        _events, resolved = await discovery.poll_once()
+
+        # Assert
+        metadata = next(iter(resolved.values()))
+        assert metadata.options.keepalive_time_ms == KEEPALIVE_TIME_MS
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_keep_a_published_worker_when_tags_go_missing(
+        self,
+    ):
+        """Test that a transient tag miss does not flap a known worker.
+
+        Given:
+            A task that was advertised with published tags on one poll,
+            whose next describe response omits the tags — the signature
+            of the eventually-consistent ``include=["TAGS"]`` secondary
+            lookup, not of the pre-publish window.
+        When:
+            poll_once is awaited again.
+        Then:
+            The worker should stay advertised with its last-read
+            metadata and no ``worker-dropped`` event should be emitted,
+            mirroring the poller's retain-on-transient-failure posture
+            for the list/describe calls themselves.
+        """
+        # Arrange
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id, version="9.9.9", secure=True)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+        await discovery.poll_once()
+        untagged = _running_task(task_id, version=None)
+        untagged["taskArn"] = client.task_arns[0]
+        client.tasks = [untagged]
+
+        # Act
+        events, resolved = await discovery.poll_once()
+
+        # Assert
+        assert events == []
+        metadata = next(iter(resolved.values()))
+        assert metadata.version == "9.9.9"
+        assert metadata.secure is True
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_warn_when_no_task_is_advertisable(self, caplog):
+        """Test that a fleet-wide zero is loud rather than silent.
+
+        Given:
+            Tasks that exist but none advertisable — every one healthy
+            yet unpublished, as a missing ecs:TagResource grant or an
+            old worker image produces fleet-wide.
+        When:
+            poll_once is awaited twice in quick succession.
+        Then:
+            It should log one rate-limited warning naming the count, so
+            the incident is a grep on the API logs instead of a bisect
+            of NoWorkersAvailable causes — and not repeat it on the
+            immediately following poll.
+        """
+        # Arrange
+        import logging
+
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [_running_task(task_id, version=None)]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cfdb.workflows.discovery"):
+            await discovery.poll_once()
+            await discovery.poll_once()
+
+        # Assert
+        warnings = [
+            record
+            for record in caplog.records
+            if "none advertisable" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "1 task(s)" in warnings[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_poll_once_should_advertise_metadata_wools_gate_admits(self):
+        """Test that a real worker's published version passes wool's gate.
+
+        Given:
+            A task tagged with the wool protocol version an actual
+            worker would publish (``wool.protocol.__version__``).
+        When:
+            poll_once resolves it into advertised metadata.
+        Then:
+            wool's version-compatibility predicate should admit it
+            against a proxy of the same version — the contract whose
+            silent violation (an invented ``"0"``) rejected the entire
+            fleet while every narrower test stayed green.
+        """
+        # Arrange
+        import wool.protocol
+        from wool.runtime.worker.proxy import is_version_compatible, parse_version
+
+        client = _FakeEcsClient()
+        task_id = uuid.uuid4().hex
+        client.task_arns = [_task_arn(task_id)]
+        client.tasks = [
+            _running_task(task_id, version=wool.protocol.__version__)
+        ]
+        client.tasks[0]["taskArn"] = client.task_arns[0]
+        discovery = EcsDiscovery(
+            cluster="c", task_definition_family="worker", client=client
+        )
+
+        # Act
+        _events, resolved = await discovery.poll_once()
+
+        # Assert
+        advertised = parse_version(next(iter(resolved.values())).version)
+        proxy_side = parse_version(wool.protocol.__version__)
+        assert advertised is not None
+        assert is_version_compatible(proxy_side, advertised)
 
     @pytest.mark.asyncio
     async def test_poll_once_with_unhealthy_task_filtered(self):
@@ -552,6 +862,48 @@ class TestEcsDiscoveryAgainstMoto:
         assert ip is not None
         parts = ip.split(".")
         assert len(parts) == 4 and all(p.isdigit() for p in parts)
+
+    def test_tag_resource_should_round_trip_through_describe_tasks(
+        self, moto_ecs_env_for_discovery
+    ):
+        """Test that the publish and read halves agree on the wire shape.
+
+        Given:
+            A moto-backed task tagged with exactly the request shape
+            ``worker_main._publish_worker_metadata`` sends — lowercase
+            ``key``/``value`` entries (ECS's shape, unlike EC2's
+            ``Key``/``Value``), which a pure ``Mock`` accepts in any
+            spelling.
+        When:
+            The same discovery client reads it back through
+            ``_describe_tasks_batched``.
+        Then:
+            The tags should surface on the described task, proving both
+            halves of the wool.version/wool.secure contract against a
+            real boto3 surface rather than against each other's mocks.
+        """
+        # Arrange
+        arn = moto_ecs_env_for_discovery["task_arns"][0]
+        client = moto_ecs_env_for_discovery["client"]
+        client.tag_resource(
+            resourceArn=arn,
+            tags=[
+                {"key": "wool.version", "value": "1.2.3"},
+                {"key": "wool.secure", "value": "true"},
+            ],
+        )
+        discovery = EcsDiscovery(
+            cluster=moto_ecs_env_for_discovery["cluster"],
+            task_definition_family=moto_ecs_env_for_discovery["family"],
+            client=client,
+        )
+
+        # Act
+        described = discovery._describe_tasks_batched([arn])[0]
+
+        # Assert
+        tags = {t["key"]: t["value"] for t in described.get("tags", [])}
+        assert tags == {"wool.version": "1.2.3", "wool.secure": "true"}
 
 
 class TestWoolReduceContract:
@@ -1163,21 +1515,20 @@ class TestEcsDiscoveryGetstateNonMutation:
 class TestEcsDiscoveryPickleEdges:
     """Completeness/edge coverage for the pickle round-trip (issue #54)."""
 
-    def test___setstate___should_preserve_poll_interval_and_version(
+    def test___setstate___should_preserve_poll_interval_and_worker_port(
         self, monkeypatch
     ):
-        """Test that non-default ``_poll_interval`` / ``_version`` survive.
+        """Test that non-default tuning config survives the round-trip.
 
         Given:
             An EcsDiscovery built with a non-default ``poll_interval`` and
-            ``version``, with ``build_ecs_client`` stubbed.
+            ``worker_port``, with ``build_ecs_client`` stubbed.
         When:
             The instance is cloudpickle round-tripped.
         Then:
-            Both ``_poll_interval`` and ``_version`` survive — config the
-            in-diff setstate test does not assert — confirming the full
-            config payload (not just cluster/family/port) crosses the
-            boundary.
+            Both survive — config the in-diff setstate test does not
+            assert — confirming the full config payload, not just
+            cluster and family, crosses the boundary.
         """
         # Arrange
         monkeypatch.setattr(
@@ -1189,7 +1540,7 @@ class TestEcsDiscoveryPickleEdges:
             task_definition_family="worker",
             client=_FakeEcsClient(),
             poll_interval=12.5,
-            version="cfdb-1.2.3",
+            worker_port=50999,
         )
 
         # Act
@@ -1197,7 +1548,7 @@ class TestEcsDiscoveryPickleEdges:
 
         # Assert
         assert restored._poll_interval == 12.5
-        assert restored._version == "cfdb-1.2.3"
+        assert restored._worker_port == 50999
 
     def test___setstate___should_rebuild_with_none_endpoint_and_region(
         self, monkeypatch

--- a/tests/test_workflows/test_worker_lan.py
+++ b/tests/test_workflows/test_worker_lan.py
@@ -4,9 +4,20 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from cfdb.workflows import worker_lan
+from cfdb.workflows.constants import TLS_IDENTITY_ENV
+
+
+class _StopServe(Exception):
+    """Sentinel raised from the patched credentials builder.
+
+    ``serve`` builds credentials as its very first statement, so raising
+    here exits the coroutine before any pool, discovery, or signal
+    machinery is touched — the call arguments are the entire subject.
+    """
 
 
 def _invoke(args: list[str]) -> tuple[int, dict[str, object]]:
@@ -236,3 +247,67 @@ def test_backpressure_bound_factory_should_survive_cloudpickle():
 
     # Assert
     assert restored.keywords["backpressure"].threshold == 1
+
+
+class TestServeIdentityWiring:
+    @pytest.mark.asyncio
+    async def test_serve_should_pass_the_configured_identity_to_the_credentials_builder(
+        self, mocker, monkeypatch
+    ):
+        """Test that the LAN pool's workers get the environment identity.
+
+        Given:
+            ``CFDB_WORKER_TLS_IDENTITY`` set to a non-default name.
+        When:
+            ``serve`` builds its worker credentials.
+        Then:
+            It should pass that identity through, because each pooled
+            worker dials its own subprocess to drain it and verifies an
+            identity-only certificate on that channel — dropping the
+            kwarg turns every graceful drain into a force-reap that
+            loses in-flight work, with no TLS error anywhere.
+        """
+        # Arrange
+        monkeypatch.setenv(TLS_IDENTITY_ENV, "custom-name")
+        build = mocker.patch.object(
+            worker_lan, "build_worker_credentials", side_effect=_StopServe
+        )
+
+        # Act
+        with pytest.raises(_StopServe):
+            await worker_lan.serve(
+                namespace="ns", workers=1, tls_ca="/ca", tls_cert="/c", tls_key="/k"
+            )
+
+        # Assert
+        build.assert_called_once_with("/ca", "/c", "/k", identity="custom-name")
+
+    @pytest.mark.asyncio
+    async def test_serve_should_verify_by_address_when_identity_opted_out(
+        self, mocker, monkeypatch
+    ):
+        """Test that the empty-string opt-out reaches the pool's workers.
+
+        Given:
+            ``CFDB_WORKER_TLS_IDENTITY`` exported as the empty string,
+            the documented opt-out.
+        When:
+            ``serve`` builds its worker credentials.
+        Then:
+            It should pass ``identity=None`` so verification falls back
+            to the dialed address on both sides of the channel.
+        """
+        # Arrange
+        monkeypatch.setenv(TLS_IDENTITY_ENV, "")
+        build = mocker.patch.object(
+            worker_lan, "build_worker_credentials", side_effect=_StopServe
+        )
+
+        # Act
+        with pytest.raises(_StopServe):
+            await worker_lan.serve(
+                namespace="ns", workers=1, tls_ca="/ca", tls_cert="/c", tls_key="/k"
+            )
+
+        # Assert
+        build.assert_called_once_with("/ca", "/c", "/k", identity=None)

--- a/tests/test_workflows/test_worker_main.py
+++ b/tests/test_workflows/test_worker_main.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 import pytest
+import pytest_asyncio
+from botocore.exceptions import ClientError
 from click.testing import CliRunner
 
 from cfdb.workflows import worker_main
+from cfdb.workflows.constants import TLS_IDENTITY_ENV
 
 
 def _invoke(args: list[str]) -> tuple[int, dict[str, object]]:
@@ -265,3 +269,283 @@ class TestServeBackpressureWiring:
 
         # Assert
         assert local_worker.call_args.kwargs["backpressure"] is None
+
+
+#: Task ARN the fake ECS metadata endpoint reports.
+_TASK_ARN = "arn:aws:ecs:us-east-2:605134458779:task/cfdb-cluster/abc123"
+
+
+@pytest_asyncio.fixture()
+async def ecs_metadata_endpoint():
+    """Serve a stand-in for the ECS task metadata endpoint.
+
+    Yields the base URL to export as ``ECS_CONTAINER_METADATA_URI_V4``.
+    A real HTTP server rather than a patched fetch, so the request and
+    the ``TaskARN`` parsing are both exercised.
+
+    A loopback socket makes these tests borderline integration by the
+    letter of the test guide, but they stay in the unit suite
+    deliberately: the server stands in for a link-local endpoint that
+    only exists inside an ECS task (there is no real counterpart to
+    integrate with off ECS), everything else in the tests is mocked,
+    and the alternative — patching ``aiohttp.ClientSession`` — would
+    un-test the two things this fixture exists to exercise.
+    """
+    from aiohttp import web
+
+    async def _task(_request: web.Request) -> web.Response:
+        return web.json_response({"TaskARN": _TASK_ARN, "Cluster": "cfdb-cluster"})
+
+    app = web.Application()
+    app.router.add_get("/task", _task)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        await runner.cleanup()
+
+
+def _arrange_started_worker(mocker, *, version: str = "1.2.3", secure: bool = False):
+    """Patch ``wool.LocalWorker`` with one that starts and reports metadata."""
+    worker_instance = mocker.Mock()
+    worker_instance.start = mocker.AsyncMock()
+    worker_instance.stop = mocker.AsyncMock()
+    worker_instance.metadata = mocker.Mock(version=version, secure=secure)
+    mocker.patch.object(
+        worker_main.wool, "LocalWorker", return_value=worker_instance
+    )
+    return worker_instance
+
+
+class TestServeMetadataPublishing:
+    @pytest.mark.asyncio
+    async def test_serve_should_not_publish_metadata_when_not_running_on_ecs(
+        self, mocker, monkeypatch
+    ):
+        """Test that a worker off ECS makes no tagging call.
+
+        Given:
+            ``ECS_CONTAINER_METADATA_URI_V4`` unset, as on a laptop.
+        When:
+            ``serve`` runs to its max-lifetime exit.
+        Then:
+            No ECS client is built and nothing is tagged, so running the
+            entrypoint locally is unaffected by the publish step.
+        """
+        # Arrange
+        monkeypatch.delenv("ECS_CONTAINER_METADATA_URI_V4", raising=False)
+        _arrange_started_worker(mocker)
+        build_client = mocker.patch.object(worker_main, "build_ecs_client")
+
+        # Act
+        await worker_main.serve(
+            worker_port=0, health_port=0, max_lifetime_seconds=0.01
+        )
+
+        # Assert
+        build_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_serve_should_publish_the_metadata_the_worker_authored(
+        self, mocker, monkeypatch, ecs_metadata_endpoint
+    ):
+        """Test that the worker tags its own task with wool's metadata.
+
+        Given:
+            A running ECS task metadata endpoint and a worker whose wool
+            metadata reports a version and a TLS flag.
+        When:
+            ``serve`` runs to its max-lifetime exit.
+        Then:
+            It should tag its own task ARN with exactly those values —
+            they are what ``EcsDiscovery`` reads back, and wool admits
+            the worker only if they are right.
+        """
+        # Arrange
+        monkeypatch.setenv("ECS_CONTAINER_METADATA_URI_V4", ecs_metadata_endpoint)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+        _arrange_started_worker(mocker, version="9.9.9", secure=True)
+        client = mocker.Mock()
+        build_client = mocker.patch.object(
+            worker_main, "build_ecs_client", return_value=client
+        )
+
+        # Act
+        await worker_main.serve(
+            worker_port=0, health_port=0, max_lifetime_seconds=0.01
+        )
+
+        # Assert
+        client.tag_resource.assert_called_once_with(
+            resourceArn=_TASK_ARN,
+            tags=[
+                {"key": "wool.version", "value": "9.9.9"},
+                {"key": "wool.secure", "value": "true"},
+            ],
+        )
+        # With AWS_REGION unset the region comes from the task ARN
+        # itself, so publishing cannot die of NoRegionError on a task
+        # definition that lost the variable.
+        build_client.assert_called_once_with(
+            endpoint_url=None, region_name="us-east-2"
+        )
+
+    @pytest.mark.asyncio
+    async def test_serve_should_raise_when_metadata_cannot_be_published(
+        self, mocker, monkeypatch, ecs_metadata_endpoint
+    ):
+        """Test that an unpublishable worker exits instead of serving.
+
+        Given:
+            A metadata endpoint but an ECS client whose ``tag_resource``
+            is throttled on every attempt, exhausting the retry budget.
+        When:
+            ``serve`` runs with a two-attempt publish budget.
+        Then:
+            It should retry the transient failure once and then
+            propagate rather than serve, because a worker whose metadata
+            never lands is invisible to the API and would hold a Fargate
+            slot without being able to receive work.
+        """
+        # Arrange
+        monkeypatch.setenv("ECS_CONTAINER_METADATA_URI_V4", ecs_metadata_endpoint)
+        _arrange_started_worker(mocker)
+        client = mocker.Mock()
+        client.tag_resource.side_effect = ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "slow down"}},
+            "TagResource",
+        )
+        mocker.patch.object(worker_main, "build_ecs_client", return_value=client)
+
+        # Act & assert
+        with pytest.raises(ClientError, match="Throttling"):
+            await worker_main.serve(
+                worker_port=0,
+                health_port=0,
+                max_lifetime_seconds=0.01,
+                publish_attempts=2,
+                publish_backoff_seconds=0.0,
+            )
+        assert client.tag_resource.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_serve_should_raise_without_retrying_when_tagging_is_denied(
+        self, mocker, monkeypatch, ecs_metadata_endpoint, caplog
+    ):
+        """Test that a missing ecs:TagResource grant fails in one attempt.
+
+        Given:
+            An ECS client whose ``tag_resource`` raises AccessDenied —
+            the signature of a workers stack deployed without the
+            ``ecs:TagResource`` grant.
+        When:
+            ``serve`` runs with the full five-attempt budget available.
+        Then:
+            It should raise after a single attempt — authorization
+            failures are permanent, so burning the backoff budget only
+            delays the exit — and the error log should name the grant
+            and the stack that provides it, so the operator's first
+            grep answers "what do I deploy".
+        """
+        # Arrange
+        monkeypatch.setenv("ECS_CONTAINER_METADATA_URI_V4", ecs_metadata_endpoint)
+        _arrange_started_worker(mocker)
+        client = mocker.Mock()
+        client.tag_resource.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+            "TagResource",
+        )
+        mocker.patch.object(worker_main, "build_ecs_client", return_value=client)
+
+        # Act & assert
+        with caplog.at_level(logging.ERROR, logger=worker_main.__name__):
+            with pytest.raises(ClientError, match="AccessDenied"):
+                await worker_main.serve(
+                    worker_port=0,
+                    health_port=0,
+                    max_lifetime_seconds=0.01,
+                    publish_backoff_seconds=0.0,
+                )
+        assert client.tag_resource.call_count == 1
+        assert "ecs:TagResource" in caplog.text
+        assert "workers.yml" in caplog.text
+
+
+class _StopAtCredentials(Exception):
+    """Sentinel raised from the patched credentials builder.
+
+    ``serve`` builds credentials as its very first statement, so raising
+    here exits the coroutine before the signal, health, worker, or
+    publish machinery is touched — the call arguments are the entire
+    subject.
+    """
+
+
+class TestServeIdentityWiring:
+    @pytest.mark.asyncio
+    async def test_serve_should_pass_the_configured_identity_to_the_credentials_builder(
+        self, mocker, monkeypatch
+    ):
+        """Test that the ECS worker gets the environment identity.
+
+        Given:
+            ``CFDB_WORKER_TLS_IDENTITY`` set to a non-default name.
+        When:
+            ``serve`` builds its worker credentials.
+        Then:
+            It should pass that identity through, because wool's
+            graceful-stop RPC dials this worker's own subprocess and
+            verifies an identity-only certificate on that channel —
+            dropping the kwarg turns every graceful drain into a
+            force-reap that loses in-flight work, with no TLS error
+            anywhere.
+        """
+        # Arrange
+        monkeypatch.setenv(TLS_IDENTITY_ENV, "custom-name")
+        build = mocker.patch.object(
+            worker_main, "build_worker_credentials", side_effect=_StopAtCredentials
+        )
+
+        # Act
+        with pytest.raises(_StopAtCredentials):
+            await worker_main.serve(
+                worker_port=0, health_port=0, tls_ca="/ca", tls_cert="/c", tls_key="/k"
+            )
+
+        # Assert
+        build.assert_called_once_with("/ca", "/c", "/k", identity="custom-name")
+
+    @pytest.mark.asyncio
+    async def test_serve_should_verify_by_address_when_identity_opted_out(
+        self, mocker, monkeypatch
+    ):
+        """Test that the empty-string opt-out reaches the ECS worker.
+
+        Given:
+            ``CFDB_WORKER_TLS_IDENTITY`` exported as the empty string,
+            the documented opt-out.
+        When:
+            ``serve`` builds its worker credentials.
+        Then:
+            It should pass ``identity=None`` so verification falls back
+            to the dialed address on both sides of the channel.
+        """
+        # Arrange
+        monkeypatch.setenv(TLS_IDENTITY_ENV, "")
+        build = mocker.patch.object(
+            worker_main, "build_worker_credentials", side_effect=_StopAtCredentials
+        )
+
+        # Act
+        with pytest.raises(_StopAtCredentials):
+            await worker_main.serve(
+                worker_port=0, health_port=0, tls_ca="/ca", tls_cert="/c", tls_key="/k"
+            )
+
+        # Assert
+        build.assert_called_once_with("/ca", "/c", "/k", identity=None)


### PR DESCRIPTION
## Summary

Turn on enforced mutual TLS for the API↔worker gRPC dispatch channel, and fix the reason it could never have worked: `EcsDiscovery` was inventing worker metadata that only the worker can know.

**Identity verification.** TLS checks a server's certificate against the address the client dialed, which nothing here can satisfy — `EcsDiscovery` reaches each worker at the awsvpc IP assigned at launch, and a containerized local worker answers on a bridge address. wool 0.13's `WorkerCredentials.as_provider(identity=…)` sets `grpc.ssl_target_name_override`, so the client verifies against a fixed logical name instead. Chain and SAN verification both still run; only the matched name changes.

**Worker-published metadata.** That alone was not sufficient. wool gates worker admission on two `WorkerMetadata` fields before any connection is attempted, and `EcsDiscovery` synthesized both: `version` defaulted to `"0"`, which fails `client <= server` against any real version, and `secure` was omitted so it defaulted to `False`, which a credentialed proxy rejects. So the API admitted no ECS workers at all — plaintext included. The fix inverts the flow to match wool's model: after start, `worker_main` tags its own ECS task with the version and TLS flag wool authored for it, and the poller reads them back with `DescribeTasks(include=["TAGS"])`. ECS keeps supplying liveness; the worker now supplies identity.

**This is live, not theoretical.** The version half was latent until wool 0.12 moved the admission check into the loop that consumes every discovery backend. #84 shipped that bump, and dev's preprocessing pipeline has been down since: a dispatch sits `pending` across every retry, twelve worker tasks were `RUNNING`/`HEALTHY` with `tags=[]` while the API reported no capacity. Those orphans were stopped manually; this PR is the fix.

**Roles are per-connection, not per-process.** The identity is not the API's alone. `wool.LocalWorker.stop` dials the worker's own subprocess to drain it, and on that one connection the worker is a client verifying a certificate whose only SAN may be the logical identity. Both stacks therefore carry `WorkerTlsIdentity` and must agree on it; a drift drains by force-reap and loses in-flight work with nothing naming TLS.

**Asymmetric certificates.** The worker leaf gets `serverAuth,clientAuth` plus the identity SAN; the API gets `clientAuth` and no SAN at all. Withholding `serverAuth` means the TLS stack itself refuses to let the API's certificate terminate a server side — closing the hole where an identity SAN on both leaves made the API's own certificate a valid worker certificate.

Closes #85
Closes #90

## Proposed changes

### Verify worker certificates against a logical identity

`build_worker_credentials` gains an `identity` and adapts its result with `as_provider` when one is given. Identity sits outside the all-or-none cert validation — it refines a complete configuration rather than forming a fourth required part of one, so an identity with no certificates still yields the plaintext path. `CFDB_WORKER_TLS_IDENTITY` defaults to `cfdb-worker`; the empty string opts back out to address verification. Every process that dials reads it, and there is deliberately no env-reading wrapper: both entrypoints resolve cert paths through click options where a CLI flag overrides the environment, which a wrapper reading `os.getenv` would silently drop.

### Publish worker metadata to ECS task tags

`worker_main` reads `TaskARN` from `${ECS_CONTAINER_METADATA_URI_V4}/task` and tags its own task with `wool.version` and `wool.secure` from `LocalWorker.metadata`. Publishing is skipped when that env var is absent, so local runs and the LAN path are untouched. A worker that cannot publish **exits** after bounded retries rather than serving: it could never be discovered, so it would hold a Fargate slot and count against `ECS_MAX_WORKERS` while unable to receive work.

The region falls back to the task ARN's own region segment when `AWS_REGION` is unset — Fargate injects no region, and boto3 would otherwise raise `NoRegionError` outside the retry loop, killing every worker seconds after launch. Every transiently-failing step (metadata fetch, client construction, `TagResource`) now sits inside the retry loop, since a fleet cold start is when all three are busiest. Only transients retry; an `AccessDenied` fails in one attempt naming the missing grant and the stack that provides it. The backoff races the stop event, and the budget is configurable via `CFDB_WORKER_PUBLISH_*`.

`EcsDiscovery` reads those tags and drops the `version` constructor parameter entirely. A task that is `RUNNING`/`HEALTHY` but has not yet published is deliberately not advertised — but that applies only to tasks never seen published, since ECS reads tags through a secondary lookup that is not strongly consistent; a task that published before keeps its last-read metadata rather than flapping out of the pool. When tasks exist but none is advertisable, the poller says so in a rate-limited warning. Channel options now come from the shared `worker_grpc_options()` rather than wool's defaults, so the keepalive cadence actually reaches the client.

### Split the certificate leaves by role

`generate-worker-certs.sh` gains `--identity` (default `cfdb-worker`) and mints per-leaf SANs and EKUs, with the identity as the worker leaf's common name so `openssl x509 -text` reads consistently. Empty, non-DNS-safe, and IP-literal identities are rejected — an IP would be minted as `DNS:<ip>`, which gRPC never matches against an address.

### Infrastructure

`backend.yml` and `workers.yml` both gain `WorkerTlsIdentity`, rendered only under each stack's mTLS condition, with an `AllowedPattern` that rejects IP literals. `workers.yml` also gains `AWS_REGION` and a new `BackendClusterName` parameter that scopes the `ecs:TagResource` grant to this environment's own cluster, with an `aws:TagKeys` condition confining it to the two `wool.*` keys — dev and prod share an account and region, and these tags are load-bearing for admission, so an account-wide grant would let a compromised worker empty the other environment's pool.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestBuildWorkerCredentials` | Complete cert config and no identity | `build_worker_credentials` is called | Returns wool's credentials unadapted | Existing behaviour preserved |
| 2 | `TestBuildWorkerCredentials` | Complete cert config and an identity | Built with that identity | Returns the provider from `as_provider` | Identity adaptation |
| 3 | `TestBuildWorkerCredentials` | An empty-string identity | Built | Returns plain credentials | Documented opt-out |
| 4 | `TestBuildWorkerCredentials` | No cert paths but an identity | Built | Returns `None` | Identity alone never enables mTLS |
| 5 | `TestServeIdentityWiring` (ECS, LAN) | A non-default identity in the environment | `serve` builds credentials | Passes that identity through | Both entrypoints pinned; deleting the kwarg previously left the suite green |
| 6 | `TestServeIdentityWiring` (ECS, LAN) | The empty-string opt-out | `serve` builds credentials | Passes `identity=None` | Opt-out reaches both sides |
| 7 | `TestIdentityMutualTls` | A worker whose only SAN is the identity | A routine is dispatched over real gRPC | Returns its result | Handshake succeeds via the override |
| 8 | `TestIdentityMutualTls` | The same certificates, no identity | A routine is dispatched | Fails hostname verification | The pass is carried by the identity |
| 9 | `TestEcsDiscoveryDispatch` | A real mTLS worker resolved from tags a real worker authored | A credentialed pool dispatches through discovery | Returns its result | The admission gate and identity dial together — the composition that shipped broken |
| 10 | `TestEcsDiscoveryDispatch` | The same worker, `wool.secure` reading false | The same pool dispatches | Never admits the worker | The rejecting branch; makes the tag load-bearing |
| 11 | `TestLocalWorkerMetadata` | A real started `LocalWorker` | Its authored version is checked against wool's predicate | Parses and is compatible | The producing end of the version contract |
| 12 | `TestEcsDiscovery` | A healthy task tagged with a version and TLS flag | `poll_once` runs | Advertises those values | Metadata comes from the worker |
| 13 | `TestEcsDiscovery` | A healthy task with no secure tag | `poll_once` runs | Advertises `secure=False` | Absent flag means insecure |
| 14 | `TestEcsDiscovery` | A healthy task with no metadata tags | `poll_once` runs | Advertises nothing | Unpublished is not ready |
| 15 | `TestEcsDiscovery` | A discovery with one running task | `poll_once` runs | Calls `describe_tasks` with `include=["TAGS"]` | Tags are actually requested |
| 16 | `TestEcsDiscovery` | A previously-published task whose tags go missing | `poll_once` runs again | Keeps advertising it | Eventual consistency does not flap the fleet |
| 17 | `TestEcsDiscovery` | Tasks exist but none is advertisable | `poll_once` runs twice | Warns once, rate-limited | A fleet-wide zero is not silent |
| 18 | `TestEcsDiscovery` | A task tagged with wool's real protocol version | `poll_once` resolves it | Satisfies wool's compatibility predicate | The contract the original defect violated |
| 19 | `TestEcsDiscovery` | A healthy published task | `poll_once` runs | Advertises the shared channel options | Keepalive cadence reaches the client |
| 20 | `TestEcsDiscoveryAgainstMoto` | A real moto task tagged through boto3 | Read back through the discovery client | Tags round-trip | ECS's lowercase key/value shape |
| 21 | `TestServeMetadataPublishing` | `ECS_CONTAINER_METADATA_URI_V4` unset | `serve` starts a worker | No ECS call is made | Local use unaffected |
| 22 | `TestServeMetadataPublishing` | A metadata endpoint returning a `TaskARN`, `AWS_REGION` unset | `serve` starts a worker | Tags that ARN, region derived from it | Publishing works without an injected region |
| 23 | `TestServeMetadataPublishing` | `tag_resource` throttled every attempt | `serve` runs with a two-attempt budget | Retries once, then raises | An unpublishable worker exits |
| 24 | `TestServeMetadataPublishing` | `tag_resource` raising AccessDenied | `serve` runs with the full budget | Raises after one attempt, naming the grant and stack | Permanent errors fail fast and diagnosably |
| 25 | CloudFormation | The workers template | Task-role policies are read | `ecs:TagResource` granted, scoped to the cluster and the two `wool.*` keys | Publishing is permitted without cross-environment reach |
| 26 | CloudFormation | The workers container definition | Environment is read | Declares `AWS_REGION` | The region the publish path needs |
| 27 | CloudFormation | Both templates | Identity parameters are compared | Defaults agree with the application constant, render only under mTLS, and reject IP literals | Drift fails at deploy, not at runtime |
| 28 | CloudFormation | The cert generator script | Its `IDENTITY` default is extracted | Equals the application constant | The fourth copy is pinned |

## Deployment prerequisites

Ordered, and the first two are not optional:

1. **Deploy the workers stack before this image reaches an environment.** The worker exits when it cannot tag its task, and the `ecs:TagResource` grant lives in `workers.yml`, which the CI role cannot deploy (`cfdb-deploy` holds no `cloudformation:*`). Merging without this ships a fleet that exits at startup while CI reports green. The forward order is harmless — an old image ignores the extra permission. Pass the new `BackendClusterName=cfdb-backend-<env>-cluster`.
2. **Expect a dispatch gap while workers cycle.** wool admits a worker only when the API's version is `<=` the worker's, enforced as a discovery filter, and the moving-tag pipeline rolls the API first. Jobs stay `pending` and the durable scheduler drains them once fresh workers spawn. To make it a non-event, drain the fleet before promoting.
3. **mTLS stays off.** This PR makes it possible, not enabled; both environments keep empty cert ARNs.
