### PR TITLE
Stop raising and logging a ValidationError on every /data request — Closes #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ Stream file contents from DCCs via HTTPS.
 | 404 | File not found, or HEAD probe of a not-yet-cached processed artifact (GET would dispatch) |
 | 416 | Range not satisfiable (out of bounds, or file size unknown so no range can be satisfied) |
 | 429 | Too many active preprocessing jobs — the active-workflow ceiling (`CFDB_WORKFLOW_MAX_ACTIVE`) is reached; `Retry-After` header set. Retry shortly. |
-| 501 | No supported access method (e.g., Globus-only files) |
+| 501 | No supported access method — the record carries no access URL, or the file is reachable only by an unsupported transfer (e.g. Globus-only files) |
 | 502 | Upstream service error |
 | 503 | Workflow subsystem shutting down (`Retry-After`) |
 | 504 | Service timeout |

--- a/src/cfdb/api/routers/data.py
+++ b/src/cfdb/api/routers/data.py
@@ -36,22 +36,28 @@ router = APIRouter(prefix="/data", tags=["data"])
 
 
 @dataclass(frozen=True)
-class FileRef:
-    """The two projected fields the /data streaming path actually reads.
+class _FileRef:
+    """What the /data handler needs to fetch a file and label the response.
 
-    ``FILE_DOC_PROJECTION`` returns a deliberately narrow document — far
-    too narrow to populate a ``FileMetadataModel``, whose ``collections``
-    field is required and never projected. Nothing past the lookup needs
-    the richer type: the handler reads ``access_url`` to fetch from and
-    ``filename`` to label the response with, and nothing else.
+    Built from the projected document rather than by validating a
+    ``FileMetadataModel``: ``FILE_DOC_PROJECTION`` never selects
+    ``collections``, which that model requires, so the validation could
+    only ever fail — and nothing past the lookup needs the richer type.
+
+    This is not the whole of what the request reads. ``file_doc`` travels
+    on to the access guard and the workflow layer, which read fields this
+    record deliberately does not carry.
     """
 
-    #: Upstream URL or DRS URI; ``None`` when the record has no access
-    #: method, which the handler turns into a 501.
-    access_url: str | None
+    #: Upstream URL or DRS URI. Non-empty by construction: the handler
+    #: answers 501 before building this when the record has no access
+    #: method.
+    access_url: str
     #: Name used for the Content-Disposition header and media-type
     #: sniffing; falls back to ``"file"`` when the record has none.
     filename: str
+    #: Total size, or ``None`` when the record does not report one.
+    size_in_bytes: int | None
 
 
 @router.head("/{dcc}/{local_id}")
@@ -139,23 +145,23 @@ async def stream_file(
                 status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
             )
 
-        # 2. Reduce the document to the two fields the streaming path reads.
-        #    Built directly rather than by validating a FileMetadataModel:
-        #    FILE_DOC_PROJECTION deliberately omits `collections`, which the
-        #    model requires, so that validation could only ever fail — and
-        #    nothing downstream consumes the richer type anyway.
-        file_metadata = FileRef(
-            access_url=file_doc.get("access_url"),
-            filename=file_doc.get("filename") or "file",
-        )
-
-        # 3. Check if file has access_url
-        if not file_metadata.access_url:
+        # 3. Check the file has an access method, then reduce the document
+        #    to what the streaming path reads. Guarding first is what lets
+        #    _FileRef.access_url be a plain str rather than an Optional the
+        #    call ordering happens to have narrowed.
+        access_url = file_doc.get("access_url")
+        if not access_url:
             logger.warning(f"File has no access_url: {normalized_dcc}/{local_id}")
             raise HTTPException(
                 status_code=status.HTTP_501_NOT_IMPLEMENTED,
                 detail="File has no access URL",
             )
+
+        file_metadata = _FileRef(
+            access_url=access_url,
+            filename=file_doc.get("filename") or "file",
+            size_in_bytes=file_doc.get("size_in_bytes"),
+        )
 
         # 4. Defence-in-depth: reject any non-public HuBMAP file that somehow
         #    survived pruning. Placed before the workflow branch so protected
@@ -183,7 +189,7 @@ async def stream_file(
 
         # ENCODE files: Stream directly via HTTPS (bypass DRS)
         if normalized_dcc == "encode":
-            return await _stream_encode_file(file_doc, file_metadata, request, range)
+            return await _stream_encode_file(file_metadata, request, range)
 
         # 6. Fetch DRS object metadata
         try:
@@ -374,8 +380,7 @@ async def stream_file_status(
 
 
 async def _stream_encode_file(
-    file_doc: dict,
-    file_metadata: FileRef,
+    file_metadata: _FileRef,
     request: Request,
     range_header: Optional[str] = None,
 ):
@@ -386,8 +391,7 @@ async def _stream_encode_file(
     We stream directly from the ENCODE download URL.
 
     Args:
-        file_doc: MongoDB document for the file
-        file_metadata: The file's access URL and filename
+        file_metadata: The file's access URL, filename, and size
         request: FastAPI request object
         range_header: Optional Range header value
 
@@ -396,18 +400,17 @@ async def _stream_encode_file(
     """
     download_url = file_metadata.access_url
     filename = file_metadata.filename
-    file_size = file_doc.get("size_in_bytes")
+    file_size = file_metadata.size_in_bytes
 
     logger.info(f"Streaming ENCODE file: {filename} from {download_url}")
 
     # Determine media type from filename; default to binary. (Branches
     # that resolve to the default are folded away.)
     media_type = "application/octet-stream"
-    if filename:
-        if filename.endswith(".gz"):
-            media_type = "application/gzip"
-        elif filename.endswith((".fastq", ".fq", ".bed")):
-            media_type = "text/plain"
+    if filename.endswith(".gz"):
+        media_type = "application/gzip"
+    elif filename.endswith((".fastq", ".fq", ".bed")):
+        media_type = "text/plain"
 
     try:
         return stream_upstream_url(

--- a/src/cfdb/api/routers/data.py
+++ b/src/cfdb/api/routers/data.py
@@ -1,6 +1,7 @@
 """REST API router for streaming files from DCCs."""
 
 import logging
+from dataclasses import dataclass
 from typing import Optional
 
 from fastapi import APIRouter, Header, HTTPException, Path, Request, status
@@ -12,7 +13,6 @@ from cfdb.api.routers.cache_stream import (
     serve_workflow_artifact_or_dispatch,
     stream_upstream_url,
 )
-from cfdb.models import FileMetadataModel
 from cfdb.services import drs, locks
 from cfdb.services.drs import (
     DRSError,
@@ -33,6 +33,25 @@ _PATH_PARAM_MAX_LEN = 256
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/data", tags=["data"])
+
+
+@dataclass(frozen=True)
+class FileRef:
+    """The two projected fields the /data streaming path actually reads.
+
+    ``FILE_DOC_PROJECTION`` returns a deliberately narrow document — far
+    too narrow to populate a ``FileMetadataModel``, whose ``collections``
+    field is required and never projected. Nothing past the lookup needs
+    the richer type: the handler reads ``access_url`` to fetch from and
+    ``filename`` to label the response with, and nothing else.
+    """
+
+    #: Upstream URL or DRS URI; ``None`` when the record has no access
+    #: method, which the handler turns into a 501.
+    access_url: str | None
+    #: Name used for the Content-Disposition header and media-type
+    #: sniffing; falls back to ``"file"`` when the record has none.
+    filename: str
 
 
 @router.head("/{dcc}/{local_id}")
@@ -120,37 +139,15 @@ async def stream_file(
                 status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
             )
 
-        # 2. Parse file metadata
-        try:
-            # Extract only the fields needed for the API from the database document
-            file_data = {
-                k: v
-                for k, v in file_doc.items()
-                if k in FileMetadataModel.model_fields
-                and k
-                not in ("dcc", "collections")  # Skip required fields not in database
-            }
-            file_metadata = FileMetadataModel(**file_data)
-        except Exception:
-            logger.exception("Failed to parse file metadata")
-            # Try to extract just the access_url if full parsing fails
-            access_url = file_doc.get("access_url")
-            if not access_url:
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="Invalid file metadata in database",
-                )
-            # Create a minimal metadata object with just access_url
-            from dataclasses import dataclass
-
-            @dataclass
-            class MinimalMetadata:
-                access_url: str
-                filename: str
-
-            file_metadata = MinimalMetadata(
-                access_url=access_url, filename=file_doc.get("filename", "file")
-            )
+        # 2. Reduce the document to the two fields the streaming path reads.
+        #    Built directly rather than by validating a FileMetadataModel:
+        #    FILE_DOC_PROJECTION deliberately omits `collections`, which the
+        #    model requires, so that validation could only ever fail — and
+        #    nothing downstream consumes the richer type anyway.
+        file_metadata = FileRef(
+            access_url=file_doc.get("access_url"),
+            filename=file_doc.get("filename") or "file",
+        )
 
         # 3. Check if file has access_url
         if not file_metadata.access_url:
@@ -378,7 +375,7 @@ async def stream_file_status(
 
 async def _stream_encode_file(
     file_doc: dict,
-    file_metadata,
+    file_metadata: FileRef,
     request: Request,
     range_header: Optional[str] = None,
 ):
@@ -390,7 +387,7 @@ async def _stream_encode_file(
 
     Args:
         file_doc: MongoDB document for the file
-        file_metadata: Parsed file metadata (FileMetadataModel or MinimalMetadata)
+        file_metadata: The file's access URL and filename
         request: FastAPI request object
         range_header: Optional Range header value
 
@@ -398,9 +395,7 @@ async def _stream_encode_file(
         StreamingResponse with file contents
     """
     download_url = file_metadata.access_url
-    filename = getattr(file_metadata, "filename", None) or file_doc.get(
-        "filename", "file"
-    )
+    filename = file_metadata.filename
     file_size = file_doc.get("size_in_bytes")
 
     logger.info(f"Streaming ENCODE file: {filename} from {download_url}")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -970,11 +970,14 @@ def _make_encode_file_doc(**overrides) -> dict:
     return doc
 
 
-def _data_router_errors(caplog) -> list[logging.LogRecord]:
+def _cfdb_errors(caplog) -> list[logging.LogRecord]:
+    # Matched across the whole cfdb logger tree rather than the data
+    # router's own name, so the pin follows the reduction if it is ever
+    # hoisted into _helpers alongside lookup_file_doc.
     return [
         record
         for record in caplog.records
-        if record.name == "cfdb.api.routers.data" and record.levelno >= logging.ERROR
+        if record.name.startswith("cfdb.") and record.levelno >= logging.ERROR
     ]
 
 
@@ -1009,7 +1012,7 @@ class TestStreamFileMetadataReduction:
 
         # Assert
         assert response.status_code == 200
-        errors = _data_router_errors(caplog)
+        errors = _cfdb_errors(caplog)
         assert errors == [], [record.getMessage() for record in errors]
 
     @pytest.mark.asyncio
@@ -1042,7 +1045,7 @@ class TestStreamFileMetadataReduction:
 
         # Assert
         assert exc_info.value.status_code == 403
-        errors = _data_router_errors(caplog)
+        errors = _cfdb_errors(caplog)
         assert errors == [], [record.getMessage() for record in errors]
 
     @pytest.mark.asyncio
@@ -1080,7 +1083,7 @@ class TestStreamFileMetadataReduction:
 
         # Assert
         assert exc_info.value.status_code == 501
-        errors = _data_router_errors(caplog)
+        errors = _cfdb_errors(caplog)
         assert errors == [], [record.getMessage() for record in errors]
 
     @pytest.mark.asyncio
@@ -1090,6 +1093,7 @@ class TestStreamFileMetadataReduction:
             ("ENCFF268EYE.bed", "text/plain"),
             ("ENCFF268EYE.fastq.gz", "application/gzip"),
             (None, "application/octet-stream"),
+            ("", "application/octet-stream"),
         ],
     )
     async def test_stream_file_should_carry_the_document_filename_downstream(
@@ -1099,13 +1103,14 @@ class TestStreamFileMetadataReduction:
 
         Given:
             An ENCODE file document whose filename is a BED name, a
-            gzipped name, or absent entirely.
+            gzipped name, absent entirely, or present but empty — the
+            last being the shape a bad upstream record produces.
         When:
             stream_file is called for it.
         Then:
             The response should carry the media type that name implies,
-            falling back to a generic name and octet-stream when the
-            document has none.
+            falling back to a generic name and octet-stream whenever the
+            document supplies no usable one.
         """
         # Arrange
         mocker.patch.object(locks, "wait_for_cutover", return_value=None)
@@ -1127,3 +1132,37 @@ class TestStreamFileMetadataReduction:
         assert response.headers["content-disposition"] == (
             f'attachment; filename="{filename or "file"}"'
         )
+
+    @pytest.mark.asyncio
+    async def test_stream_file_should_log_an_error_when_it_genuinely_fails(
+        self, mock_db, mocker, caplog
+    ):
+        """Test that a real failure still produces an error signal.
+
+        Given:
+            A lookup that raises an unexpected exception.
+        When:
+            stream_file is called.
+        Then:
+            It should raise the 500 and log an ERROR record — the
+            positive control that keeps the absence assertions above
+            from passing on a broken capture path.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mocker.patch(
+            "cfdb.api.routers.data.lookup_file_doc",
+            side_effect=RuntimeError("lookup exploded"),
+        )
+        mock_db.file.docs = [_make_encode_file_doc()]
+
+        # Act
+        with (
+            caplog.at_level(logging.INFO, logger="cfdb.api.routers.data"),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await stream_file("encode", "ENCFF268EYE", _make_request(), range=None)
+
+        # Assert
+        assert exc_info.value.status_code == 500
+        assert _cfdb_errors(caplog) != []

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
@@ -947,3 +949,181 @@ class TestStreamFileStatus:
 
         # Assert
         assert result == {"ready": True}
+
+
+def _make_encode_file_doc(**overrides) -> dict:
+    doc = {
+        "submission": "encode",
+        "id_namespace": "tag:encodeproject.org,2017:",
+        "local_id": "ENCFF268EYE",
+        "filename": "ENCFF268EYE.bed",
+        "md5": FIXTURE_MD5,
+        "access_url": (
+            "https://www.encodeproject.org/files/ENCFF268EYE"
+            "/@@download/ENCFF268EYE.bed"
+        ),
+        "dcc": {"dcc_abbreviation": "ENCODE"},
+        "file_format": {"name": "BED"},
+        "size_in_bytes": 1024,
+    }
+    doc.update(overrides)
+    return doc
+
+
+def _data_router_errors(caplog) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == "cfdb.api.routers.data" and record.levelno >= logging.ERROR
+    ]
+
+
+class TestStreamFileMetadataReduction:
+    """The file reference /data streams from is built off the document."""
+
+    @pytest.mark.asyncio
+    async def test_stream_file_should_log_no_error_when_the_request_succeeds(
+        self, mock_db, mocker, caplog
+    ):
+        """Test that a served /data request produces no error signal.
+
+        Given:
+            A public ENCODE file document and an unwired workflow
+            subsystem, so the request streams straight from upstream.
+        When:
+            stream_file is called for it.
+        Then:
+            It should return a 200 response and log no ERROR record from
+            the data router.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mocker.patch.object(api, "processor_registry", None)
+        mock_db.file.docs = [_make_encode_file_doc()]
+
+        # Act
+        with caplog.at_level(logging.INFO, logger="cfdb.api.routers.data"):
+            response = await stream_file(
+                "encode", "ENCFF268EYE", _make_request(), range=None
+            )
+
+        # Assert
+        assert response.status_code == 200
+        errors = _data_router_errors(caplog)
+        assert errors == [], [record.getMessage() for record in errors]
+
+    @pytest.mark.asyncio
+    async def test_stream_file_should_log_no_error_when_access_is_refused(
+        self, mock_db, mocker, caplog
+    ):
+        """Test that a refused /data request produces only its own signal.
+
+        Given:
+            A HuBMAP file whose data_access_level is "consortium".
+        When:
+            stream_file is called for it.
+        Then:
+            It should raise the 403 and log no ERROR record from the data
+            router, since the file reference is built before the access
+            guard runs.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mocker.patch.object(api, "processor_registry", None)
+        mock_db.dcc.docs = [_make_dcc_doc()]
+        mock_db.file.docs = [_make_file_doc(access_level="consortium")]
+
+        # Act
+        with (
+            caplog.at_level(logging.INFO, logger="cfdb.api.routers.data"),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await stream_file("hubmap", "file-1", _make_request(), range=None)
+
+        # Assert
+        assert exc_info.value.status_code == 403
+        errors = _data_router_errors(caplog)
+        assert errors == [], [record.getMessage() for record in errors]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("access_url", [None, ""])
+    async def test_stream_file_should_raise_501_when_no_access_url(
+        self, mock_db, mocker, caplog, access_url
+    ):
+        """Test that a file with no access method mirrors /status's 501.
+
+        Given:
+            An ENCODE file document whose access_url is absent or empty.
+        When:
+            stream_file is called for it.
+        Then:
+            It should raise HTTPException(501) — the same code the
+            /status probe reports for the same record — and log no ERROR
+            record from the data router.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mocker.patch.object(api, "processor_registry", None)
+        doc = _make_encode_file_doc()
+        if access_url is None:
+            del doc["access_url"]
+        else:
+            doc["access_url"] = access_url
+        mock_db.file.docs = [doc]
+
+        # Act
+        with (
+            caplog.at_level(logging.INFO, logger="cfdb.api.routers.data"),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await stream_file("encode", "ENCFF268EYE", _make_request(), range=None)
+
+        # Assert
+        assert exc_info.value.status_code == 501
+        errors = _data_router_errors(caplog)
+        assert errors == [], [record.getMessage() for record in errors]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("filename", "expected_media_type"),
+        [
+            ("ENCFF268EYE.bed", "text/plain"),
+            ("ENCFF268EYE.fastq.gz", "application/gzip"),
+            (None, "application/octet-stream"),
+        ],
+    )
+    async def test_stream_file_should_carry_the_document_filename_downstream(
+        self, mock_db, mocker, filename, expected_media_type
+    ):
+        """Test that the streamed response is labelled from the document.
+
+        Given:
+            An ENCODE file document whose filename is a BED name, a
+            gzipped name, or absent entirely.
+        When:
+            stream_file is called for it.
+        Then:
+            The response should carry the media type that name implies,
+            falling back to a generic name and octet-stream when the
+            document has none.
+        """
+        # Arrange
+        mocker.patch.object(locks, "wait_for_cutover", return_value=None)
+        mocker.patch.object(api, "processor_registry", None)
+        doc = _make_encode_file_doc()
+        if filename is None:
+            del doc["filename"]
+        else:
+            doc["filename"] = filename
+        mock_db.file.docs = [doc]
+
+        # Act
+        response = await stream_file(
+            "encode", "ENCFF268EYE", _make_request(), range=None
+        )
+
+        # Assert
+        assert response.media_type == expected_media_type
+        assert response.headers["content-disposition"] == (
+            f'attachment; filename="{filename or "file"}"'
+        )


### PR DESCRIPTION
Closes #88

## What was wrong

Every `GET`/`HEAD /data/{dcc}/{local_id}` raised a `pydantic.ValidationError`, logged a full ERROR traceback, and then completed normally through the `except` branch. The parse could not succeed under any input: it filtered the projected document down to `FileMetadataModel`'s fields and then explicitly dropped the only two the model requires. `dcc` was dropped needlessly — `FILE_DOC_PROJECTION` does select `dcc.dcc_abbreviation`, and `Dcc` has no required fields of its own, so it would have validated — but `collections` is genuinely never projected, so the construction was unreachable-by-construction rather than data-dependent. One ERROR traceback per `/data` call, in every environment, on requests that succeeded.

## The fix, and why this one

The issue offers three candidates. This PR takes the second: drop the `FileMetadataModel` construction entirely and build the minimal object unconditionally.

The deciding question is what the parsed object is genuinely used for. It is read in exactly two ways: `.access_url` (four sites) and `getattr(file_metadata, "filename", None)` in `_stream_encode_file`. Nothing consumes the richer type, and that `getattr` with a fallback was already conceding the object's type was not knowable. If the richer model buys nothing, constructing it is the defect — not the exclusion list being wrong. So a small frozen `_FileRef` is built straight off the document, the `try`/`except` is gone, and `_stream_encode_file` now takes that one fully-typed argument instead of the document plus a partial view of it.

Against the other two:

- **Pass `collections` through and stop excluding `dcc`.** Smaller in line count, but it keeps a construction whose only purpose is to be partly filled and then have two attributes read off it, leaves the `except` branch and its locally-defined `MinimalMetadata` dataclass as unreachable code, and makes the object *more* misleading rather than less: `dcc` would be typed as a full `Dcc` while carrying only `dcc_abbreviation`, and `collections` would always be `[]` regardless of the file's real collections. It removes the log line without removing the reason the log line existed.
- **Give `collections` a default on the model.** Largest blast radius, and the only one that reaches beyond this router. `FileMetadataModel` is shared with the GraphQL layer and the materializer — and the GraphQL layer builds it from *unprojected* documents, so `collections` is a live guarantee there. Weakening it to accommodate a router that does not use the field trades a real schema invariant for a local convenience.

## One behaviour change

A document with no `access_url` previously produced `500 Invalid file metadata in database`, because the doomed parse always ran first and its handler checked `access_url` before the real guard was ever reached. That guard — `501 File has no access URL` — was dead code. It is now live, which is what the README's `/data` table already documented (it lists 501 and has no entry for such a 500) and what the sibling `/data/{dcc}/{local_id}/status` probe already returned for the very same record. The README's 501 row previously named only the Globus case; this PR widens it to name both sub-cases, since the other one is now materially more reachable.

## Verification of the issue's claims

All checked against the code rather than taken on trust: `dcc` **is** projected by `FILE_DOC_PROJECTION`; `Dcc` has no required fields; `collections` is genuinely absent from the projection (`FileMetadataModel`'s required set is exactly `['dcc', 'collections']`); `stream_file_status` does not perform the parse; and `routers/index.py` neither imports `FileMetadataModel` nor builds any equivalent object — it reads `file_doc` fields directly throughout, so the pattern is specific to `data.py`.

## Tests

Nine new cases in `TestStreamFileMetadataReduction`; four fail on the pre-fix code (verified by running them against `master`'s `data.py`).

- Two `caplog` pins assert that no ERROR record is emitted — on a request that is served, and on one refused with 403, since the file reference is built before the access guard runs. They assert nothing about the shape of the object the handler builds, because such an assertion would hold on the buggy code too and would pin nothing. A third case is their positive control: it forces the lookup to raise and asserts an ERROR record *does* appear, so the two absence assertions cannot pass on a broken capture path.
- Two cases pin the 501 for a document whose access method is absent or empty.
- Four parametrized cases guard the filename plumbing across the `data.py` → `cache_stream.py` seam via the response media type and `Content-Disposition`. Three do not discriminate between old and new code; they exist because the fix deleted the `getattr(...) or file_doc.get(...)` double fallback. The fourth — a filename present but empty — covers the one semantic the fix actually changed, `.get(k, default)` to `.get(k) or default`.

Full suite: 823 passed, 3 skipped.

## Review

A seven-reviewer principal-engineer round returned no blocking findings. Its advisory findings on the change itself are all applied: the record is private and its `access_url` is a plain `str` established by guarding before construction rather than by statement ordering; `size_in_bytes` folded in so the ENCODE streamer takes one argument; the now-dead `if filename:` guard dropped; the duplicated rationale collapsed to one copy; the docstring scoped, since the document itself still travels on to the access guard and the workflow layer. Four pre-existing defects the diff sits near were raised and deliberately left alone: the `file_meta` docstring in `workflows/processors/base.py` still describes a `FileMetadataModel.model_dump()` where the projected document actually flows, two `except Exception` blocks in this router log `str(e)` without a traceback, `Content-Disposition` interpolates the document filename unquoted, and a non-`str` filename surfaces as an unexplained 500.
