### PR TITLE
Reject a pageSize of 0 and validate page bounds on the files query — Closes #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ The GraphQL API uses an implicit OR/AND clause system for building MongoDB queri
 
 Pagination is supported via `page` and `pageSize` parameters (defaults: 0 and 25). `totalCount` is unaffected by both — it always reports the full number of matches for the filter.
 
+Both parameters are bounds-checked and an out-of-range value is rejected with a GraphQL error rather than being passed to the cursor: `page` must be `>= 0`, and `pageSize` must be between 1 and 500 (`MAX_PAGE_SIZE`). The floor matters because MongoDB reads `limit(0)` as *no limit*, so an unvalidated `pageSize: 0` would fetch and convert every matching document — on an unauthenticated endpoint over a collection of millions. Use `fileCount` when you want a count without documents.
+
 #### OR Query - Multiple Values in a List
 
 Find files with either filename:

--- a/README.md
+++ b/README.md
@@ -365,7 +365,9 @@ The GraphQL API uses an implicit OR/AND clause system for building MongoDB queri
 
 Pagination is supported via `page` and `pageSize` parameters (defaults: 0 and 25). `totalCount` is unaffected by both — it always reports the full number of matches for the filter.
 
-Both parameters are bounds-checked and an out-of-range value is rejected with a GraphQL error rather than being passed to the cursor: `page` must be `>= 0`, and `pageSize` must be between 1 and 500 (`MAX_PAGE_SIZE`). The floor matters because MongoDB reads `limit(0)` as *no limit*, so an unvalidated `pageSize: 0` would fetch and convert every matching document — on an unauthenticated endpoint over a collection of millions. Use `fileCount` when you want a count without documents.
+Both parameters are bounds-checked and an out-of-range value is rejected with a GraphQL error rather than being passed to the cursor: `page` must be `>= 0`, and `pageSize` must be between 1 and 500 (`MAX_PAGE_SIZE`). The floor matters because MongoDB reads `limit(0)` as *no limit*, so an unvalidated `pageSize: 0` would fetch and convert every matching document — on an unauthenticated endpoint over a collection of millions. Use `fileCount` when you want a count without documents. This is a behavior change: `pageSize: 0` previously returned every match, `pageSize: -1` quietly behaved as `pageSize: 1`, and any `pageSize` above 500 was honored.
+
+Note what those bounds do *not* cover. `page` has a floor but no ceiling, so a deep page still costs the database an O(skip) walk — MongoDB satisfies a skip by discarding documents one at a time — and the ceiling on `pageSize` bounds a single `files` selection rather than a whole request, which may alias the field more than once. Both are properties of the endpoint as a whole rather than of a single argument, and neither is addressed here.
 
 #### OR Query - Multiple Values in a List
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -508,7 +508,17 @@ type ProjectType {
 }
 
 type Query {
-  files(input: [FileMetadataInput!] = null, page: Int! = 0, pageSize: Int! = 25): FileList!
+  files(
+    input: [FileMetadataInput!] = null
+
+    """Zero-based page index. Must be >= 0."""
+    page: Int! = 0
+
+    """
+    Documents per page, from 1 to 500. Use the fileCount query for a count without documents.
+    """
+    pageSize: Int! = 25
+  ): FileList!
   file(id: ObjectIdScalar!): FileMetadataType
   distinctValues(fields: [String!]!, input: [FileMetadataInput!] = null): [DistinctFieldType!]!
   fileCount(input: [FileMetadataInput!] = null): Int!

--- a/src/cfdb/api/__init__.py
+++ b/src/cfdb/api/__init__.py
@@ -17,6 +17,16 @@ if TYPE_CHECKING:
 DATABASE_URL: Final = os.getenv("DATABASE_URL", "mongodb://127.0.0.1:27017")
 DATABASE_NAME: Final = os.getenv("DATABASE_NAME", "cfdb")
 PAGE_SIZE: Final = 25
+# Ceiling on the ``files`` query's page size. ``/metadata`` is
+# unauthenticated and the production ``files`` collection holds millions
+# of documents, so an unbounded page is a denial-of-service vector: every
+# returned document is converted through ``FileMetadataModel(...)
+# .model_dump()`` and ``from_pydantic`` on the event loop, blocking every
+# other request for the duration. 500 is 20x the default and bounds that
+# synchronous pass at roughly 65ms and a few MB for a representative
+# document (measured at ~0.13ms and ~6KB each), while staying generous
+# enough for bulk clients paginating a large filter.
+MAX_PAGE_SIZE: Final = 500
 
 # TLS authentication configuration (production)
 MONGODB_TLS_ENABLED: Final = os.getenv("MONGODB_TLS_ENABLED", "false").lower() == "true"

--- a/src/cfdb/api/__init__.py
+++ b/src/cfdb/api/__init__.py
@@ -17,15 +17,25 @@ if TYPE_CHECKING:
 DATABASE_URL: Final = os.getenv("DATABASE_URL", "mongodb://127.0.0.1:27017")
 DATABASE_NAME: Final = os.getenv("DATABASE_NAME", "cfdb")
 PAGE_SIZE: Final = 25
-# Ceiling on the ``files`` query's page size. ``/metadata`` is
+# Ceiling on a single ``files`` selection's page size. ``/metadata`` is
 # unauthenticated and the production ``files`` collection holds millions
 # of documents, so an unbounded page is a denial-of-service vector: every
 # returned document is converted through ``FileMetadataModel(...)
 # .model_dump()`` and ``from_pydantic`` on the event loop, blocking every
-# other request for the duration. 500 is 20x the default and bounds that
-# synchronous pass at roughly 65ms and a few MB for a representative
-# document (measured at ~0.13ms and ~6KB each), while staying generous
-# enough for bulk clients paginating a large filter.
+# other request for the duration. 500 is 20x the default and holds that
+# synchronous pass to tens of milliseconds and a few MB — measured by
+# timing the conversion of a representative enriched file document, so
+# re-measure if ``FileMetadataModel`` grows materially — while staying
+# generous enough for bulk clients paginating a large filter.
+#
+# Two limits of this bound are worth stating rather than discovering. It
+# is per selection, not per request: a query may alias ``files`` many
+# times, so bounding what one request can cost needs request-level cost
+# limiting, which this is not. And it is deliberately a fixed literal
+# rather than one of this module's ``_parse_int_env`` knobs, because the
+# value is published to clients (README, and the rejection message
+# itself) and a contract that varies per deployment is worse than one
+# that does not.
 MAX_PAGE_SIZE: Final = 500
 
 # TLS authentication configuration (production)

--- a/src/cfdb/api/gql/schema.py
+++ b/src/cfdb/api/gql/schema.py
@@ -97,6 +97,21 @@ class Query:
         page: int = 0,
         page_size: int = api.PAGE_SIZE,
     ) -> FileList:
+        # Reject out-of-range pagination before touching the database.
+        # Neither bound is enforceable by the cursor: Mongo reads
+        # ``limit(0)`` as *no limit* (so ``pageSize: 0`` would fetch the
+        # whole collection) and ``limit(-n)`` as "at most n, then close",
+        # while a negative skip raises deep in pymongo rather than as a
+        # client error.
+        if page < 0:
+            raise ValueError(f"page must be >= 0 (got {page})")
+        if not 1 <= page_size <= api.MAX_PAGE_SIZE:
+            raise ValueError(
+                f"pageSize must be between 1 and {api.MAX_PAGE_SIZE} "
+                f"(got {page_size}); use the fileCount query for a count "
+                "without documents"
+            )
+
         # Wait for any database cutover to complete
         await locks.wait_for_cutover()
 

--- a/src/cfdb/api/gql/schema.py
+++ b/src/cfdb/api/gql/schema.py
@@ -1,7 +1,9 @@
 import asyncio
-from typing import List, Optional
+import logging
+from typing import Annotated, List, Optional
 
 import strawberry
+from graphql import GraphQLError
 
 from cfdb import api
 from cfdb.api.gql.inputs import (
@@ -17,6 +19,44 @@ from cfdb.api.gql.types import (
 )
 from cfdb.models import FileMetadataModel
 from cfdb.services import locks
+
+
+logger = logging.getLogger(__name__)
+
+
+class ClientInputError(ValueError):
+    """An argument the caller got wrong.
+
+    Subclassing ``ValueError`` keeps the client-visible behavior and the
+    resolver convention unchanged — Strawberry surfaces either as a
+    GraphQL error carrying this message. The distinct type exists so
+    ``Schema.process_errors`` can log it as the routine client mistake it
+    is: Strawberry's default logs every error at ERROR with the full
+    traceback attached, and ``/metadata`` is unauthenticated, so anything
+    written per rejected request is a log volume an anonymous caller
+    chooses — and it buries genuine faults in the same stream.
+    """
+
+
+class Schema(strawberry.Schema):
+    """Schema that logs a caller's mistake as a caller's mistake.
+
+    ``ClientInputError`` is reported at INFO without ``exc_info``; every
+    other error keeps Strawberry's default ERROR-with-traceback handling,
+    which is what an operator wants to be alerted on.
+    """
+
+    def process_errors(
+        self, errors: List[GraphQLError], execution_context=None
+    ) -> None:
+        unexpected = []
+        for error in errors:
+            if isinstance(error.original_error, ClientInputError):
+                logger.info("Rejected request: %s", error.message)
+            else:
+                unexpected.append(error)
+        if unexpected:
+            super().process_errors(unexpected, execution_context)
 
 
 ALLOWED_DISTINCT_FIELDS: frozenset[str] = frozenset(
@@ -94,8 +134,19 @@ class Query:
         self,
         _: strawberry.Info,
         input: list[FileMetadataInput] | None = None,
-        page: int = 0,
-        page_size: int = api.PAGE_SIZE,
+        page: Annotated[
+            int,
+            strawberry.argument(description="Zero-based page index. Must be >= 0."),
+        ] = 0,
+        page_size: Annotated[
+            int,
+            strawberry.argument(
+                description=(
+                    f"Documents per page, from 1 to {api.MAX_PAGE_SIZE}. "
+                    "Use the fileCount query for a count without documents."
+                )
+            ),
+        ] = api.PAGE_SIZE,
     ) -> FileList:
         # Reject out-of-range pagination before touching the database.
         # Neither bound is enforceable by the cursor: Mongo reads
@@ -104,9 +155,9 @@ class Query:
         # while a negative skip raises deep in pymongo rather than as a
         # client error.
         if page < 0:
-            raise ValueError(f"page must be >= 0 (got {page})")
+            raise ClientInputError(f"page must be >= 0 (got {page})")
         if not 1 <= page_size <= api.MAX_PAGE_SIZE:
-            raise ValueError(
+            raise ClientInputError(
                 f"pageSize must be between 1 and {api.MAX_PAGE_SIZE} "
                 f"(got {page_size}); use the fileCount query for a count "
                 "without documents"
@@ -159,7 +210,7 @@ class Query:
     ) -> List[DistinctFieldType]:
         disallowed = set(fields) - ALLOWED_DISTINCT_FIELDS
         if disallowed:
-            raise ValueError(
+            raise ClientInputError(
                 f"Field(s) not queryable: {', '.join(sorted(disallowed))}"
             )
 
@@ -191,4 +242,4 @@ class Query:
         return await api.db.files.count_documents(query)
 
 
-schema = strawberry.Schema(query=Query)
+schema = Schema(query=Query)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,15 @@ def _match(doc: dict, query: dict) -> bool:
 
 
 class _FakeCursor:
-    """Async-iterable cursor backed by a plain list."""
+    """Async-iterable cursor backed by a plain list.
+
+    ``skip`` and ``limit`` reproduce pymongo's semantics rather than the
+    intuitive ones, because that mismatch is where #86's pagination bugs
+    lived: a limit of 0 means *no limit*, a negative limit means "at most
+    abs(n), then close the cursor", and a negative skip is rejected
+    client-side by the driver. A double that smoothed any of these over
+    would let the resolver's bounds regress unnoticed.
+    """
 
     def __init__(self, docs: list[dict]) -> None:
         self._docs = list(docs)
@@ -90,6 +98,8 @@ class _FakeCursor:
         self._limit = 0
 
     def skip(self, n: int) -> "_FakeCursor":
+        if n < 0:
+            raise ValueError("skip must be >= 0")
         self._skip = n
         return self
 
@@ -97,18 +107,18 @@ class _FakeCursor:
         self._limit = n
         return self
 
-    async def to_list(self, *, length: Any = None) -> list[dict]:
+    @property
+    def _window(self) -> list[dict]:
         sliced = self._docs[self._skip :]
         if self._limit:
-            sliced = sliced[: self._limit]
+            sliced = sliced[: abs(self._limit)]
         return sliced
 
+    async def to_list(self, *, length: Any = None) -> list[dict]:
+        return self._window
+
     def __aiter__(self):
-        self._iter_docs = iter(
-            self._docs[self._skip :]
-            if not self._limit
-            else self._docs[self._skip : self._skip + self._limit]
-        )
+        self._iter_docs = iter(self._window)
         return self
 
     async def __anext__(self):

--- a/tests/test_fake_collection.py
+++ b/tests/test_fake_collection.py
@@ -244,8 +244,7 @@ class TestFakeCollectionContract:
         # Assert
         assert [d["n"] for d in result] == [0, 1]
 
-    @pytest.mark.asyncio
-    async def test_find_should_raise_when_skip_is_negative(self):
+    def test_find_should_raise_when_skip_is_negative(self):
         """Test a negative skip is refused, as pymongo refuses it.
 
         Given:
@@ -271,22 +270,23 @@ class TestFakeCollectionContract:
         """Test cursor iteration and listing agree on the window.
 
         Given:
-            A FakeCollection holding five documents and a skip and limit
-            applied to the cursor.
+            A FakeCollection holding five documents, and a skip with a
+            negative limit — the case where the two drain paths used to
+            disagree.
         When:
             One cursor is drained with async iteration and another with
             to_list.
         Then:
-            Both should yield the same documents — production code consumes
-            cursors both ways.
+            Both should yield the same two documents — production code
+            consumes cursors both ways.
         """
         # Arrange
         coll = FakeCollection()
         coll.docs.extend({"n": i} for i in range(5))
 
         # Act
-        listed = await coll.find({}).skip(1).limit(2).to_list(length=None)
-        iterated = [doc async for doc in coll.find({}).skip(1).limit(2)]
+        listed = await coll.find({}).skip(1).limit(-2).to_list(length=None)
+        iterated = [doc async for doc in coll.find({}).skip(1).limit(-2)]
 
         # Assert
         assert listed == iterated

--- a/tests/test_fake_collection.py
+++ b/tests/test_fake_collection.py
@@ -197,3 +197,97 @@ class TestFakeCollectionContract:
 
         # Assert
         assert coll.docs[0]["stages_done"] == ["data"]
+
+    @pytest.mark.asyncio
+    async def test_find_should_return_every_document_when_limit_is_zero(self):
+        """Test a limit of zero means no limit, as it does in MongoDB.
+
+        Given:
+            A FakeCollection holding five documents.
+        When:
+            The cursor is limited to zero and listed.
+        Then:
+            It should return all five documents — the counter-intuitive
+            driver semantics the files query's page size floor exists to
+            defend against (#86), so softening it here would hollow out
+            that regression test.
+        """
+        # Arrange
+        coll = FakeCollection()
+        coll.docs.extend({"n": i} for i in range(5))
+
+        # Act
+        result = await coll.find({}).limit(0).to_list(length=None)
+
+        # Assert
+        assert [d["n"] for d in result] == [0, 1, 2, 3, 4]
+
+    @pytest.mark.asyncio
+    async def test_find_should_return_abs_limit_documents_when_limit_is_negative(self):
+        """Test a negative limit returns at most its magnitude.
+
+        Given:
+            A FakeCollection holding five documents.
+        When:
+            The cursor is limited to -2 and listed.
+        Then:
+            It should return two documents, mirroring the wire protocol's
+            "at most abs(n), then close the cursor".
+        """
+        # Arrange
+        coll = FakeCollection()
+        coll.docs.extend({"n": i} for i in range(5))
+
+        # Act
+        result = await coll.find({}).limit(-2).to_list(length=None)
+
+        # Assert
+        assert [d["n"] for d in result] == [0, 1]
+
+    @pytest.mark.asyncio
+    async def test_find_should_raise_when_skip_is_negative(self):
+        """Test a negative skip is refused, as pymongo refuses it.
+
+        Given:
+            A FakeCollection holding five documents.
+        When:
+            The cursor is asked to skip a negative number of documents.
+        Then:
+            It should raise ValueError client-side rather than silently
+            slicing from the tail.
+        """
+        # Arrange
+        coll = FakeCollection()
+        coll.docs.extend({"n": i} for i in range(5))
+
+        # Act & assert
+        with pytest.raises(ValueError, match="skip must be >= 0"):
+            coll.find({}).skip(-1)
+
+    @pytest.mark.asyncio
+    async def test_find_should_yield_the_same_documents_when_iterated_as_when_listed(
+        self,
+    ):
+        """Test cursor iteration and listing agree on the window.
+
+        Given:
+            A FakeCollection holding five documents and a skip and limit
+            applied to the cursor.
+        When:
+            One cursor is drained with async iteration and another with
+            to_list.
+        Then:
+            Both should yield the same documents — production code consumes
+            cursors both ways.
+        """
+        # Arrange
+        coll = FakeCollection()
+        coll.docs.extend({"n": i} for i in range(5))
+
+        # Act
+        listed = await coll.find({}).skip(1).limit(2).to_list(length=None)
+        iterated = [doc async for doc in coll.find({}).skip(1).limit(2)]
+
+        # Assert
+        assert listed == iterated
+        assert [d["n"] for d in listed] == [1, 2]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -130,7 +131,7 @@ class TestFilesQuery:
         assert len(result.data["files"]["items"]) == 2
 
     @pytest.mark.asyncio
-    async def test_files_should_reject_a_page_size_of_zero(self, mock_db):
+    async def test_files_should_return_an_error_when_page_size_is_zero(self, mock_db):
         """Test a page size of zero is refused rather than fetching everything.
 
         Given:
@@ -173,7 +174,7 @@ class TestFilesQuery:
         assert "fileCount" in message
 
     @pytest.mark.asyncio
-    async def test_files_should_reject_a_negative_page_size(self, mock_db):
+    async def test_files_should_return_an_error_when_page_size_is_negative(self, mock_db):
         """Test a negative page size is refused rather than quietly clamped.
 
         Given:
@@ -212,11 +213,11 @@ class TestFilesQuery:
         assert "(got -1)" in result.errors[0].message
 
     @pytest.mark.asyncio
-    async def test_files_should_reject_a_page_size_above_the_maximum(self, mock_db):
+    async def test_files_should_return_an_error_when_page_size_exceeds_the_maximum(self, mock_db):
         """Test the page size ceiling is enforced.
 
         Given:
-            Three files in the database.
+            A file in the database.
         When:
             The GraphQL files query is executed with a page size one above
             MAX_PAGE_SIZE.
@@ -248,11 +249,12 @@ class TestFilesQuery:
         assert f"(got {over_ceiling})" in result.errors[0].message
 
     @pytest.mark.asyncio
-    async def test_files_should_reject_a_negative_page(self, mock_db, mocker):
+    async def test_files_should_return_an_error_when_page_is_negative(self, mock_db, mocker):
         """Test a negative page is refused before a cursor is ever built.
 
         Given:
-            Three files in the database and a spy on the collection's find.
+            Three files in the database and spies on both collection calls
+            the resolver makes.
         When:
             The GraphQL files query is executed with page: -1, which would
             otherwise reach pymongo as a negative skip.
@@ -268,6 +270,7 @@ class TestFilesQuery:
             _make_file_doc("f3"),
         ]
         find = mocker.spy(mock_db.files, "find")
+        count_documents = mocker.spy(mock_db.files, "count_documents")
 
         # Act
         result = await schema.execute(
@@ -289,6 +292,7 @@ class TestFilesQuery:
         assert "page must be >= 0 (got -1)" in message
         assert "skip" not in message
         assert find.call_count == 0
+        assert count_documents.call_count == 0
 
     # GraphQL's Int scalar is 32-bit, so values outside it are rejected during
     # variable coercion rather than by the resolver. Bounding the generated
@@ -315,7 +319,7 @@ class TestFilesQuery:
         max_examples=50,
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
-    def test_files_should_reject_every_out_of_range_pagination_argument(
+    def test_files_should_return_an_error_when_any_pagination_argument_is_out_of_range(
         self, mock_db, pagination
     ):
         """Test no out-of-range pagination request ever returns documents.
@@ -326,12 +330,14 @@ class TestFilesQuery:
         When:
             The GraphQL files query runs with those pagination arguments.
         Then:
-            It should always return a GraphQL error and never any data.
+            It should always return a validation error naming the offending
+            argument and the rejected value, and never any data.
         """
         # Arrange
-        # As in the invariant property above: ``mock_db`` is function-scoped
-        # and reused across examples, so the dataset is reseeded each time,
-        # and the async resolver is driven via asyncio.run.
+        # As in ``test_files_should_report_total_count_invariant_under_pagination``:
+        # ``mock_db`` is function-scoped and reused across examples, so the
+        # dataset is reseeded each time, and the async resolver is driven
+        # via asyncio.run.
         page, page_size = pagination
         mock_db.files.docs = [_make_file_doc(f"f{i}") for i in range(12)]
 
@@ -355,6 +361,67 @@ class TestFilesQuery:
         # Assert
         assert result.errors is not None
         assert result.data is None
+        message = result.errors[0].message
+        # Asserting the message shape, not just that something failed: the
+        # cursor double rejects a negative skip too, so a bare "an error
+        # occurred" oracle would be satisfied by the driver over half this
+        # domain even with the resolver's own guard removed.
+        assert message.startswith(("page must be", "pageSize must be"))
+        assert f"(got {page if page < 0 else page_size})" in message
+
+    @pytest.mark.asyncio
+    async def test_files_should_not_log_an_error_when_pagination_is_out_of_range(
+        self, mock_db, caplog
+    ):
+        """Test a refused request is logged as a client mistake, not a fault.
+
+        Given:
+            Log capture over the whole application.
+        When:
+            The GraphQL files query is executed with pageSize: 0.
+        Then:
+            It should record the rejection without an ERROR-level entry, so
+            an anonymous caller cannot drive the error stream a deployment
+            alerts on.
+        """
+        # Act
+        with caplog.at_level(logging.INFO):
+            result = await schema.execute("{ files(pageSize: 0) { totalCount } }")
+
+        # Assert
+        assert result.errors is not None
+        assert [r.message for r in caplog.records if r.levelno >= logging.ERROR] == []
+        assert any("pageSize must be between" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_files_should_log_an_error_when_the_resolver_fails_unexpectedly(
+        self, mock_db, mocker, caplog
+    ):
+        """Test a genuine fault still reaches the error stream.
+
+        Given:
+            A cutover wait that raises, standing in for an unexpected
+            server-side failure.
+        When:
+            An in-range GraphQL files query is executed.
+        Then:
+            It should record the failure at ERROR with the exception
+            attached, unlike a refused pagination argument.
+        """
+        # Arrange
+        mocker.patch.object(
+            locks, "wait_for_cutover", side_effect=RuntimeError("cutover exploded")
+        )
+
+        # Act
+        with caplog.at_level(logging.INFO):
+            result = await schema.execute("{ files { totalCount } }")
+
+        # Assert
+        assert result.errors is not None
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors
+        assert errors[0].exc_info is not None
 
     @pytest.mark.asyncio
     async def test_files_should_return_one_item_when_page_size_is_one(self, mock_db):
@@ -1661,17 +1728,54 @@ class TestMetadataEndpointPagination:
         with TestClient(main.app) as test_client:
             yield test_client
 
+    _QUERY = """
+        query Files($page: Int!, $pageSize: Int!) {
+            files(page: $page, pageSize: $pageSize) {
+                totalCount
+            }
+        }
+    """
+
+    def test_files_should_answer_with_data_when_pagination_is_in_range(self, client):
+        """Test the endpoint serves a valid paginated request.
+
+        Given:
+            The application mounted at /metadata and in-range pagination
+            variables.
+        When:
+            The files query is POSTed to the endpoint.
+        Then:
+            It should answer 200 with a match count and no errors.
+        """
+        # Act
+        response = client.post(
+            "/metadata",
+            json={
+                "query": self._QUERY,
+                "variables": {"page": 0, "pageSize": api.PAGE_SIZE},
+            },
+        )
+
+        # Assert
+        assert response.status_code == 200
+        body = response.json()
+        assert "errors" not in body
+        assert body["data"]["files"]["totalCount"] == 0
+
     @pytest.mark.parametrize(
-        "variables",
+        ("variables", "expected"),
         [
-            {"page": -1, "pageSize": 25},
-            {"page": 0, "pageSize": 0},
-            {"page": 0, "pageSize": -1},
-            {"page": 0, "pageSize": api.MAX_PAGE_SIZE + 1},
+            ({"page": -1, "pageSize": 25}, "page must be >= 0 (got -1)"),
+            ({"page": 0, "pageSize": 0}, "pageSize must be between 1 and 500 (got 0)"),
+            ({"page": 0, "pageSize": -1}, "pageSize must be between 1 and 500 (got -1)"),
+            (
+                {"page": 0, "pageSize": api.MAX_PAGE_SIZE + 1},
+                f"pageSize must be between 1 and 500 (got {api.MAX_PAGE_SIZE + 1})",
+            ),
         ],
     )
     def test_files_should_answer_with_a_graphql_error_when_pagination_is_out_of_range(
-        self, client, variables
+        self, client, variables, expected
     ):
         """Test out-of-range pagination reaches the client as a GraphQL error.
 
@@ -1681,27 +1785,17 @@ class TestMetadataEndpointPagination:
         When:
             The files query is POSTed to the endpoint.
         Then:
-            It should answer 200 with a null data field and a populated
-            errors array rather than a server error carrying a traceback.
+            It should answer 200 with a null data field and an errors array
+            carrying the message for the argument that was refused.
         """
         # Act
         response = client.post(
             "/metadata",
-            json={
-                "query": """
-                    query Files($page: Int!, $pageSize: Int!) {
-                        files(page: $page, pageSize: $pageSize) {
-                            totalCount
-                        }
-                    }
-                """,
-                "variables": variables,
-            },
+            json={"query": self._QUERY, "variables": variables},
         )
 
         # Assert
         assert response.status_code == 200
         body = response.json()
         assert body["data"] is None
-        assert body["errors"]
-        assert "Traceback" not in body["errors"][0]["message"]
+        assert expected in body["errors"][0]["message"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,7 +7,11 @@ import asyncio
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from mongomock_motor import AsyncMongoMockClient
+from starlette.testclient import TestClient
 
+from cfdb import api
+from cfdb.api import main
 from cfdb.api.gql.schema import from_pydantic, schema
 from cfdb.api.gql.types import FileMetadataType
 from cfdb.models import FileMetadataModel
@@ -124,6 +128,346 @@ class TestFilesQuery:
         # Assert
         assert result.errors is None
         assert len(result.data["files"]["items"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_files_should_reject_a_page_size_of_zero(self, mock_db):
+        """Test a page size of zero is refused rather than fetching everything.
+
+        Given:
+            Thirty files in the database — more than the default page size,
+            so an unbounded fetch is distinguishable from a default page.
+        When:
+            The GraphQL files query is executed with pageSize: 0, which
+            MongoDB would read as "no limit".
+        Then:
+            It should return a GraphQL error naming the argument, the
+            rejected value and the accepted range, return no data, and
+            point the caller at the fileCount query.
+        """
+        # Arrange
+        mock_db.files.docs = [_make_file_doc(f"f{i}") for i in range(30)]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files(pageSize: 0) {
+                    totalCount
+                    items {
+                        localId
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is not None
+        assert result.data is None
+        message = result.errors[0].message
+        # The literal ceiling is asserted here rather than interpolated from
+        # MAX_PAGE_SIZE: it is a documented part of the client contract
+        # (README), so raising it should fail loudly and prompt a doc update.
+        assert "pageSize must be between 1 and 500" in message
+        assert "(got 0)" in message
+        assert "fileCount" in message
+
+    @pytest.mark.asyncio
+    async def test_files_should_reject_a_negative_page_size(self, mock_db):
+        """Test a negative page size is refused rather than quietly clamped.
+
+        Given:
+            Three files in the database.
+        When:
+            The GraphQL files query is executed with pageSize: -1, which the
+            MongoDB wire protocol reads as "at most one, then close".
+        Then:
+            It should return a GraphQL error naming the rejected value and
+            return no data.
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("f1"),
+            _make_file_doc("f2"),
+            _make_file_doc("f3"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files(pageSize: -1) {
+                    items {
+                        localId
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is not None
+        assert result.data is None
+        assert "pageSize" in result.errors[0].message
+        assert "(got -1)" in result.errors[0].message
+
+    @pytest.mark.asyncio
+    async def test_files_should_reject_a_page_size_above_the_maximum(self, mock_db):
+        """Test the page size ceiling is enforced.
+
+        Given:
+            Three files in the database.
+        When:
+            The GraphQL files query is executed with a page size one above
+            MAX_PAGE_SIZE.
+        Then:
+            It should return a GraphQL error naming the rejected value and
+            return no data.
+        """
+        # Arrange
+        mock_db.files.docs = [_make_file_doc("f1")]
+        over_ceiling = api.MAX_PAGE_SIZE + 1
+
+        # Act
+        result = await schema.execute(
+            """
+            query Files($pageSize: Int!) {
+                files(pageSize: $pageSize) {
+                    items {
+                        localId
+                    }
+                }
+            }
+            """,
+            variable_values={"pageSize": over_ceiling},
+        )
+
+        # Assert
+        assert result.errors is not None
+        assert result.data is None
+        assert f"(got {over_ceiling})" in result.errors[0].message
+
+    @pytest.mark.asyncio
+    async def test_files_should_reject_a_negative_page(self, mock_db, mocker):
+        """Test a negative page is refused before a cursor is ever built.
+
+        Given:
+            Three files in the database and a spy on the collection's find.
+        When:
+            The GraphQL files query is executed with page: -1, which would
+            otherwise reach pymongo as a negative skip.
+        Then:
+            It should return a GraphQL error naming the page argument rather
+            than leaking the driver's own skip complaint, and it should not
+            query the collection at all.
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("f1"),
+            _make_file_doc("f2"),
+            _make_file_doc("f3"),
+        ]
+        find = mocker.spy(mock_db.files, "find")
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files(page: -1) {
+                    items {
+                        localId
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is not None
+        assert result.data is None
+        message = result.errors[0].message
+        assert "page must be >= 0 (got -1)" in message
+        assert "skip" not in message
+        assert find.call_count == 0
+
+    # GraphQL's Int scalar is 32-bit, so values outside it are rejected during
+    # variable coercion rather than by the resolver. Bounding the generated
+    # domain keeps this test about the resolver's own validation.
+    _INT32_MIN = -(2**31)
+    _INT32_MAX = 2**31 - 1
+
+    @given(
+        pagination=st.one_of(
+            st.tuples(
+                st.integers(_INT32_MIN, -1),
+                st.integers(1, api.MAX_PAGE_SIZE),
+            ),
+            st.tuples(
+                st.integers(0, 20),
+                st.one_of(
+                    st.integers(_INT32_MIN, 0),
+                    st.integers(api.MAX_PAGE_SIZE + 1, _INT32_MAX),
+                ),
+            ),
+        )
+    )
+    @settings(
+        max_examples=50,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_files_should_reject_every_out_of_range_pagination_argument(
+        self, mock_db, pagination
+    ):
+        """Test no out-of-range pagination request ever returns documents.
+
+        Given:
+            A fixed collection of 12 files and a pagination pair in which at
+            least one of page and page_size falls outside the accepted range.
+        When:
+            The GraphQL files query runs with those pagination arguments.
+        Then:
+            It should always return a GraphQL error and never any data.
+        """
+        # Arrange
+        # As in the invariant property above: ``mock_db`` is function-scoped
+        # and reused across examples, so the dataset is reseeded each time,
+        # and the async resolver is driven via asyncio.run.
+        page, page_size = pagination
+        mock_db.files.docs = [_make_file_doc(f"f{i}") for i in range(12)]
+
+        # Act
+        result = asyncio.run(
+            schema.execute(
+                """
+                query Files($page: Int!, $pageSize: Int!) {
+                    files(page: $page, pageSize: $pageSize) {
+                        totalCount
+                        items {
+                            localId
+                        }
+                    }
+                }
+                """,
+                variable_values={"page": page, "pageSize": page_size},
+            )
+        )
+
+        # Assert
+        assert result.errors is not None
+        assert result.data is None
+
+    @pytest.mark.asyncio
+    async def test_files_should_return_one_item_when_page_size_is_one(self, mock_db):
+        """Test the smallest accepted page size is served, not rejected.
+
+        Given:
+            Three files in the database.
+        When:
+            The GraphQL files query is executed with page: 1, pageSize: 1.
+        Then:
+            It should return exactly the second file, with no errors.
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("f1"),
+            _make_file_doc("f2"),
+            _make_file_doc("f3"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files(page: 1, pageSize: 1) {
+                    items {
+                        localId
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert [f["localId"] for f in result.data["files"]["items"]] == ["f2"]
+
+    @pytest.mark.asyncio
+    async def test_files_should_return_items_when_page_size_is_the_maximum(
+        self, mock_db
+    ):
+        """Test the page size ceiling is inclusive.
+
+        Given:
+            Three files in the database.
+        When:
+            The GraphQL files query is executed with a page size of exactly
+            MAX_PAGE_SIZE.
+        Then:
+            It should return all three files, with no errors.
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc("f1"),
+            _make_file_doc("f2"),
+            _make_file_doc("f3"),
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query Files($pageSize: Int!) {
+                files(pageSize: $pageSize) {
+                    items {
+                        localId
+                    }
+                }
+            }
+            """,
+            variable_values={"pageSize": api.MAX_PAGE_SIZE},
+        )
+
+        # Assert
+        assert result.errors is None
+        assert len(result.data["files"]["items"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_files_should_return_a_default_page_when_pagination_is_omitted(
+        self, mock_db
+    ):
+        """Test the default page size still satisfies the new bounds.
+
+        Given:
+            Five more files than the default page size.
+        When:
+            The GraphQL files query is executed with neither pagination
+            argument supplied.
+        Then:
+            It should return exactly PAGE_SIZE files alongside the full
+            match count.
+        """
+        # Arrange
+        mock_db.files.docs = [
+            _make_file_doc(f"f{i}") for i in range(api.PAGE_SIZE + 5)
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files {
+                    totalCount
+                    items {
+                        localId
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert len(result.data["files"]["items"]) == api.PAGE_SIZE
+        assert result.data["files"]["totalCount"] == api.PAGE_SIZE + 5
 
     @pytest.mark.asyncio
     async def test_files_should_return_total_count_independent_of_page_size(
@@ -1299,3 +1643,65 @@ class TestFileCountQuery:
         # Assert
         assert result.errors is None
         assert result.data["fileCount"] == expected
+
+
+class TestMetadataEndpointPagination:
+    """The bounds as a client sees them: over HTTP, through /metadata."""
+
+    @pytest.fixture()
+    def client(self, mocker):
+        """Serve the app over an in-memory client, mirroring test_cors."""
+        # The app binds the real lifespan at import, so entering the client
+        # runs it — back it with mongomock and disable the workflow
+        # subsystem, as the CORS suite does.
+        mocker.patch.object(
+            main, "create_mongodb_client", return_value=AsyncMongoMockClient()
+        )
+        mocker.patch.object(main.WorkflowProfile, "from_env", return_value=None)
+        with TestClient(main.app) as test_client:
+            yield test_client
+
+    @pytest.mark.parametrize(
+        "variables",
+        [
+            {"page": -1, "pageSize": 25},
+            {"page": 0, "pageSize": 0},
+            {"page": 0, "pageSize": -1},
+            {"page": 0, "pageSize": api.MAX_PAGE_SIZE + 1},
+        ],
+    )
+    def test_files_should_answer_with_a_graphql_error_when_pagination_is_out_of_range(
+        self, client, variables
+    ):
+        """Test out-of-range pagination reaches the client as a GraphQL error.
+
+        Given:
+            The application mounted at /metadata and pagination variables
+            outside the accepted range.
+        When:
+            The files query is POSTed to the endpoint.
+        Then:
+            It should answer 200 with a null data field and a populated
+            errors array rather than a server error carrying a traceback.
+        """
+        # Act
+        response = client.post(
+            "/metadata",
+            json={
+                "query": """
+                    query Files($page: Int!, $pageSize: Int!) {
+                        files(page: $page, pageSize: $pageSize) {
+                            totalCount
+                        }
+                    }
+                """,
+                "variables": variables,
+            },
+        )
+
+        # Assert
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"] is None
+        assert body["errors"]
+        assert "Traceback" not in body["errors"][0]["message"]


### PR DESCRIPTION
## Summary

Introduce a `BigInt` custom scalar — a signed 64-bit integer serialized as a JSON number — and apply it to `sizeInBytes` on both `FileMetadataType` (output) and `FileMetadataInput` (input filter).

GraphQL's specification fixes `Int` at 32 bits, so any file over 2,147,483,647 bytes could not be represented: the field resolved to `null` and the response carried an `Int cannot represent non 32-bit signed integer value` entry in `errors`, degrading a whole page of results to a partial one. That is the common case rather than an edge case — every one of the 3,581 ENCODE `.hic` files runs 6–51 GB, and the larger 4DN mcools exceed the ceiling too.

**The wire representation is the real decision here, so it is worth stating explicitly.** GraphQL has no 64-bit `Int`, and the two realistic options are a `BigInt` that serializes as a JSON number and one that serializes as a String. This PR chooses the **number**.

The case against a number is real but does not bind here: a JSON number above `Number.MAX_SAFE_INTEGER` (2^53-1) is not exactly representable in JavaScript, and the consumer is a browser client (Gosling Designer), so "fits in 64 bits" is genuinely not the same as "the client can read it". But 2^53 bytes is roughly 9 PB. No file this API serves — or plausibly ever will — comes within five orders of magnitude of that ceiling, so the precision hazard is theoretical while the ergonomic cost of a String is immediate: every consumer of `sizeInBytes` would have to parse before comparing or summing, and a client that forgot would get silently wrong arithmetic (`"6262125716" + 1` is `"62621257161"` in JavaScript) rather than a loud failure. A number keeps `sizeInBytes` directly usable and keeps the JSON body byte-for-byte what a client already expected, only correct.

The scalar's schema description records the 2^53 caveat so the reasoning survives in the published contract, and `_coerce_big_int` rejects non-integers (including `true`/`false`, since `bool` subclasses `int` in Python) and anything outside the signed 64-bit range, in both directions.

**What breaks for a client that assumed `Int`.** This is a breaking schema change in three ways: a query declaring `query Q($s: [Int!])` and passing it to `sizeInBytes` now fails variable-type validation with `used in position expecting type '[BigInt!]'` and must declare `[BigInt!]`; generated clients must re-run codegen against the new SDL; and any client validating responses against a stored copy of the schema must refresh it. A client that merely *reads* `sizeInBytes` out of the JSON response needs no change at all — it was already receiving a JSON number, and now receives a correct one instead of `null`.

The widening lands on the input filter as well as the output field. Widening only the output would leave exactly the files it newly exposes unfilterable by size, which is half the bug.

Closes #83

## Proposed changes

### `BigInt` scalar and a scoped override mechanism

`src/cfdb/api/gql/types.py` defines `BigInt` alongside the existing `ObjectIdScalar`, following the same module-level `@strawberry.scalar` structure. One coercion function serves both `serialize` and `parse_value`, because the wire form is symmetric — the value that goes out is the value that comes back.

The output types are generated from the Pydantic models by runtime introspection, so a bare `int` maps to GraphQL `Int`. Rather than widening every `int` in the schema, `_SCALAR_OVERRIDES` maps `(model, field name)` to a replacement scalar and `annotate()` consults it first. Keying on the pair rather than the field name matters: `ExtraFile.file_size` is a same-named-shaped sibling on a different model that must stay `Int`, and so must `totalCount`, `fileCount`, and the `page`/`pageSize` arguments. `_substitute_scalar` preserves the `Optional` wrapper so `Optional[int]` becomes `Optional[BigInt]`.

`src/cfdb/api/gql/inputs.py` is hand-written, so `FileMetadataInput.size_in_bytes` changes type directly.

### Regenerate `schema.graphql`, and keep it that way

`schema.graphql` is a generated artifact that nothing in the repo regenerated or verified — the `strawberry` CLI is not an installed extra, so refreshing it meant reconstructing the `print_schema` incantation by hand, and nothing failed when the checked-in copy went stale. Add `scripts/export_schema.py` and a `make schema` target, plus a test asserting the file on disk matches what the live schema renders. That gap predates this change but is worth closing in the PR that first exercises it: the SDL is what clients codegen against, so a stale copy ships a wrong public contract silently.

### Documentation

Add a **Custom Scalars** section to `README.md` recording the wire-representation decision and the three concrete client breakages, and note `make schema` in the Makefile targets table.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestSizeInBytesScalar` | The 6,262,125,716-byte ENCODE file from the issue | The `files` query selects `sizeInBytes` | Returns the exact size with no errors | Reported symptom |
| 2 | `TestSizeInBytesScalar` | A size at zero, an ordinary size, either side of the old `Int` ceiling, the JavaScript safe-integer maximum, or the 64-bit maximum | The `files` query selects `sizeInBytes` | Returns that exact value with no errors | Round trip across the declared range |
| 3 | `TestSizeInBytesScalar` | A file with no recorded size | The `files` query selects `sizeInBytes` | Returns `null` with no errors | Optional field passthrough |
| 4 | `TestSizeInBytesScalar` | Two files, the first holding a size beyond the 64-bit range | The `files` query selects `sizeInBytes` alongside other fields | Nulls only that file's `sizeInBytes`, reports the failure at that field's path, and leaves every other field and the sibling file intact | Page survival on an unrepresentable stored value |
| 5 | `TestSizeInBytesScalar` | One file above the old ceiling and one ordinary file | The `files` query filters on the large size as a query literal | Returns only the large file | Input filter, literal path |
| 6 | `TestSizeInBytesScalar` | The same two files | The `files` query filters through a `[BigInt!]` variable | Returns only the large file | Input filter, variable coercion path |
| 7 | `TestSizeInBytesScalar` | A query declaring its size-filter variable as `[Int!]`, as a pre-`BigInt` client would | The query is executed | Fails validation naming the expected `[BigInt!]` type rather than truncating | Documented breaking change |
| 8 | `TestSizeInBytesScalar` | A filter literal that is a boolean, or one step beyond either end of the 64-bit range | The `files` query is executed | Rejects the query with a `BigInt` error rather than coercing | Scalar bounds and the `bool` trap |
| 9 | `TestSizeInBytesScalar` | A `[BigInt!]` variable carrying a numeric string or a fractional number | The `files` query is executed | Rejects the query with a `BigInt` error | Wire form stays an unambiguous JSON integer |
| 10 | `TestSizeInBytesScalar` | The published schema | `FileMetadataType` and `FileMetadataInput` are introspected | Both name `sizeInBytes` as `BigInt` | Widening reached both sides |
| 11 | `TestSizeInBytesScalar` | The published schema | `ExtraFileType.fileSize`, `FileList.totalCount`, `fileCount`, and the `page`/`pageSize` arguments are introspected | Each is still `Int` | Override did not over-apply |
| 12 | `test_schema.py` | The checked-in `schema.graphql` | The SDL is rendered from the live schema | The two are byte-identical | Generated-artifact drift |
| 13 | `test_metadata_endpoint.py` | The issue's file stored in a mongomock-backed database | The reproduction query is POSTed to `/metadata` | The raw response body carries the size as an unquoted JSON number with no errors | HTTP and JSON boundary |
| 14 | `test_metadata_endpoint.py` | The same file | A `/metadata` query filters on its size through a `[BigInt!]` variable | Matches that file | BSON encode and decode of the filter value |
