### PR TITLE
Populate compression_format on ENCODE file documents in the scraper — Closes #31

### DIFF
--- a/ENCODE-SUPPLEMENT.md
+++ b/ENCODE-SUPPLEMENT.md
@@ -93,6 +93,7 @@ ENCODE uses human-readable strings for file formats, assay types, output types, 
 | `creation_time` | `Experiment date released` | string | ISO date |
 | `data_access_level` | — | string | Constant: `"public"` (all released ENCODE files) |
 | `file_format` | `File format` | FileFormat | Mapped via `FILE_FORMAT_TO_EDAM` |
+| `compression_format` | `File download URL` | string | EDAM term ID derived from the URL's filename suffix via `COMPRESSION_SUFFIX_TO_EDAM`; `""` when no compression suffix is present; **omitted** when compressed in a format no EDAM term names (`UNMAPPABLE_COMPRESSION_SUFFIXES`) or when the URL carries no filename. Derived from the URL only — never from the accession-synthesized `filename`, which cannot carry a suffix. `format:3989` means gzip-family and does not exclude BGZF. The TSV has no compression column. |
 | `data_type` | `Output type` | DataType | Mapped via `OUTPUT_TYPE_TO_EDAM` |
 | `assay_type` | `Assay` | AssayType | Mapped via `ASSAY_TITLE_TO_OBI` |
 
@@ -246,6 +247,7 @@ fetch_encode_metadata()                 # Streaming TSV from ENCODE API
   │
   └─> transform_to_c2m2(row)            # Per-row transformation
         ├─ Map File format -> EDAM      # ontology_mappings.get_file_format()
+        ├─ Derive compression -> EDAM   # from the download URL's suffix
         ├─ Map Output type -> EDAM      # ontology_mappings.get_data_type()
         ├─ Map Assay -> OBI             # ontology_mappings.get_assay_type()
         ├─ Map Organism -> NCBI         # ontology_mappings.get_taxonomy()

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ The central entity representing a stable digital asset.
 | `md5` | string? | MD5 checksum (if SHA-256 unavailable) |
 | `filename` | string | Filename without path |
 | `file_format` | FileFormat? | EDAM CV term for digital format |
-| `compression_format` | string? | EDAM CV term for compression (e.g., gzip) |
+| `compression_format` | string? | EDAM CV term ID for compression (e.g., `format:3989` for gzip); `""` when no compression is recorded or recognized; null/absent when undetermined. Read the note below before relying on it. |
 | `data_type` | DataType? | EDAM CV term for data type |
 | `assay_type` | AssayType? | OBI CV term for experiment type |
 | `analysis_type` | string? | OBI CV term for analysis type |
@@ -473,6 +473,10 @@ The central entity representing a stable digital asset.
 | `status` | string? | Dataset status (e.g., "Published", "QA") |
 | `data_access_level` | string? | Access level: public, consortium, or protected |
 | `extra` | EnrichedFile? | DCC-specific file metadata (see EnrichedFile) |
+
+**A note on `compression_format`, because it is easy to over-read.** The field reports compression that is *extrinsic* to `file_format` — a wrapper the source reveals and `file_format` does not. It is not a statement about whether the bytes are compressed. A BAM, bigWig or bigBed carries `""` despite being internally compressed, because its `file_format` already names that container. Conversely 4DN and HuBMAP take the value straight from their upstream C2M2 datapackage, which in practice leaves it blank on every file — including gzipped ones — so `""` from those DCCs means "upstream recorded nothing", not "uncompressed". Never treat `""` as a licence to skip inspecting the bytes.
+
+ENCODE derives the value from the download URL's filename suffix, because the ENCODE metadata TSV has no compression column. Two consequences are worth knowing. The field is **absent** (rendered as null) rather than `""` when nothing could be determined — no filename in the URL, or a compression suffix no EDAM term expresses (`.bz2`, `.xz`, `.zst`, `.zip`, `.starch`) — so treat null as "sniff the bytes", never as "uncompressed". And `format:3989` means "gzip-family stream": ENCODE names both plain gzip and BGZF `.gz` (it publishes no `.bgz` at all, and roughly a quarter of its `.gz` files are BGZF), so the value cannot distinguish them. Anything deciding on `gunzip | bgzip` must read the BGZF header — which is what `cfdb.workflows.processors.tabix` does, deliberately, and that byte-level check remains the decision of record.
 
 #### Dcc
 

--- a/src/cfdb/models.py
+++ b/src/cfdb/models.py
@@ -387,8 +387,13 @@ class FileMetadataModel(BaseModel):
             (e.g., TSV or FASTQ). If compressed, this is the uncompressed format.
 
         compression_format:
-            An EDAM CV term ID identifying the compression format (e.g., gzip or
-            bzip2). None if file is not compressed.
+            An EDAM CV term ID identifying compression that is extrinsic to
+            file_format (e.g., "format:3989" for gzip). The empty string means
+            no compression was recorded or recognized -- NOT that the bytes are
+            uncompressed, since a BAM or bigWig is internally compressed and
+            carries it, and the C2M2-sourced DCCs leave the upstream column
+            blank on gzipped files. None means no determination was possible;
+            neither value licenses skipping a byte-level check.
 
         data_type:
             An EDAM CV term ID identifying the type of information stored in this

--- a/src/cfdb/services/encode.py
+++ b/src/cfdb/services/encode.py
@@ -14,6 +14,9 @@ File
 ~~~~
 File accession                  → local_id
 File download URL               → access_url, filename (derived)
+File download URL               → compression_format (suffix-derived; the TSV
+                                  carries no compression column, and the field
+                                  is omitted when undetermined)
 File format                     → file_format (EDAM-mapped)
 Output type                     → data_type (EDAM-mapped), output_type
 Assay                           → assay_type (OBI-mapped)
@@ -101,6 +104,7 @@ Static / config-derived:          dcc.id, dcc.dcc_name, dcc.dcc_abbreviation,
 import logging
 import re
 from typing import AsyncGenerator, Optional
+from urllib.parse import unquote, urlsplit
 
 import aiohttp
 
@@ -199,6 +203,99 @@ def _parse_int(value: str | None) -> int | None:
         return None
 
 
+# Compression suffix to EDAM CV term ID, verified against OLS4: format:3989 is
+# "GZIP format" (extensions gz, gzip), format:3615 is "bgzip" (bgz). Beware
+# format:3990, which adjoins them and is "AVI", not the bzip2 term it looks
+# like. The ENCODE metadata TSV carries no compression column (verified against
+# the live 59-column header), so the filename suffix is the only indicator.
+#
+# Only .gz and .starch actually occur in the released ENCODE corpus; the rest
+# are defensive. The suffix cannot distinguish BGZF from plain gzip — ENCODE
+# publishes no .bgz and roughly a quarter of its .gz files are BGZF — so
+# format:3989 here means "gzip-family stream", not "not bgzip".
+COMPRESSION_SUFFIX_TO_EDAM = {
+    ".gz": "format:3989",
+    ".gzip": "format:3989",
+    ".tgz": "format:3989",  # gzip-compressed tar; same bytes as .tar.gz
+    ".bgz": "format:3615",
+}
+
+# Suffixes that mark a file as compressed but that no EDAM term can express.
+# EDAM has no bzip2, xz, zstd or starch term. .zip is here despite having one
+# (format:3987) because a ZIP holds many members with many formats, so there is
+# no single post-decompression file_format to pair it with, and the tabix
+# processor rejects the PK magic outright — calling it a named compression
+# would invite a consumer to decompress and feed it onward. .starch is a
+# BEDOPS-compressed BED archive whose file_format already maps to plain BED.
+#
+# These resolve to None rather than to UNCOMPRESSED: they are compressed, so
+# claiming otherwise would be worse than admitting we cannot say.
+UNMAPPABLE_COMPRESSION_SUFFIXES = (".bz2", ".xz", ".zst", ".zip", ".starch")
+
+# Longest suffix first, so a more specific suffix is never shadowed by a
+# shorter one it ends with.
+_COMPRESSION_SUFFIXES: tuple[tuple[str, str | None], ...] = tuple(
+    sorted(
+        list(COMPRESSION_SUFFIX_TO_EDAM.items())
+        + [(suffix, None) for suffix in UNMAPPABLE_COMPRESSION_SUFFIXES],
+        key=lambda item: len(item[0]),
+        reverse=True,
+    )
+)
+
+# Sentinel for "no compression beyond what file_format already implies",
+# mirroring the value 4DN and HuBMAP carry from their upstream C2M2
+# datapackages. It is NOT a claim that the bytes are uncompressed: BAM, bigWig
+# and bigBed are internally compressed and carry this value, because their
+# file_format names the container rather than its decompressed contents.
+# Distinct from None, which means no determination was possible at all.
+UNCOMPRESSED = ""
+
+
+def derive_compression_format(filename_or_url: str | None) -> str | None:
+    """
+    Derive the EDAM compression term ID from a filename or download URL.
+
+    Reports only compression that is *extrinsic* to the declared file format —
+    a wrapper the filename reveals and file_format does not. A .bam is not
+    reported as compressed even though BGZF underlies it, because its
+    file_format already names that container; a .starch is not reported as
+    uncompressed, because its file_format names the BED it decompresses to.
+
+    Args:
+        filename_or_url: A bare filename or a full download URL.
+
+    Returns:
+        The EDAM CV term ID for the compression format (e.g. "format:3989"
+        for gzip); "" when the name carries no compression suffix; or None
+        when no determination is possible — either because no name was
+        available, or because the name ends in a compression suffix no EDAM
+        term can express.
+    """
+    value = _nonempty(filename_or_url)
+    if value is None:
+        return None
+
+    # Reduce to a basename. Query strings and fragments are URL syntax, so they
+    # are stripped only when the value actually is a URL — in a bare filename a
+    # '?' or '#' is an ordinary character and must not truncate the name.
+    if "://" in value:
+        basename = unquote(urlsplit(value).path).rsplit("/", 1)[-1]
+    else:
+        basename = value.rsplit("/", 1)[-1]
+    basename = basename.lower()
+    if not basename:
+        # A directory-style URL carries no evidence either way. Reporting it
+        # as uncompressed would be a positive claim about a file we cannot see.
+        return None
+
+    for suffix, term_id in _COMPRESSION_SUFFIXES:
+        if basename.endswith(suffix):
+            return term_id
+
+    return UNCOMPRESSED
+
+
 def _extract_donor_ids(donors_str: str | None) -> list[str]:
     """
     Extract donor accession IDs from the Donor(s) TSV field.
@@ -281,6 +378,16 @@ def transform_to_c2m2(row: dict) -> Optional[dict]:
         "creation_time": _nonempty(row.get("Experiment date released")),
         "persistent_id": f"https://www.encodeproject.org/files/{accession}/",
     }
+
+    # Add compression format if it could be determined. Derived from the
+    # download URL alone: when the row has no URL, `filename` is synthesized
+    # from the accession and cannot carry a compression suffix, so deriving
+    # from it would assert "uncompressed" on no evidence. Left absent rather
+    # than set to None so an undetermined file does not surface as a null in
+    # distinctValues, which the compressionFormat filter cannot select.
+    compression_format_edam = derive_compression_format(access_url)
+    if compression_format_edam is not None:
+        doc["compression_format"] = compression_format_edam
 
     # Add file format if mapped
     if file_format_edam:

--- a/src/cfdb/services/ontology_mappings.py
+++ b/src/cfdb/services/ontology_mappings.py
@@ -220,14 +220,6 @@ ORGANISM_TO_NCBI_TAXONOMY = {
     "Caenorhabditis elegans": {"id": "NCBI:txid6239", "name": "Caenorhabditis elegans", "clade": "species"},
 }
 
-# Compression format mapping
-COMPRESSION_TO_EDAM = {
-    "gzip": "format:3989",
-    "gz": "format:3989",
-    "bz2": "format:3990",
-    "zip": "format:3987",
-}
-
 
 def get_file_format(encode_format: str) -> dict | None:
     """

--- a/src/cfdb/services/sync.py
+++ b/src/cfdb/services/sync.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import subprocess
+from collections import Counter
 from copy import copy
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -842,6 +843,11 @@ async def _sync_encode(task: SyncTask) -> None:
 
         batch = []
         count = 0
+        # Tally the derived compression terms. The derivation depends on the
+        # shape of ENCODE's download URLs, which nobody here controls, so a
+        # corpus-wide flip (an upstream column rename, a redirect stub) would
+        # otherwise be invisible behind an unchanged row count.
+        compression_counts: Counter[str | None] = Counter()
 
         async for encode_file in fetch_encode_metadata():
             # Transform to C2M2 format
@@ -849,6 +855,7 @@ async def _sync_encode(task: SyncTask) -> None:
             if doc is None:
                 continue
 
+            compression_counts[doc.get("compression_format")] += 1
             batch.append(doc)
             count += 1
 
@@ -866,6 +873,13 @@ async def _sync_encode(task: SyncTask) -> None:
 
     task.progress = f"ENCODE sync complete: {count} files"
     logger.info(task.progress)
+    logger.info(
+        "ENCODE compression_format distribution: %s",
+        {
+            ("undetermined" if term is None else term or "uncompressed"): tally
+            for term, tally in compression_counts.most_common()
+        },
+    )
 
 
 async def _materialize_files(submission: str) -> None:

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,0 +1,541 @@
+"""Tests for ENCODE compression-format derivation and row transformation."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from cfdb.services.encode import (
+    COMPRESSION_SUFFIX_TO_EDAM,
+    UNCOMPRESSED,
+    UNMAPPABLE_COMPRESSION_SUFFIXES,
+    derive_compression_format,
+    transform_to_c2m2,
+)
+
+DOWNLOAD_URL = "https://www.encodeproject.org/files/ENCFF123ABC/@@download/{name}"
+
+# Every value the derivation is allowed to produce, for closed-domain
+# assertions.
+DERIVED_VALUES = set(COMPRESSION_SUFFIX_TO_EDAM.values()) | {UNCOMPRESSED, None}
+
+
+def _encode_row(**overrides) -> dict:
+    """Return a minimal but realistic ENCODE metadata TSV row."""
+    row = {
+        "File accession": "ENCFF123ABC",
+        "File format": "bed narrowPeak",
+        "File download URL": DOWNLOAD_URL.format(name="ENCFF123ABC.bed.gz"),
+        "Output type": "peaks",
+        "Assay": "TF ChIP-seq",
+        "Size": "1024",
+        "md5sum": "d41d8cd98f00b204e9800998ecf8427e",
+        "File Status": "released",
+        "Experiment date released": "2020-01-01",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_compression_suffix_tables_should_hold_the_verified_edam_terms():
+    """Test the suffix vocabulary against literal, externally verified IDs.
+
+    Given:
+        The EDAM terms resolved against OLS4: format:3989 is "GZIP format"
+        (extensions gz, gzip), format:3615 is "bgzip", and format:3990 is
+        "AVI" rather than the bzip2 term it resembles.
+    When:
+        The published suffix tables are compared to those literals.
+    Then:
+        They should match exactly, so a mistyped or dropped term cannot ship
+        unnoticed.
+    """
+    # Act & assert
+    assert COMPRESSION_SUFFIX_TO_EDAM == {
+        ".gz": "format:3989",
+        ".gzip": "format:3989",
+        ".tgz": "format:3989",
+        ".bgz": "format:3615",
+    }
+    assert UNMAPPABLE_COMPRESSION_SUFFIXES == (
+        ".bz2",
+        ".xz",
+        ".zst",
+        ".zip",
+        ".starch",
+    )
+
+
+def test_derive_compression_format_should_return_gzip_term_when_url_ends_in_gz():
+    """Test the canonical ENCODE download URL for a gzipped file.
+
+    Given:
+        The real ENCODE download URL shape, whose basename ends in ".bed.gz"
+        and whose path contains an "@@download" segment.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return the EDAM gzip term ID.
+    """
+    # Arrange
+    url = DOWNLOAD_URL.format(name="ENCFF123ABC.bed.gz")
+
+    # Act
+    result = derive_compression_format(url)
+
+    # Assert
+    assert result == "format:3989"
+
+
+@pytest.mark.parametrize(
+    ("suffix", "term_id"), sorted(COMPRESSION_SUFFIX_TO_EDAM.items())
+)
+def test_derive_compression_format_should_return_the_mapped_term_for_every_suffix(
+    suffix, term_id
+):
+    """Test that every suffix in the mapping table is reachable.
+
+    Given:
+        A filename ending in each suffix the module publishes.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return that suffix's EDAM term ID.
+    """
+    # Act
+    result = derive_compression_format(f"ENCFF123ABC.bed{suffix}")
+
+    # Assert
+    assert result == term_id
+
+
+def test_derive_compression_format_should_return_bgzip_term_when_suffix_is_bgz():
+    """Test that the gzip suffix does not shadow the bgzip suffix.
+
+    Given:
+        A filename ending in ".bgz", which contains the letters "gz".
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return the bgzip term rather than the plain gzip term.
+    """
+    # Act
+    result = derive_compression_format("ENCFF123ABC.bed.bgz")
+
+    # Assert
+    assert result == "format:3615"
+
+
+def test_derive_compression_format_should_agree_on_tgz_and_tar_gz():
+    """Test that the two spellings of a gzipped tar agree.
+
+    Given:
+        The same artifact named ".tar.gz" and named ".tgz".
+    When:
+        derive_compression_format is called on each.
+    Then:
+        Both should return the gzip term, since the compression is identical.
+    """
+    # Act
+    long_form = derive_compression_format("ENCFF1.tar.gz")
+    short_form = derive_compression_format("ENCFF1.tgz")
+
+    # Assert
+    assert long_form == short_form == "format:3989"
+
+
+@pytest.mark.parametrize(
+    "name", ["ENCFF1.BED.GZ", "ENCFF1.bed.Gz", "ENCFF1.BED.BGZ", "ENCFF1.TGZ"]
+)
+def test_derive_compression_format_should_ignore_case_of_the_suffix(name):
+    """Test that suffix matching is case insensitive.
+
+    Given:
+        A filename whose compression suffix is upper or mixed case.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return the same term as the lowercase spelling.
+    """
+    # Act
+    result = derive_compression_format(name)
+
+    # Assert
+    assert result == derive_compression_format(name.lower())
+
+
+def test_derive_compression_format_should_use_the_basename_when_the_query_holds_a_path():
+    """Test that a query string containing a slash cannot become the basename.
+
+    Given:
+        A gzipped download URL whose query string embeds a path ending in a
+        different, uncompressed filename.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return the gzip term from the real basename.
+    """
+    # Act
+    result = derive_compression_format("https://h/ENCFF1.bed.gz?redirect=/x/y.bam")
+
+    # Assert
+    assert result == "format:3989"
+
+
+@pytest.mark.parametrize(
+    "url", ["https://h/ENCFF1.bed?download=y.gz", "https://h/ENCFF1.bed#part.gz"]
+)
+def test_derive_compression_format_should_ignore_a_suffix_outside_the_basename(url):
+    """Test that a query string or fragment cannot fabricate a suffix.
+
+    Given:
+        A URL for an uncompressed file whose query string or fragment ends in
+        a compression suffix.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should report no compression.
+    """
+    # Act
+    result = derive_compression_format(url)
+
+    # Assert
+    assert result == UNCOMPRESSED
+
+
+@pytest.mark.parametrize("name", ["sample#1.bed.gz", "sample?1.bed.gz"])
+def test_derive_compression_format_should_keep_url_punctuation_in_a_bare_filename(name):
+    """Test that a bare filename is not truncated at a '#' or '?'.
+
+    Given:
+        A gzipped bare filename containing a character that would delimit a
+        query string or fragment in a URL.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should still return the gzip term, since URL syntax does not apply
+        to a name that is not a URL.
+    """
+    # Act
+    result = derive_compression_format(name)
+
+    # Assert
+    assert result == "format:3989"
+
+
+@pytest.mark.parametrize(
+    "name", ["ENCFF1.gz.bed", "ENCFF1.bed.gz.txt", "gzfile.bed", "ENCFF1.zip.bam"]
+)
+def test_derive_compression_format_should_report_uncompressed_when_suffix_is_not_final(
+    name,
+):
+    """Test that a compression token away from the end does not match.
+
+    Given:
+        A filename in which a compression token appears somewhere other than
+        the final suffix.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should report no compression.
+    """
+    # Act
+    result = derive_compression_format(name)
+
+    # Assert
+    assert result == UNCOMPRESSED
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["ENCFF1.bed", "ENCFF1.bam", "ENCFF1.bigWig", "ENCFF1.bigBed", "ENCFF1.tar"],
+)
+def test_derive_compression_format_should_report_uncompressed_when_no_suffix_matches(
+    name,
+):
+    """Test the sentinel for names carrying no extrinsic compression.
+
+    Given:
+        Filenames for formats the corpus carries, including BAM, bigWig and
+        bigBed, whose bytes are internally compressed but whose file_format
+        already names that container.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return the empty-string sentinel, which reports the absence
+        of compression beyond file_format rather than uncompressed bytes.
+    """
+    # Act
+    result = derive_compression_format(name)
+
+    # Assert
+    assert result == UNCOMPRESSED
+    assert result is not None
+
+
+@pytest.mark.parametrize("suffix", UNMAPPABLE_COMPRESSION_SUFFIXES)
+def test_derive_compression_format_should_return_none_when_compression_is_unmappable(
+    suffix,
+):
+    """Test that a compressed file EDAM cannot name is not called uncompressed.
+
+    Given:
+        A filename ending in a compression suffix no EDAM term expresses.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return None rather than the uncompressed sentinel.
+    """
+    # Act
+    result = derive_compression_format(f"ENCFF1.bed{suffix}")
+
+    # Assert
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "value", [None, "", "   ", "https://h/files/ENCFF1/@@download/", "https://h/"]
+)
+def test_derive_compression_format_should_return_none_when_no_basename_is_available(
+    value,
+):
+    """Test that a name-less input yields no determination.
+
+    Given:
+        An absent, blank, or directory-style value carrying no filename.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return None, since there is no evidence either way.
+    """
+    # Act
+    result = derive_compression_format(value)
+
+    # Assert
+    assert result is None
+
+
+@given(st.none() | st.text())
+@settings(max_examples=300)
+def test_derive_compression_format_should_return_a_value_from_the_closed_vocabulary(
+    value,
+):
+    """Test that the derived value never escapes its vocabulary.
+
+    Given:
+        Any text, or no value at all, as a filename or URL.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return a mapped EDAM term, the uncompressed sentinel, or
+        None, and never raise.
+    """
+    # Act
+    result = derive_compression_format(value)
+
+    # Assert
+    assert result in DERIVED_VALUES
+
+
+@given(
+    name=st.text(min_size=1).filter(
+        lambda s: s == s.strip() and not (set(s) & set("/?#"))
+    ),
+    host=st.text(alphabet=st.characters(whitelist_categories=("Ll", "Nd")), min_size=1),
+    query=st.text().filter(lambda s: not (set(s) & set("?#"))),
+    fragment=st.text().filter(lambda s: "#" not in s),
+)
+@settings(max_examples=200)
+def test_derive_compression_format_should_ignore_url_decoration(
+    name, host, query, fragment
+):
+    """Test that wrapping a filename in a URL does not change the answer.
+
+    Given:
+        Any filename free of the URL-reserved characters that would make it
+        mean something else inside a URL, plus any host, query string and
+        fragment to decorate it with.
+    When:
+        derive_compression_format is called on the bare name and on the
+        decorated URL.
+    Then:
+        Both should yield the same value.
+    """
+    # Arrange
+    url = f"https://{host}/p/{name}?{query}#{fragment}"
+
+    # Act
+    bare_result = derive_compression_format(name)
+    url_result = derive_compression_format(url)
+
+    # Assert
+    assert bare_result == url_result
+
+
+@given(
+    stem=st.text().filter(lambda s: "/" not in s),
+    suffix=st.sampled_from(sorted(COMPRESSION_SUFFIX_TO_EDAM)),
+)
+@settings(max_examples=200)
+def test_derive_compression_format_should_classify_any_stem_with_a_known_suffix(
+    stem, suffix
+):
+    """Test that no stem can suppress a recognized compression suffix.
+
+    Given:
+        Any stem free of path separators, followed by one of the mapped
+        compression suffixes.
+    When:
+        derive_compression_format is called.
+    Then:
+        It should return a mapped EDAM term rather than the uncompressed
+        sentinel or None.
+    """
+    # Act
+    result = derive_compression_format(stem + suffix)
+
+    # Assert
+    assert result in set(COMPRESSION_SUFFIX_TO_EDAM.values())
+
+
+def test_transform_to_c2m2_should_set_the_gzip_term_when_the_download_url_is_gzipped():
+    """Test that a gzipped row carries gzip alongside the uncompressed format.
+
+    Given:
+        An ENCODE row for a narrowPeak file published as ".bed.gz".
+    When:
+        transform_to_c2m2 is called.
+    Then:
+        It should set compression_format to the gzip term while file_format
+        stays the uncompressed EDAM format.
+    """
+    # Arrange
+    row = _encode_row()
+
+    # Act
+    doc = transform_to_c2m2(row)
+
+    # Assert
+    assert doc["compression_format"] == "format:3989"
+    assert doc["file_format"] == {"id": "format:3613", "name": "NarrowPeak"}
+
+
+def test_transform_to_c2m2_should_report_uncompressed_when_the_url_carries_no_suffix():
+    """Test the sentinel on a row whose download URL names a plain file.
+
+    Given:
+        An ENCODE row whose download URL ends in ".bam".
+    When:
+        transform_to_c2m2 is called.
+    Then:
+        It should set compression_format to the uncompressed sentinel.
+    """
+    # Arrange
+    row = _encode_row(
+        **{"File download URL": DOWNLOAD_URL.format(name="ENCFF123ABC.bam")}
+    )
+
+    # Act
+    doc = transform_to_c2m2(row)
+
+    # Assert
+    assert doc["compression_format"] == UNCOMPRESSED
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        DOWNLOAD_URL.format(name="ENCFF123ABC.bed.starch"),
+        "https://www.encodeproject.org/files/ENCFF123ABC/@@download/",
+        "",
+    ],
+    ids=["unmappable-suffix", "no-filename", "no-url"],
+)
+def test_transform_to_c2m2_should_omit_compression_format_when_undetermined(url):
+    """Test that an undetermined compression is left absent, not stored as null.
+
+    Given:
+        An ENCODE row whose download URL ends in a compression suffix EDAM
+        cannot name, carries no filename, or is missing entirely.
+    When:
+        transform_to_c2m2 is called.
+    Then:
+        The document should omit compression_format, so an undetermined file
+        never surfaces as a null the compressionFormat filter cannot select.
+    """
+    # Arrange
+    row = _encode_row(**{"File download URL": url})
+
+    # Act
+    doc = transform_to_c2m2(row)
+
+    # Assert
+    assert "compression_format" not in doc
+
+
+def test_transform_to_c2m2_should_not_derive_from_the_synthesized_filename():
+    """Test that a filename the transform invented is not treated as evidence.
+
+    Given:
+        An ENCODE row with a file format but no download URL, so the filename
+        is synthesized from the accession and can carry no suffix.
+    When:
+        transform_to_c2m2 is called.
+    Then:
+        It should leave compression_format absent rather than claim the file
+        is uncompressed on the strength of a name it made up.
+    """
+    # Arrange
+    row = _encode_row(**{"File download URL": "", "File format": "bed"})
+
+    # Act
+    doc = transform_to_c2m2(row)
+
+    # Assert
+    assert doc["access_url"] is None
+    assert doc["filename"] == "ENCFF123ABC.bed"
+    assert "compression_format" not in doc
+
+
+def test_transform_to_c2m2_should_return_none_when_the_row_has_no_accession():
+    """Test that the accession guard still short-circuits the transformation.
+
+    Given:
+        A row with a gzipped download URL but no file accession.
+    When:
+        transform_to_c2m2 is called.
+    Then:
+        It should return None without deriving anything.
+    """
+    # Arrange
+    row = _encode_row(**{"File accession": "   "})
+
+    # Act
+    doc = transform_to_c2m2(row)
+
+    # Assert
+    assert doc is None
+
+
+@given(st.text())
+@settings(max_examples=200)
+def test_transform_to_c2m2_should_not_raise_for_any_download_url(url):
+    """Test that no download URL can abort an ENCODE sync.
+
+    Given:
+        Any text in the download URL column of an otherwise valid row.
+    When:
+        transform_to_c2m2 is called.
+    Then:
+        It should return a document whose compression_format, when present,
+        is drawn from the closed vocabulary, without raising.
+    """
+    # Arrange
+    row = _encode_row(**{"File download URL": url})
+
+    # Act
+    doc = transform_to_c2m2(row)
+
+    # Assert
+    assert doc.get("compression_format", UNCOMPRESSED) in DERIVED_VALUES

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -723,6 +723,52 @@ class TestEnrichedBiosample:
 
 
 class TestFileMetadataModel:
+    def test___init___should_preserve_the_uncompressed_sentinel(self):
+        """Test that the uncompressed sentinel is not collapsed into None.
+
+        Given:
+            One document whose compression_format is the empty string, and
+            one that omits the field entirely.
+        When:
+            Both are instantiated.
+        Then:
+            The first should keep "" and the second should be None, since ""
+            means known-uncompressed while None means undetermined.
+        """
+        # Arrange
+        uncompressed = {**_minimal_file_metadata(), "compression_format": ""}
+        undetermined = _minimal_file_metadata()
+
+        # Act
+        uncompressed_result = FileMetadataModel(**uncompressed)
+        undetermined_result = FileMetadataModel(**undetermined)
+
+        # Assert
+        assert uncompressed_result.compression_format == ""
+        assert undetermined_result.compression_format is None
+
+    def test___init___should_reject_a_subdocument_compression_format(self):
+        """Test that the field stays a scalar rather than an EDAM subdocument.
+
+        Given:
+            A document whose compression_format is an id/name dict, the shape
+            file_format takes after materialization.
+        When:
+            The model is instantiated.
+        Then:
+            It should raise a ValidationError, since the GraphQL type, the
+            input filter and the upstream C2M2 column are all scalar strings.
+        """
+        # Arrange
+        data = {
+            **_minimal_file_metadata(),
+            "compression_format": {"id": "format:3989", "name": "gzip"},
+        }
+
+        # Act & assert
+        with pytest.raises(ValidationError):
+            FileMetadataModel(**data)
+
     def test_deserializes_with_dict_shaped_extra_file_format(self):
         """Test that a 4DN doc with a CV-object extra_files file_format loads.
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -279,6 +279,85 @@ class TestFilesQuery:
         assert result.data["files"]["items"] == []
 
     @pytest.mark.asyncio
+    async def test_files_should_return_the_uncompressed_sentinel_as_an_empty_string(
+        self, mock_db
+    ):
+        """Test that the uncompressed sentinel survives the resolver as "".
+
+        Given:
+            One file known to be uncompressed and one gzipped file.
+        When:
+            The GraphQL files query selects compressionFormat.
+        Then:
+            It should return "" for the uncompressed file rather than null,
+            preserving the distinction from an undetermined value.
+        """
+        # Arrange
+        mock_db.files.docs = [
+            {**_make_file_doc("f1"), "compression_format": ""},
+            {**_make_file_doc("f2"), "compression_format": "format:3989"},
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files(input: []) {
+                    items {
+                        localId
+                        compressionFormat
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        returned = {
+            item["localId"]: item["compressionFormat"]
+            for item in result.data["files"]["items"]
+        }
+        assert returned == {"f1": "", "f2": "format:3989"}
+
+    @pytest.mark.asyncio
+    async def test_files_should_filter_documents_by_compression_format(self, mock_db):
+        """Test that the derived term is queryable through the input filter.
+
+        Given:
+            An uncompressed file, a gzipped file and a bgzipped file.
+        When:
+            The GraphQL files query filters on the gzip term.
+        Then:
+            It should return only the gzipped file.
+        """
+        # Arrange
+        mock_db.files.docs = [
+            {**_make_file_doc("f1"), "compression_format": ""},
+            {**_make_file_doc("f2"), "compression_format": "format:3989"},
+            {**_make_file_doc("f3"), "compression_format": "format:3615"},
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                files(input: [{ compressionFormat: ["format:3989"] }]) {
+                    totalCount
+                    items {
+                        localId
+                    }
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        assert result.data["files"]["totalCount"] == 1
+        assert result.data["files"]["items"] == [{"localId": "f2"}]
+
+    @pytest.mark.asyncio
     async def test_files_should_count_only_matching_documents_when_input_filter_supplied(
         self, mock_db
     ):
@@ -743,6 +822,52 @@ class TestDistinctValuesQuery:
         assert result.errors is None
         entry = result.data["distinctValues"][0]
         assert entry["values"] == ["hubmap"]
+
+    @pytest.mark.asyncio
+    async def test_distinct_values_should_return_derived_compression_formats(
+        self, mock_db
+    ):
+        """Test distinct values for a field the DCCs populate.
+
+        Given:
+            Three files carrying the uncompressed sentinel, the gzip term and
+            the bgzip term
+        When:
+            The distinctValues query is executed with fields: ["compression_format"]
+        Then:
+            It should return all three as scalar strings, including the empty
+            string
+        """
+        # Arrange
+        mock_db.files.docs = [
+            {**_make_distinct_doc("f1", "4DN"), "compression_format": ""},
+            {
+                **_make_distinct_doc("f2", "ENCODE"),
+                "compression_format": "format:3989",
+            },
+            {
+                **_make_distinct_doc("f3", "ENCODE"),
+                "compression_format": "format:3615",
+            },
+        ]
+
+        # Act
+        result = await schema.execute(
+            """
+            query {
+                distinctValues(fields: ["compression_format"]) {
+                    field
+                    values
+                }
+            }
+            """
+        )
+
+        # Assert
+        assert result.errors is None
+        entry = result.data["distinctValues"][0]
+        assert sorted(entry["values"]) == ["", "format:3615", "format:3989"]
+        assert all(isinstance(value, str) for value in entry["values"])
 
     @pytest.mark.asyncio
     async def test_distinct_values_returns_empty_list_for_missing_field(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,17 +2,39 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
+from cfdb.services import encode as encode_module
 from cfdb.services import sync as sync_module
 from cfdb.services.sync import (
     SyncTask,
     _enrich_hubmap_collections_and_subjects,
     _enrich_hubmap_files,
+    _load_dataset_async,
     _prune_non_public_hubmap_raw_records,
     _sync_dccs,
+    _sync_encode,
 )
 from cfdb.indexes import data_index_specs
+
+
+def _encode_metadata_row(accession: str, filename: str) -> dict:
+    """Return a minimal ENCODE metadata TSV row for the given download name."""
+    return {
+        "File accession": accession,
+        "File format": "bed",
+        "File download URL": (
+            f"https://www.encodeproject.org/files/{accession}/@@download/{filename}"
+        ),
+    }
+
+
+async def _async_iter(rows):
+    """Yield the given rows, standing in for the streaming metadata fetch."""
+    for row in rows:
+        yield row
 
 
 class TestSyncDccsDataIndexing:
@@ -294,3 +316,191 @@ class TestEnrichHubmapFiles:
         # Non-HuBMAP files untouched
         non_hubmap = [d for d in mock_db.files.docs if d["submission"] == "4dn"]
         assert "data_access_level" not in non_hubmap[0]
+
+
+# ---------------------------------------------------------------------------
+# _load_dataset_async
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDatasetAsync:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("submission", ["4dn", "hubmap"])
+    async def test__load_dataset_async_should_store_compression_format_verbatim(
+        self, mock_db, tmp_path, submission
+    ):
+        """Test that the upstream compression_format column is copied unchanged.
+
+        Given:
+            A C2M2 file table whose compression_format values deliberately
+            contradict what the filenames imply — an uncompressed value on a
+            gzipped name, and a gzip term on a plain name.
+        When:
+            _load_dataset_async loads it for a C2M2-sourced DCC.
+        Then:
+            It should store the column's values, not the filename-implied
+            ones.
+        """
+        # Arrange
+        table = tmp_path / "file.tsv"
+        table.write_text(
+            "local_id\tfilename\tcompression_format\n"
+            "a\tx.bed.gz\t\n"
+            "b\ty.bed\tformat:3989\n"
+            "c\tz.bed.gz\tformat:3989\n"
+        )
+
+        # Act
+        await _load_dataset_async(tmp_path, submission)
+
+        # Assert
+        loaded = {doc["local_id"]: doc["compression_format"] for doc in mock_db.file.docs}
+        assert loaded == {"a": "", "b": "format:3989", "c": "format:3989"}
+
+    @pytest.mark.asyncio
+    async def test__load_dataset_async_should_not_add_compression_format_when_absent(
+        self, mock_db, tmp_path
+    ):
+        """Test that the loader never synthesizes the column.
+
+        Given:
+            A C2M2 file table with no compression_format column at all.
+        When:
+            _load_dataset_async loads it for a C2M2-sourced DCC.
+        Then:
+            The stored records should carry no compression_format key.
+        """
+        # Arrange
+        table = tmp_path / "file.tsv"
+        table.write_text("local_id\tfilename\na\tx.bed.gz\n")
+
+        # Act
+        await _load_dataset_async(tmp_path, "4dn")
+
+        # Assert
+        assert all("compression_format" not in doc for doc in mock_db.file.docs)
+
+
+# ---------------------------------------------------------------------------
+# _sync_encode
+# ---------------------------------------------------------------------------
+
+
+class TestSyncEncode:
+    @pytest.mark.asyncio
+    async def test__sync_encode_should_populate_compression_format_on_inserted_docs(
+        self, mock_db, mocker
+    ):
+        """Test that the derived value reaches the documents the sync inserts.
+
+        Given:
+            Three ENCODE metadata rows published as gzip, bigWig and starch,
+            the three outcomes the released corpus actually produces.
+        When:
+            _sync_encode runs the fetch-transform-insert pipeline.
+        Then:
+            Each inserted document should carry the compression term its
+            filename implies, and the starch document should carry no
+            compression_format key at all.
+        """
+        # Arrange
+        rows = [
+            _encode_metadata_row("ENCFF001AAA", "ENCFF001AAA.bed.gz"),
+            _encode_metadata_row("ENCFF002BBB", "ENCFF002BBB.bigWig"),
+            _encode_metadata_row("ENCFF003CCC", "ENCFF003CCC.bed.starch"),
+        ]
+        mocker.patch.object(
+            encode_module, "fetch_encode_metadata", lambda: _async_iter(rows)
+        )
+
+        # Act
+        await _sync_encode(SyncTask(id="t1", dcc_names=["encode"]))
+
+        # Assert
+        derived = {
+            doc["local_id"]: doc.get("compression_format", "<absent>")
+            for doc in mock_db.files.docs
+        }
+        assert derived == {
+            "ENCFF001AAA": "format:3989",
+            "ENCFF002BBB": "",
+            "ENCFF003CCC": "<absent>",
+        }
+
+    @pytest.mark.asyncio
+    async def test__sync_encode_should_log_the_compression_format_distribution(
+        self, mock_db, mocker, caplog
+    ):
+        """Test that the sync reports how the derived values came out.
+
+        Given:
+            ENCODE metadata rows covering gzip, no compression and an
+            undetermined compression.
+        When:
+            _sync_encode runs.
+        Then:
+            It should log a tally of the derived terms, so a corpus-wide flip
+            in ENCODE's URL shape is visible rather than hidden behind an
+            unchanged row count.
+        """
+        # Arrange
+        rows = [
+            _encode_metadata_row("ENCFF001AAA", "ENCFF001AAA.bed.gz"),
+            _encode_metadata_row("ENCFF002BBB", "ENCFF002BBB.bigWig"),
+            _encode_metadata_row("ENCFF003CCC", "ENCFF003CCC.bed.starch"),
+        ]
+        mocker.patch.object(
+            encode_module, "fetch_encode_metadata", lambda: _async_iter(rows)
+        )
+
+        # Act
+        with caplog.at_level(logging.INFO, logger="cfdb.services.sync"):
+            await _sync_encode(SyncTask(id="t1", dcc_names=["encode"]))
+
+        # Assert
+        distribution = next(
+            record.getMessage()
+            for record in caplog.records
+            if "compression_format distribution" in record.getMessage()
+        )
+        assert "'format:3989': 1" in distribution
+        assert "'uncompressed': 1" in distribution
+        assert "'undetermined': 1" in distribution
+
+    @pytest.mark.asyncio
+    async def test__sync_encode_should_leave_other_dcc_documents_unchanged(
+        self, mock_db, mocker
+    ):
+        """Test that the ENCODE derivation does not touch the other DCCs.
+
+        Given:
+            Materialized 4DN and HuBMAP file documents whose
+            compression_format values contradict their filenames, alongside
+            one ENCODE row to sync.
+        When:
+            _sync_encode runs.
+        Then:
+            The 4DN and HuBMAP documents should be byte-identical afterwards.
+        """
+        # Arrange
+        others = [
+            {"submission": "4dn", "filename": "a.pairs.gz", "compression_format": ""},
+            {
+                "submission": "hubmap",
+                "filename": "b.bed",
+                "compression_format": "format:3989",
+            },
+        ]
+        mock_db.files.docs = [dict(doc) for doc in others]
+        mocker.patch.object(
+            encode_module,
+            "fetch_encode_metadata",
+            lambda: _async_iter([_encode_metadata_row("ENCFF001AAA", "x.bed.gz")]),
+        )
+
+        # Act
+        await _sync_encode(SyncTask(id="t1", dcc_names=["encode"]))
+
+        # Assert
+        survivors = [d for d in mock_db.files.docs if d["submission"] != "encode"]
+        assert survivors == others


### PR DESCRIPTION
Closes #31

## What changed

ENCODE file documents never carried `compression_format`, so every gzipped ENCODE file was indistinguishable from an uncompressed one. `transform_to_c2m2` now derives the field from the download URL's filename suffix and sets it on every document where a determination is possible.

The ENCODE metadata TSV genuinely has no compression column — verified against the live endpoint's header, which has 59 columns, none of them compression-related. So the filename suffix is the only available signal, as the issue says. No REST calls are needed (the per-file REST API exposes no compression field either).

## Departure from the issue text: a scalar string, not an EDAM dict

The issue asks for "an EDAM-term dict (same shape as `file_format`)". **This PR emits a term-ID string instead**, because acceptance criteria 1 and 4 cannot both hold with a dict, and the string is the type the whole stack already uses:

- `src/cfdb/models.py:455` declares `compression_format: Optional[str]`
- `schema.graphql` exposes `compressionFormat: String` and the input filter `compressionFormat: [String!]`
- `src/cfdb/indexes.py:185` indexes it
- unlike `file_format`, the Rust materializer never expands it into a subdocument — 4DN and HuBMAP carry the upstream C2M2 column verbatim

Criterion 4 requires 4DN and HuBMAP to keep `""` — a string — while criterion 1 would have ENCODE carry a dict. That would break the existing `[String!]` filter and require an index change, a materializer change, and a migration, none of which the issue scopes. I read the "dict" wording as carried over from `file_format` by mistake. Full reasoning is recorded on #31.

Term ID rather than the human-readable name, because `models.py` documents the field as "an EDAM CV term ID", C2M2 defines it that way, and a 4DN or HuBMAP file that ever ships compressed will carry a term ID from its datapackage.

## What the field asserts — narrower than it first looks

The field reports compression that is **extrinsic to `file_format`** — a wrapper the name reveals and `file_format` does not. It is not a claim about whether the bytes are compressed. A BAM, bigWig or bigBed carries `""` while being internally compressed, because its `file_format` already names that container; a `.starch` carries nothing, because its `file_format` names the BED it decompresses to. And 4DN/HuBMAP take the value straight from an upstream C2M2 column that is blank on every file including gzipped ones, so `""` from those DCCs means "upstream recorded nothing". `""` never licenses skipping a byte-level check, and the docs now say so.

Two cases leave the field **absent** rather than `""` — a departure from criterion 2, which says unrecognized suffixes fall back to `""`:

- **A compression suffix no EDAM term expresses** (`.bz2`, `.xz`, `.zst`, `.zip`, `.starch`). Note `format:3990` sits among the compression terms and is **AVI**, not bzip2 — a trap for anyone extending the table. `.zip` is here despite having a term, because a ZIP holds many members with many formats so there is no single post-decompression `file_format`, and the tabix processor rejects the PK magic outright.
- **A URL with no filename at all**, which carries no evidence either way.

Absent rather than an explicit `null` so an undetermined file does not surface as a `null` in `distinctValues` that `compressionFormat: [String!]` cannot select.

**`format:3989` means gzip-family, not "not bgzip."** ENCODE publishes no `.bgz` at all and roughly a quarter of its `.gz` files are BGZF, so the suffix cannot distinguish them. Anything deciding on `gunzip | bgzip` must read the BGZF header — which `cfdb.workflows.processors.tabix` already does deliberately, and that byte-level check remains the decision of record. This limits what #31 buys #30: the field is a queryable corpus attribute, not a substitute for sniffing. Verified EDAM IDs: `format:3989` GZIP (`gz`, `gzip`), `format:3615` bgzip (`bgz`), `format:3987` ZIP.

## Tests

- **The 4DN/HuBMAP invariant is pinned executably, not asserted.** Those values arrive through the shared C2M2 loader, so `test__load_dataset_async_should_store_compression_format_verbatim` loads a file table whose `compression_format` column deliberately contradicts its filenames and requires the column to win. Mutation-tested: inlining the ENCODE derivation into `_load_dataset_async` fails all three loader tests. A second test runs the full ENCODE sync over pre-seeded 4DN and HuBMAP documents and requires them back byte-identical.
- **The suffix vocabulary is pinned against literal EDAM IDs**, not against the table itself, so a mistyped term cannot pass by agreeing with the implementation that produced it.
- **Three property tests** pin the closed value vocabulary, invariance under URL decoration, and that no stem can suppress a known suffix — the first doubling as proof that no download URL can raise and abort a sync.
- Mutation-verified that the suite now catches: a wrong EDAM ID, restoring the synthesized-filename fallback, and storing an explicit null instead of omitting the key.

Full suite: 872 passed, 3 skipped, up from 814 / 3 on master.

## Review

A seven-reviewer principal-engineer round found six blocking issues, all fixed here: the derivation was reading a filename synthesized from the accession when a row had no URL (asserting "uncompressed" on an invented name); `""` was documented as "known to be uncompressed", which the live corpus contradicts for BAM/bigWig and for every gzipped 4DN file; the EDAM table was pinned only against itself; `.gzip` was classified uncompressed despite being a gzip extension; the derivation helper was private while its tests targeted it directly, against the test guide's public-API rule (now `derive_compression_format`); and the absent-vs-null document shape was unpinned. Also fixed: `.tgz` now agrees with `.tar.gz`, a dead and mis-mapped `COMPRESSION_TO_EDAM` table (with the AVI ID) is deleted, a `#` or `?` inside a bare filename no longer truncates it, and `_sync_encode` logs the derived distribution so a corpus-wide flip in ENCODE's URL shape cannot hide behind an unchanged row count.

Two claims in the original version of this description were wrong and are corrected above: ENCODE's `.bed.gz` narrowPeak files are **plain gzip**, not BGZF (BGZF clusters in `vcf`, `pairs`, `bed bed3+` and some `fastq`); and a dict *could* have gone through `distinctValues`, whose `values` field is a JSON scalar — the real blockers on a dict are the input filter, the model type, the index and the migration.

## Adjacent defects found, not fixed

- `transform_to_c2m2` reads the biosample genetic modifications from one compound column, but the live TSV has **six separate columns**, so `extra.encode.biosample_genetic_modifications` can never populate.
- `compression_format` is indexed on the raw `file` collection but not on the materialized `files` collection that GraphQL queries — and ENCODE bypasses the materializer entirely. Filtering on it is a collection scan.
- `_sync_encode` transforms rows with no per-row guard, inside the cutover lock and after the corpus has been cleared, so any single-row exception leaves ENCODE empty until the next successful sync. The new derivation cannot raise, but the surrounding fragility is real.
