### PR TITLE
Reject a workers-stack deploy that omits BackendClusterName, and correct the deploy runbook — Closes #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ Two environments share the account `605134458779` and region `us-east-2`. Every 
 
 Note the templates' parameter defaults (`cfdb.vis-api.link`, `10.2.0.0/21`, `cfdb-tg`) match *neither* live environment — they exist only so a bare `cloudformation deploy` is not rejected for missing parameters. Always pass explicit overrides.
 
+One parameter deliberately breaks that convention: `workers.yml`'s `BackendClusterName` has **no default**, so a deploy that omits it is rejected outright. The convention rests on a wrong value failing visibly — a wrong `DomainName` is the wrong DNS, a wrong `TargetGroupName` collides — and that does not hold for a value which scopes an IAM grant. A placeholder there deploys cleanly, attaches `ecs:TagResource` to a cluster that does not exist, and leaves every worker failing the same `AccessDenied` the grant exists to prevent, with `UPDATE_COMPLETE` on screen. CloudFormation reuses stored parameter values on update, so it only has to be supplied on a stack's first deploy.
+
 #### Deploying the prod stacks
 
-One-time, run by an IAM-capable principal (not the `cfdb-deploy` CI role, which has no `cloudformation:*` or `iam:PassRole`). The CIDRs deliberately do not overlap dev's so the two VPCs can be peered later if needed.
+One-time, run by a principal holding `cloudformation:*`, `iam:PassRole`, and `iam:PutRolePolicy` — see [Which principal can run a privileged deploy](#which-principal-can-run-a-privileged-deploy), because the obvious candidate is not sufficient. The CIDRs deliberately do not overlap dev's so the two VPCs can be peered later if needed.
 
 ```bash
 aws cloudformation deploy --region us-east-2 \
@@ -172,7 +174,6 @@ Promotion re-tags rather than rebuilds, so prod runs bytes byte-identical to wha
 Prod requires this one-time setup before the first promotion:
 
 - A `prod` **GitHub Environment** with required reviewers, carrying two environment variables: `PROD_BACKEND_CLUSTER` (`cfdb-backend-prod-cluster`) and `PROD_BACKEND_SERVICE` (`cfdb-backend-prod-service`). The workflow fails its pre-flight before touching ECR if either is unset.
-- The `cfdb-deploy` CI role's `ecs:UpdateService`/`DescribeServices`/`DescribeTasks`/`ListTasks` extended to `cfdb-backend-prod-cluster` — it is currently scoped to the dev cluster only. It already holds the `ecr:BatchGetImage`/`PutImage` the re-tag needs. This role is created out of band, not in this repo.
 - Both ECR repositories accepting the `:prod` moving tag (see the mutability note above).
 
 As with dev, confirm after the first promotion that the running prod tasks reference `:prod`. If the task definitions still pin a `:<sha>`, promotions will report success while the live code never advances.
@@ -190,7 +191,7 @@ A few operational caveats of the moving-tag pattern:
 This needs two pieces of one-time configuration:
 
 - **GitHub repo variables** (in addition to the existing `AWS_IAM_ROLE` secret): `BACKEND_CLUSTER` (= `cfdb-backend-dev-cluster`) and `BACKEND_SERVICE` (= `cfdb-backend-dev-service`) — the ECS cluster and service the "Roll API service" / "Wait for API rollout" steps target via `aws ecs update-service`. These are GitHub **variables** (`vars.*`), not secrets. `backend.yml` now sets an explicit `ServiceName: ${AWS::StackName}-service` so `BACKEND_SERVICE` is the deterministic `<stack>-service` (e.g. `cfdb-backend-dev-service`) rather than a CloudFormation-generated name. **Caveat:** introducing that explicit name forces a ONE-TIME service replacement on the next backend `cloudformation deploy` (the service is recreated under the new name), after which `BACKEND_SERVICE` must be set to `<stack>-service`.
-- **One-time privileged bootstrap** (run once, by an IAM-capable principal — *not* the `cfdb-deploy` CI role, which lacks CloudFormation/PassRole). Flip both task definitions from a `:<sha>` image to the moving `:dev` tag with a single `cloudformation deploy` per stack, after which all steady-state deploys run on the CI role's existing permissions:
+- **One-time privileged bootstrap** (run once, by a principal holding `cloudformation:*`, `iam:PassRole`, and `iam:PutRolePolicy` — see [Which principal can run a privileged deploy](#which-principal-can-run-a-privileged-deploy); the `cfdb-deploy` CI role has none of them). Flip both task definitions from a `:<sha>` image to the moving `:dev` tag with a single `cloudformation deploy` per stack, after which all steady-state deploys run on the CI role's existing permissions:
 
 > **Failure mode if the bootstrap is skipped — the deploy reports green but ships nothing.** The CI workflow only pushes images and force-rolls the service; it never touches the task definition. Until both task defs reference `:dev`, the service keeps re-pulling whatever SHA the task def still pins, so every CI run will pass (`update-service` and `services-stable` both succeed) while the live code never advances. Always run the bootstrap once before relying on CI deploys, and confirm the running tasks reference `:dev` afterward. The "Verify live image is :dev" guard step below performs a best-effort check of this on every deploy and warns (without failing the build) when the running task's image is not `:dev`; it inspects `aws ecs describe-services` → `aws ecs describe-tasks` because the `cfdb-deploy` role intentionally lacks `ecs:DescribeTaskDefinition`.
 
@@ -213,7 +214,7 @@ aws cloudformation deploy \
 
 The `cloudformation/backend.yml` `ImageURI` and `cloudformation/workers.yml` `WorkerImageURI` parameters now **default** to these `:dev` URIs. Note what that default does and does not do: on a stack **UPDATE**, CloudFormation reuses each parameter's **previous** value, not its default — so the `:dev` default only governs a fresh stack **CREATE**. The point is that a later infra `cloudformation deploy` (an update) keeps whatever value the bootstrap set — `:dev` — rather than reverting to a stale SHA, so the moving-tag CI deploy stays the source of truth for what code runs. Because the task defs pin `:dev` rather than a SHA, task-definition-level traceability to a commit is intentionally given up; it is recovered by the immutable `:<sha>` tag pushed alongside `:dev` and by SHA-based rollback via ECR re-tag.
 
-> **One-time privileged bootstrap #2 — the `ecs:TagResource` grant, ordered BEFORE the image.** Worker images that publish their own metadata (the `wool.version`/`wool.secure` task tags `EcsDiscovery` requires) **exit at startup** when their task role lacks `ecs:TagResource` — deliberately, because an unpublishable worker can never be discovered and would otherwise hold a Fargate slot while unable to receive work. That grant lives in `cloudformation/workers.yml`, and the CI pipeline **cannot deploy it**: the `cfdb-deploy` role holds no `cloudformation:*`, so merging ships the tag-or-die image while the deployed task role still lacks the permission. The failure mode is a fleet that empties itself — every `RunTask` launches a worker that logs `ecs:TagResource denied … exiting` and dies, jobs sit `pending` to the 4 h deadline, and the API-side symptom is the same `NoWorkersAvailable` as every other failure in this section — while CI reports green. **Before the first image carrying metadata publishing reaches an environment**, an IAM-capable principal must run, per environment:
+> **One-time privileged bootstrap #2 — the `ecs:TagResource` grant, ordered BEFORE the image.** Worker images that publish their own metadata (the `wool.version`/`wool.secure` task tags `EcsDiscovery` requires) **exit at startup** when their task role lacks `ecs:TagResource` — deliberately, because an unpublishable worker can never be discovered and would otherwise hold a Fargate slot while unable to receive work. That grant lives in `cloudformation/workers.yml`, and the CI pipeline **cannot deploy it**: the `cfdb-deploy` role holds no `cloudformation:*`, so merging ships the tag-or-die image while the deployed task role still lacks the permission. The failure mode is a fleet that empties itself — every `RunTask` launches a worker that logs `ecs:TagResource denied … exiting` and dies, jobs sit `pending` to the 4 h deadline, and the API-side symptom is the same `NoWorkersAvailable` as every other failure in this section — while CI reports green. **Before the first image carrying metadata publishing reaches an environment**, a principal holding `cloudformation:*`, `iam:PassRole`, and `iam:PutRolePolicy` (see [below](#which-principal-can-run-a-privileged-deploy)) must run, per environment:
 >
 > ```bash
 > aws cloudformation deploy --region us-east-2 \
@@ -224,6 +225,21 @@ The `cloudformation/backend.yml` `ImageURI` and `cloudformation/workers.yml` `Wo
 > ```
 >
 > The forward order is harmless — an old image simply ignores the extra permission — so deploy the stack first, then merge. The same ordering applies to prod before the first promotion carrying this change (`promote-to-prod.yml` runs no CloudFormation either). Confirm with a worker log line `Published worker metadata to <arn>`; the denial, if you got the order wrong, is an `AccessDeniedException` in the worker's CloudWatch group and a rate-limited `none advertisable` warning in the API's.
+
+#### Which principal can run a privileged deploy
+
+Every bootstrap above needs `cloudformation:*`, **`iam:PassRole`**, and **`iam:PutRolePolicy`**. `PassRole` is required because any template change touching a container definition registers a new ECS task definition, which passes the task and execution roles; `PutRolePolicy` because these templates own inline policies on those roles.
+
+**`AWSReservedSSO_PowerUserAccess` is not sufficient**, and it is the trap: it is the role a cfdb operator actually holds, and it is *not* the `cfdb-deploy` CI role, so it reads as qualifying. But PowerUserAccess excludes `iam:*`. The deploy gets as far as building a changeset and then fails:
+
+```
+Resource handler returned message: "Access denied for operation 'Create TaskDefinition
+Access denied: User: arn:aws:sts::605134458779:assumed-role/AWSReservedSSO_PowerUserAccess_.../...
+is not authorized to perform: iam:PassRole on resource:
+arn:aws:iam::605134458779:role/cfdb-workers-dev-WorkerTaskRole-...
+```
+
+A refused attempt is safe: the stack rolls back to `UPDATE_ROLLBACK_COMPLETE` with nothing partially applied, so the cost is a round trip rather than a broken stack. Log in with an `AdministratorAccess`-equivalent permission set and re-run the identical command — these deploys are idempotent.
 
 **Tearing down the cache.** CloudFormation cannot delete a non-empty S3 bucket, so empty the `CacheBucket` before deleting the workers stack or the delete will fail and roll back.
 

--- a/cloudformation/workers.yml
+++ b/cloudformation/workers.yml
@@ -69,10 +69,19 @@ Parameters:
       torn down (CFDB_WORKER_DRAIN_GRACE_SECONDS).
   BackendClusterName:
     Type: String
-    # NOTE: like every default in these templates, this matches neither
-    # live environment — pass <backend-stack>-cluster explicitly
-    # (cfdb-backend-dev-cluster / cfdb-backend-prod-cluster).
-    Default: cfdb-backend-cluster
+    # Deliberately has NO default, unlike every other parameter here.
+    # The rest carry a placeholder so a bare `cloudformation deploy` is
+    # not rejected for missing values, on the reasoning that a wrong one
+    # fails visibly (a wrong DomainName is the wrong DNS; a wrong
+    # TargetGroupName collides). That reasoning does not hold here: this
+    # value scopes the ecs:TagResource grant below, so a placeholder
+    # deploys cleanly, attaches the policy to a cluster that does not
+    # exist, and leaves every worker failing the same AccessDenied it
+    # was meant to fix — with UPDATE_COMPLETE on screen. Better to be
+    # rejected at deploy time for a missing value than to ship a grant
+    # that grants nothing. CloudFormation reuses stored parameter
+    # values on update, so this must be supplied on the first deploy
+    # only.
     Description: >
       Name of the ECS cluster the backend stack creates
       (${BackendStackName}-cluster). Used only to scope the worker task

--- a/scripts/deploy-worker-metadata-grant.sh
+++ b/scripts/deploy-worker-metadata-grant.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+#
+# Deploy the workers stack so worker tasks can publish their own wool
+# metadata (issue #90, PR #89).
+#
+# WHY THIS EXISTS
+#
+# Since PR #89, a worker publishes its wool protocol version and TLS
+# flag by tagging its own ECS task, and EcsDiscovery reads those tags
+# back to build the WorkerMetadata wool gates admission on. A worker
+# that cannot tag its task exits deliberately — it could never be
+# discovered, so serving would hold a Fargate slot while unable to
+# receive work.
+#
+# The ecs:TagResource grant that makes tagging possible lives in
+# cloudformation/workers.yml. The CI pipeline CANNOT deploy it: the
+# cfdb-deploy role holds no cloudformation:* (by design). So shipping
+# the image without first deploying this stack empties the fleet —
+# every RunTask launches a worker that exits in ~25s — while CI reports
+# success, because update-service and services-stable both pass.
+#
+# That is exactly what happened to dev on 2026-08-05.
+#
+# ORDER MATTERS, IN ONE DIRECTION ONLY
+#
+#   stack THEN image  -> harmless; an older image ignores a permission
+#                        it never uses.
+#   image THEN stack  -> outage for the whole window between them.
+#
+# So this is always safe to run early, and never safe to run late.
+#
+# USAGE
+#
+#   ./scripts/deploy-worker-metadata-grant.sh preflight   # check creds only
+#   ./scripts/deploy-worker-metadata-grant.sh dev
+#   ./scripts/deploy-worker-metadata-grant.sh prod
+#   ./scripts/deploy-worker-metadata-grant.sh verify dev|prod
+#
+# CREDENTIALS
+#
+# Requires cloudformation:*, iam:PassRole, and iam:PutRolePolicy.
+# AWSReservedSSO_PowerUserAccess is NOT sufficient — it excludes iam:*,
+# and the deploy fails at RegisterTaskDefinition with:
+#
+#   is not authorized to perform: iam:PassRole on resource:
+#   .../cfdb-workers-<env>-WorkerTaskRole-...
+#
+# The failure rolls back cleanly (UPDATE_ROLLBACK_COMPLETE), so a
+# refused attempt costs nothing but time. See the README section
+# "Which principal can run a privileged deploy" — this script's
+# preflight enforces what that section documents.
+
+set -euo pipefail
+
+readonly REGION="us-east-2"
+readonly ACCOUNT="605134458779"
+readonly ECR="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com"
+readonly TEMPLATE="cloudformation/workers.yml"
+
+# Per-environment coordinates. BackendClusterName scopes the tagging
+# grant to this environment's own cluster — dev and prod share an
+# account and region, and these tags drive admission, so an unscoped
+# grant would let a compromised worker in one environment empty the
+# other's pool. Its template default (cfdb-backend-cluster) matches
+# NEITHER environment on purpose, so a forgotten override fails loudly
+# rather than silently granting nothing usable.
+env_config() {
+    case "$1" in
+        dev)
+            STACK="cfdb-workers-dev"
+            CLUSTER="cfdb-backend-dev-cluster"
+            IMAGE="${ECR}/cfdb-wool:dev"
+            ;;
+        prod)
+            STACK="cfdb-workers-prod"
+            CLUSTER="cfdb-backend-prod-cluster"
+            IMAGE="${ECR}/cfdb-wool:prod"
+            ;;
+        *)
+            echo "unknown environment: $1 (expected dev or prod)" >&2
+            exit 2
+            ;;
+    esac
+    WORKER_FAMILY="${STACK}-worker"
+    LOG_GROUP="/ecs/${WORKER_FAMILY}"
+}
+
+# ---------------------------------------------------------------------
+# Preflight — fail before touching a stack, not halfway through one.
+# ---------------------------------------------------------------------
+
+preflight() {
+    echo "== caller identity =="
+    aws sts get-caller-identity --output json
+
+    # A cheap, non-mutating probe of the permission that actually
+    # blocks this deploy. PowerUserAccess can read IAM here but cannot
+    # PassRole, and the distinction is invisible until RegisterTaskDefinition.
+    local arn
+    arn="$(aws sts get-caller-identity --query Arn --output text)"
+    case "$arn" in
+        *PowerUserAccess*)
+            cat >&2 <<'WARN'
+
+WARNING: this looks like AWSReservedSSO_PowerUserAccess, which excludes
+iam:* and therefore cannot PassRole. The deploy will fail at
+WorkerTaskDefinition and roll back. Log in with an IAM-capable
+permission set (AdministratorAccess or equivalent) first.
+
+WARN
+            return 1
+            ;;
+    esac
+    echo "principal is not PowerUser — proceeding"
+}
+
+# ---------------------------------------------------------------------
+# Deploy.
+# ---------------------------------------------------------------------
+
+deploy() {
+    env_config "$1"
+
+    echo "== ${STACK}: state before =="
+    aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
+        --query 'Stacks[0].{Status:StackStatus,Updated:LastUpdatedTime}' --output json
+
+    # WorkerImageURI is passed explicitly even though CloudFormation
+    # would reuse the previous value on an update. Being explicit means
+    # this script says what it deploys rather than depending on stack
+    # history — and both stacks already point at their moving tag, so
+    # this is a no-op that documents itself.
+    #
+    # Every other parameter (WorkerCpu, WorkerMemory, the TLS secret
+    # ARNs, ...) is deliberately omitted so CloudFormation reuses the
+    # deployed values. In particular the WorkerTls*SecretArn parameters
+    # stay empty, which keeps mTLS off — this change does not enable it.
+    echo "== deploying ${STACK} =="
+    aws cloudformation deploy \
+        --region "$REGION" \
+        --stack-name "$STACK" \
+        --template-file "$TEMPLATE" \
+        --parameter-overrides \
+            "WorkerImageURI=${IMAGE}" \
+            "BackendClusterName=${CLUSTER}" \
+        --capabilities CAPABILITY_IAM
+
+    echo "== ${STACK}: state after =="
+    aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
+        --query 'Stacks[0].StackStatus' --output text
+}
+
+# ---------------------------------------------------------------------
+# Verify — assert the grant landed, then (dev) prove a job moves.
+# ---------------------------------------------------------------------
+
+verify() {
+    env_config "$1"
+
+    # 1. The inline policy exists on the worker task role. Before the
+    #    deploy this lists only "cache-access"; after, it must also
+    #    carry "worker-metadata".
+    local role
+    role="$(aws cloudformation describe-stack-resources \
+        --stack-name "$STACK" --region "$REGION" \
+        --logical-resource-id WorkerTaskRole \
+        --query 'StackResources[0].PhysicalResourceId' --output text)"
+    echo "== worker task role: ${role} =="
+    aws iam list-role-policies --role-name "$role" --query 'PolicyNames' --output json
+
+    # 2. The grant is scoped to THIS environment's cluster and to the
+    #    two wool.* keys. A bare task/* here would mean the
+    #    BackendClusterName override was missed.
+    #    Tolerates absence so this whole function is runnable BEFORE the
+    #    deploy, to capture a baseline — a missing policy is the
+    #    pre-fix state, not a reason to stop reporting.
+    echo "== ecs:TagResource statement =="
+    if ! aws iam get-role-policy --role-name "$role" --policy-name worker-metadata \
+            --query 'PolicyDocument.Statement[0].{Action:Action,Resource:Resource,Condition:Condition}' \
+            --output json 2>/dev/null; then
+        echo "MISSING — the worker-metadata policy is not attached."
+        echo "         This is the pre-fix state: workers will exit at startup."
+    fi
+
+    # 3. No worker should be crash-looping. Before the fix these exit 1
+    #    within ~25s of starting; after, they run until they self-reap.
+    echo "== recent worker exits (expect none new after the deploy) =="
+    local stopped
+    stopped="$(aws ecs list-tasks --cluster "$CLUSTER" --family "$WORKER_FAMILY" \
+        --desired-status STOPPED --region "$REGION" \
+        --query 'taskArns[-3:]' --output text 2>/dev/null || true)"
+    if [ -n "$stopped" ]; then
+        # shellcheck disable=SC2086
+        aws ecs describe-tasks --cluster "$CLUSTER" --region "$REGION" --tasks $stopped \
+            --query 'tasks[].{stopped:stoppedAt,exit:containers[0].exitCode,reason:stoppedReason}' \
+            --output json
+    else
+        echo "(no stopped worker tasks)"
+    fi
+
+    # 4. The diagnostic that names this exact failure. Silence here
+    #    after a deploy is the signal you want; a hit means the grant
+    #    still is not reaching the worker.
+    echo "== worker log: TagResource denials in the last 15m =="
+    aws logs tail "$LOG_GROUP" --region "$REGION" --since 15m --format short 2>/dev/null \
+        | grep -c "ecs:TagResource denied" \
+        || echo "0 (good)"
+
+    # 5. Workers now publish, so a discovered task carries wool.* tags.
+    #    Empty output with no running workers just means nothing is
+    #    dispatching — run the smoke below to create one.
+    echo "== tags on running workers (expect wool.version / wool.secure) =="
+    local running
+    running="$(aws ecs list-tasks --cluster "$CLUSTER" --family "$WORKER_FAMILY" \
+        --desired-status RUNNING --region "$REGION" --query 'taskArns' --output text 2>/dev/null || true)"
+    if [ -n "$running" ]; then
+        # shellcheck disable=SC2086
+        aws ecs describe-tasks --cluster "$CLUSTER" --region "$REGION" --tasks $running \
+            --include TAGS --query 'tasks[].tags' --output json
+    else
+        echo "(no running workers)"
+    fi
+}
+
+# ---------------------------------------------------------------------
+# End-to-end smoke (dev only — do not dispatch load at prod casually).
+#
+# Not an AWS call, but it is the only check that proves the pipeline
+# actually works rather than that the permission exists. Pick an
+# uncached BED, dispatch, and watch the job leave "pending".
+#
+#   API=https://dev.cfdb.vis-api.link
+#   ID=ENCFF247ILV
+#
+#   # side-effect-free: {"ready":false} means a GET would preprocess
+#   curl -sS "$API/data/ENCODE/$ID/status"
+#
+#   # dispatch: expect 202 + Location: /jobs/<uuid>
+#   curl -sS -D - -o /dev/null "$API/data/ENCODE/$ID"
+#
+#   # poll: pending -> running -> completed, ~200s on a cold Fargate start
+#   watch -n 15 "curl -sS $API/jobs/<uuid>"
+#
+# A job that sits "pending" past ~5 minutes with no running worker means
+# the fix has not taken. Check step 4 above first.
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# NOT REQUIRED, and deliberately not automated here.
+#
+# cloudformation/backend.yml also changed in PR #89, but only by adding
+# the WorkerTlsIdentity parameter and an env var rendered under
+# ApiMtlsEnabled. Both environments run with empty cert ARNs, so that
+# condition is false, the env var resolves to AWS::NoValue, and the
+# deployed task definition is byte-identical. Deploying the backend
+# stacks changes nothing today.
+#
+# It becomes necessary only before enabling mTLS, at which point both
+# stacks need the same WorkerTlsIdentity value:
+#
+#   aws cloudformation deploy --region us-east-2 \
+#     --stack-name cfdb-backend-<env> \
+#     --template-file cloudformation/backend.yml \
+#     --parameter-overrides WorkerTlsIdentity=cfdb-worker ... \
+#     --capabilities CAPABILITY_IAM
+#
+# Already satisfied, verified 2026-08-06 — do NOT redo:
+#   - GitHub prod environment carries PROD_BACKEND_CLUSTER and
+#     PROD_BACKEND_SERVICE.
+#   - cfdb-deploy already grants ecs:UpdateService / DescribeServices /
+#     DescribeTasks / ListTasks on BOTH cluster ARNs.
+# ---------------------------------------------------------------------
+
+main() {
+    local cmd="${1:-}"
+    case "$cmd" in
+        preflight) preflight ;;
+        dev|prod)  preflight && deploy "$cmd" && verify "$cmd" ;;
+        verify)    verify "${2:?usage: $0 verify dev|prod}" ;;
+        *)
+            sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -262,6 +262,37 @@ def test_worker_tag_grant_should_be_scoped_to_the_cluster_and_wool_keys():
     assert "BackendClusterName" in (template.get("Parameters") or {})
 
 
+def test_backend_cluster_name_should_have_no_default():
+    """Test that a deploy cannot silently mis-scope the tagging grant.
+
+    Given:
+        The workers template's BackendClusterName parameter, which
+        scopes the ecs:TagResource grant to one environment's cluster.
+    When:
+        The parameter is inspected for a default.
+    Then:
+        It should have none, so CloudFormation rejects a deploy that
+        omits it. A placeholder default deploys cleanly and attaches the
+        policy to a cluster that does not exist, leaving every worker
+        failing the same AccessDenied the grant exists to prevent — with
+        UPDATE_COMPLETE on screen and no signal that anything is wrong.
+        Every other parameter here may carry a placeholder because a
+        wrong value fails visibly; this one may not.
+    """
+    # Arrange
+    template = _load_template("workers.yml")
+
+    # Act
+    parameter = template["Parameters"]["BackendClusterName"]
+
+    # Assert
+    assert "Default" not in parameter, (
+        "BackendClusterName must have no default — see the comment in "
+        "workers.yml. A default makes a forgotten override deploy "
+        "successfully while granting nothing usable."
+    )
+
+
 def test_worker_container_should_declare_aws_region():
     """Test that the worker container is told its region.
 


### PR DESCRIPTION
## Summary

`cloudformation/workers.yml`'s `BackendClusterName` parameter scopes the `ecs:TagResource` grant a worker needs to publish its own metadata. It carried a placeholder default, `cfdb-backend-cluster`, matching neither live environment.

Every parameter in these templates carries such a placeholder. The stated reason is that a bare `cloudformation deploy` should not be rejected for missing values, and the risk is acceptable because a wrong value fails visibly — a wrong `DomainName` is the wrong DNS, a wrong `TargetGroupName` collides. That reasoning does not extend to a value that scopes an IAM grant. A deploy omitting the override succeeds, attaches the policy to a cluster that does not exist, and leaves every worker failing the same `AccessDenied` the grant exists to prevent. The operator sees `UPDATE_COMPLETE`.

Removing the default makes CloudFormation refuse that deploy.

Three bootstraps in the README direct the operator to run as an "IAM-capable principal", parenthetically excluding the `cfdb-deploy` CI role. `AWSReservedSSO_PowerUserAccess` satisfies that description, is the role a cfdb operator holds, and lacks `iam:PassRole`. The deploy builds a changeset and then fails at `RegisterTaskDefinition`. This cost a round trip during the dev recovery on 2026-08-06.

A fourth README item, listed as an outstanding prod prerequisite, was already satisfied.

This prevents recurrence. It does not fix the current outage: dev still needs the workers-stack deploy, and prod's grant is still unapplied.

Closes #91

## Proposed changes

### Require the cluster name at deploy time

Drop `Default:` from `BackendClusterName`. The adjacent comment records why this parameter is the exception, so a later edit restoring symmetry has to argue with it first. CloudFormation reuses stored parameter values on update, so the override is required on a stack's first deploy only.

### Name the permissions a privileged deploy needs

All three sites now name `cloudformation:*`, `iam:PassRole`, and `iam:PutRolePolicy`, and link to a new section, **Which principal can run a privileged deploy**. That section carries the error text, states that PowerUserAccess is insufficient despite not being the CI role, and records that a refused attempt rolls back to `UPDATE_ROLLBACK_COMPLETE` with nothing partially applied. An operator who has just watched a deploy fail needs to know whether the stack is now broken.

The parameter-defaults convention gains its exception, so a reader who notices the missing default finds the reason rather than restoring symmetry. The stale prerequisite is deleted: `cfdb-deploy-policy` already covers both cluster ARNs for `service/` and `task/`.

### Add a bootstrap script

`scripts/deploy-worker-metadata-grant.sh` takes an environment and runs preflight, deploy, and verify. Preflight enforces the credential requirement before touching a stack. Verify runs standalone and tolerates the pre-fix state, so one command captures a baseline before the deploy and the proof after: task-role policies, the grant's scope and tag-key condition, recent worker exits, `TagResource` denials in the log, and the `wool.*` tags on any running worker.

Only the two parameters that must change are passed. CloudFormation reuses the rest, so the TLS cert ARNs stay empty and mTLS stays off.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `test_cloudformation` | The workers template's `BackendClusterName` parameter | It is inspected for a default | It should have none, so a deploy omitting it is rejected rather than mis-scoping the grant | The guard is a single absent line; this stops it being silently reinstated |

Three checks beyond the suite:

| Check | Result |
|---|---|
| Re-add the default | Test 1 fails, alone |
| `validate-template` | Accepted; parameter reported with no `DefaultValue` |
| Deploy against `cfdb-workers-dev` omitting the parameter | `Parameters: [BackendClusterName] must have values`, raised at `CreateChangeSet` before a changeset exists |

## Applying this

Merging changes nothing on its own. CI cannot deploy CloudFormation, so the template change sits in `master` until someone runs the privileged deploy. That deploy is outstanding for both environments. Dev's preprocessing has been down since 2026-08-05. Prod is unaffected only because `:prod` is `50cf881b`, which predates the wool 0.12 bump; the next promotion breaks it the same way.

After this merges:

```bash
git clone https://github.com/abdenlab/cfdb.git && cd cfdb
aws sso login                                          # AdministratorAccess-equivalent

./scripts/deploy-worker-metadata-grant.sh preflight    # credentials check only
./scripts/deploy-worker-metadata-grant.sh prod         # prod first
./scripts/deploy-worker-metadata-grant.sh dev
```

Prod goes first: its prerequisite is still ahead of the failure, while dev is already down. Both deploys are additive and idempotent — no image changes, no mTLS, no backend stacks touched — and a wrong-credentials attempt rolls back with nothing partially applied.

Verify reads the same state on either side of the deploy:

```bash
./scripts/deploy-worker-metadata-grant.sh verify dev
```

Expect `worker-metadata` alongside `cache-access` on the task role, the grant scoped to `task/cfdb-backend-dev-cluster/*` with the two `wool.*` keys, and zero `TagResource` denials. A dispatched BED job then reaches `completed` in roughly 200s on a cold Fargate start.
