### PR TITLE
Fix make mongodb failing to start from a clean checkout — Closes #113

### DIFF
--- a/Dockerfile.mongodb
+++ b/Dockerfile.mongodb
@@ -1,8 +1,25 @@
 FROM mongo:latest
 
-# Copy database dump and scripts
-COPY database/ /data/database/
 COPY scripts/create-indexes.js /scripts/create-indexes.js
+
+# The sample dump is NOT baked into the image. It used to be — `COPY
+# database/ /data/database/` — but `database/` is gitignored (the 4DN
+# backup was removed from the repo in 2fc98f8), so on a clean checkout
+# the directory does not exist at all and the COPY failed the build
+# outright with `"/database": not found`. The build only appeared to
+# work on machines where a stray file such as `.DS_Store` happened to
+# keep the directory alive.
+#
+# Mounting the dump at run time instead (see the `mongodb` target in the
+# Makefile) fixes that and is the better shape regardless: the image no
+# longer varies with whatever a developer happens to have on disk, and
+# obtaining a dump later is a container restart rather than a rebuild.
+# The directory is created here so `mongorestore` always has a valid
+# target — it exits 1 on a path that does not exist, which under
+# `set -e` below would take the container down — and so running the
+# image with no mount at all degrades to "empty database" rather than
+# to a crash.
+RUN mkdir -p /data/database
 
 # Create startup script (development mode only)
 COPY <<'EOF' /startup.sh
@@ -22,9 +39,19 @@ until mongosh --eval "db.adminCommand('ping')" >/dev/null 2>&1; do
 done
 echo "MongoDB started."
 
-# Restore database
-echo "Restoring database..."
-mongorestore --gzip /data/database
+# Restore the dump, if one was mounted. `set -e` is deliberately kept:
+# a failed restore of a dump that IS present should stop the container
+# rather than leave a half-loaded database looking healthy. The empty
+# case is not a failure though, so it is reported as such instead of
+# being left to mongorestore's "0 document(s) restored" trace, which
+# reads like something went wrong.
+if [ -n "$(ls -A /data/database 2>/dev/null)" ]; then
+    echo "Restoring database from /data/database..."
+    mongorestore --gzip /data/database
+else
+    echo "No dump at /data/database — starting with an empty database."
+    echo "Populate it with 'curl -X POST http://localhost:8000/sync'."
+fi
 
 # Create indexes
 echo "Creating indexes..."

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,13 @@ mongodb:
 	@docker rm mongodb 2>/dev/null || true
 	@echo "Building MongoDB image..."
 	docker build -t cfdb-mongodb -f Dockerfile.mongodb .
+	@# database/ is gitignored and empty on a clean checkout. It is a
+	@# drop-in point for an optional mongodump, mounted read-only rather
+	@# than baked into the image (see Dockerfile.mongodb). Created here so
+	@# the mount source always exists and so the drop-in point is visible.
+	@mkdir -p database
 	@echo "Starting MongoDB container..."
-	docker run -d --name mongodb --network cvh-backend-network --network-alias cvh-backend -p 27017:27017 cfdb-mongodb
+	docker run -d --name mongodb --network cvh-backend-network --network-alias cvh-backend -p 27017:27017 -v "$(CURDIR)/database:/data/database:ro" cfdb-mongodb
 	@echo "MongoDB container starting on port 27017. Check logs with: docker logs -f mongodb"
 
 build-materialize:

--- a/README.md
+++ b/README.md
@@ -35,19 +35,23 @@ Requires Python 3.11 or later.
 ### Docker Startup
 
 ```bash
-# 1. Start MongoDB (restores sample data and creates indexes)
+# 1. Start MongoDB (creates indexes, and restores a dump if one is present)
 make mongodb
 
 # 2. Start the API server
 make api
 
-# 3. (Optional) Sync latest DCC metadata
+# 3. Populate the database
 curl -X POST http://localhost:8000/sync
 ```
 
 This starts:
 - MongoDB on port 27017 (with indexes)
 - GraphQL/REST API on port 8000
+
+**The database starts empty.** A 4DN sample dump used to be committed under `database/`, but it was removed and the directory gitignored, so a clean checkout has no data to restore and step 3 is how you get some — it is not optional. `make mongodb` still creates every index, so an empty database is a working one rather than a broken one.
+
+`database/` remains the drop-in point if you do have a dump: put a `mongodump --gzip` tree there (`database/cfdb/*.bson.gz`) and it is restored on the next `make mongodb`. It is mounted read-only at run time rather than baked into the image, so obtaining a dump later costs a container restart and not a rebuild.
 
 ### Production (TLS/X.509)
 
@@ -80,7 +84,7 @@ Run `./certs/generate-certs.sh --help` for full usage information.
 
 | Target | Description |
 |--------|-------------|
-| `make mongodb` | Build and start MongoDB with sample data and indexes |
+| `make mongodb` | Build and start MongoDB, creating indexes. The database starts empty unless a `mongodump --gzip` tree is present in `database/`, which is restored if one is. |
 | `make api` | Build and start the API container |
 | `make materialize-files` | Manually materialize all file metadata (usually done via sync) |
 | `make materialize-dcc DCC=hubmap` | Materialize a single DCC |

--- a/scripts/create-indexes.js
+++ b/scripts/create-indexes.js
@@ -17,7 +17,37 @@ function ensureIndex(coll, keys, opts) {
         throw new Error("ensureIndex requires opts.name");
     }
     var name = opts.name;
-    var existing = coll.getIndexes();
+    // ``getIndexes`` raises NamespaceNotFound (code 26, "ns does not
+    // exist") when the collection has never been written to. On a
+    // database with no dump restored — the normal state of a clean
+    // checkout, since the sample dump is gitignored and no longer
+    // shipped — that is every collection this script touches. The bare
+    // ``createIndex`` calls elsewhere in this file are immune because
+    // ``createIndex`` creates the namespace implicitly; this helper is
+    // the only code path that reads the existing indexes first, which
+    // is why ``jobs`` was the single collection that aborted the run
+    // (and, under ``set -e`` in Dockerfile.mongodb's startup script,
+    // took the whole container down with it on exit 1).
+    //
+    // A namespace that does not exist trivially holds no index that
+    // could conflict, so treat it as the empty list and fall through to
+    // ``createIndex``, which creates the collection along with the
+    // index. This preserves the drop-and-recreate contract exactly: a
+    // collection with no indexes cannot produce a name match, so the
+    // IndexOptionsConflict path below is unreachable in this case and
+    // stays untouched for the case it was written for. Only
+    // NamespaceNotFound is swallowed — any other server error still
+    // propagates, so a genuine failure is not masked into a silently
+    // half-indexed database.
+    var existing;
+    try {
+        existing = coll.getIndexes();
+    } catch (e) {
+        if (e.codeName !== "NamespaceNotFound" && e.code !== 26) {
+            throw e;
+        }
+        existing = [];
+    }
     var match = null;
     for (var i = 0; i < existing.length; i++) {
         if (existing[i].name === name) {


### PR DESCRIPTION
## Summary

Make `make mongodb` produce a working database from a clean checkout. Two independent defects blocked it, and either one alone was fatal — the container either failed to build or exited 1 seconds after starting.

The first is a latent build failure: `database/` is gitignored, so `COPY database/ /data/database/` fails outright on a fresh clone. This has been broken since `2fc98f8` removed the committed 4DN dump without updating the Dockerfile, and went unnoticed because a stray `.DS_Store` kept the directory alive on developer machines. Move the dump from a build-time `COPY` to a run-time read-only mount, which fixes the build and is the better shape regardless — the image no longer varies with what a developer has on disk, and obtaining a dump later costs a container restart rather than a rebuild.

The second is the reported symptom: `ensureIndex` in the index bootstrap calls `getIndexes()`, which raises `NamespaceNotFound` rather than returning an empty list when the collection has never been written. Treat that specific error as "no existing index to conflict with" and fall through to `createIndex`, which creates the collection.

Deliberately **not** changed: `set -e` in the startup script, and `mongorestore`. `set -e` surfaced a real bug rather than causing one, and a failed restore of a dump that *is* present should stop the container rather than leave a half-loaded database looking healthy. `mongorestore` was never at fault — it handled the dump-less directory correctly, logging `0 document(s) restored` and exiting 0.

Closes #113

## Proposed changes

### Stop baking the dump into the image

Replace `COPY database/ /data/database/` with `RUN mkdir -p /data/database`, and mount `database/` read-only at run time from the `mongodb` Makefile target. The directory is still created inside the image so `mongorestore` always has a valid target — it exits 1 on a nonexistent path, which under `set -e` would take the container down — and so running the image with no mount at all degrades to an empty database rather than a crash. The Makefile creates `database/` locally so the mount source always exists and the drop-in point stays visible.

### Guard the restore on a dump actually being present

Branch on the directory being non-empty. An absent dump is the normal state of a clean checkout, so report it as such rather than leaving the reader to interpret `mongorestore`'s `0 document(s) restored` trace, which reads like a failure.

### Survive a namespace that does not exist

Wrap `getIndexes()` in a try/catch that swallows only `NamespaceNotFound` (code 26) and rethrows everything else, so a genuine server error still aborts rather than silently producing a half-indexed database. The `IndexOptionsConflict` drop-and-recreate path is untouched and unreachable in the empty case — a collection with no indexes cannot produce a name match.

Only `ensureIndex` was affected. Every bare `createIndex` call in the file is immune because `createIndex` creates the namespace implicitly, which is why `jobs` — the sole `ensureIndex` caller — was the single collection that aborted the run.

### Correct the README

The Docker Startup block claimed step 1 restores sample data and that `POST /sync` was optional. Both are false: the database starts empty and `/sync` is how it gets data. The Makefile Targets table repeated the same claim and is corrected to match, so the two places state one fact in one voice.

## Test cases

No automated tests accompany this change, and the reason is worth stating rather than glossing: the defects live in a Dockerfile and a `mongosh` bootstrap script, neither of which the Python suite executes. `tests/test_indexes.py` pins the operational index *specs* in lockstep between `scripts/create-indexes.js` and `src/cfdb/indexes.py`, but it parses the specs rather than running the script against a server — which is precisely why a `NamespaceNotFound` raised at run time was invisible to a green suite. Closing that gap needs a container-backed integration test and is larger than this fix.

Verification was performed by hand against real containers:

| # | Scenario | Given | When | Then | Coverage target |
|---|----------|-------|------|------|-----------------|
| 1 | Baseline reproduction | A build context with no `database/` directory | The pre-fix `Dockerfile.mongodb` is built | Build fails with `"/database": not found` | Defect (b) is real |
| 2 | Clean checkout build | The same context, no `database/` | The fixed Dockerfile is built | Build succeeds | Defect (b) is fixed |
| 3 | Empty database startup | No dump present | `make mongodb` runs | Container stays up, logs `No dump at /data/database`, then `All indexes created successfully` | Defect (a) is fixed |
| 4 | Index completeness | A container started with no dump | `cfdb.jobs` indexes are listed | All six are present, including `workflow_key_active_unique` and `terminal_ttl` | The `ensureIndex` path completes |
| 5 | Dump present | Two seeded docs dumped with `mongodump --gzip` into `database/` | `make mongodb` runs | Restore reports `2 document(s) restored`, indexes still apply, docs are queryable | The mount path works |

The Python suite was confirmed unchanged at **1112 passed, 91 deselected** against `origin/master`, and `tests/test_indexes.py` passes 29/29. Ruff reports two findings, both pre-existing on `master` and in files this PR does not touch.